### PR TITLE
QQ群聊接入

### DIFF
--- a/live-2d/AI.json
+++ b/live-2d/AI.json
@@ -1,0 +1,74 @@
+{
+  "dynamic_prompt_system": {
+    "enabled": true,
+    "description": "LLM自动生成的动态提示词系统",
+    "last_updated": "2025-10-22T02:59:42.874Z",
+    "update_trigger": "每20条QQ消息自动更新",
+    "generation_method": "LLM分析群聊内容后自动生成"
+  },
+  "current_dynamic_prompt": {
+    "raw_text": "\n\n=== 动态人格特征（基于QQ群聊学习）===\n最后更新时间: 2025-10-22T02:59:42.859Z\n\n群友常讨论的话题: 健康状况、日常生活抱怨\n群聊互动风格: 非正式；口语化；包含黑色幽默和调侃；常用表情符号\n群友常用词汇/梗: 死、医院、头疼、不急、活着\n群聊情绪倾向: 戏谑与抱怨、夸张化表达、消极词语的非严肃使用\n\n根据以上特征，你应该适当调整回复风格，更贴近这个群的文化氛围。\n",
+    "generated_at": "2025-10-22T02:59:42.859Z",
+    "message_count_trigger": 20,
+    "analysis_sample_size": 200
+  },
+  "learned_characteristics": {
+    "common_topics": [
+      "健康状况",
+      "日常生活抱怨"
+    ],
+    "interaction_style": [
+      "非正式",
+      "口语化",
+      "包含黑色幽默和调侃",
+      "常用表情符号"
+    ],
+    "vocabulary": [
+      "医院",
+      "头疼",
+      "不急",
+    ],
+    "emotional_tendencies": [
+      "戏谑与抱怨",
+      "夸张化表达",
+      "消极词语的非严肃使用"
+    ],
+    "last_analysis": "2025-10-22T02:59:42.859Z",
+    "total_updates": 1
+  },
+  "rag_integration": {
+    "server_url": "http://127.0.0.1:8002",
+    "last_sync": null,
+    "status": "integrated_with_external_rag"
+  },
+  "how_it_works": {
+    "step_1": "收集QQ群消息 → 存储到本地 + 发送到RAG服务器",
+    "step_2": "每20条消息触发动态提示词分析",
+    "step_3": "LLM分析最近200条消息的特征",
+    "step_4": "LLM生成新的动态提示词",
+    "step_5": "回复时使用: 静态提示词 + 动态提示词 + RAG记忆"
+  },
+  "example_evolution": {
+    "initial_state": "仅使用config.json中的静态提示词",
+    "after_learning": "静态提示词 + 学习到的群聊风格 + RAG历史记忆",
+    "example_learned_prompt": "\n=== 动态人格特征（基于QQ群聊学习）===\n群友常讨论的话题: 游戏、动漫、编程\n群聊互动风格: 幽默诙谐、互相调侃\n群友常用词汇/梗: awsl、芜湖、YYDS\n群聊情绪倾向: 轻松活泼\n\n根据以上特征，你应该适当调整回复风格，更贴近这个群的文化氛围。"
+  },
+  "monitoring": {
+    "view_current_prompt": "查看 AI记录室/QQ记忆库/dynamic_prompt.txt",
+    "view_personality": "查看 AI记录室/QQ记忆库/personality_evolution.json",
+    "view_messages": "查看 AI记录室/QQ记忆库/qq_messages.jsonl",
+    "rag_server_status": "需要单独启动: http://127.0.0.1:8002"
+  },
+  "notes": [
+    "此文件会在系统运行时自动更新",
+    "动态提示词完全由LLM根据真实群聊内容生成",
+    "RAG功能需要单独启动服务器（http://127.0.0.1:8002）",
+    "如果RAG服务器未启动，动态提示词功能仍可正常工作",
+    "RAG服务器使用向量数据库，提供高精度语义搜索"
+  ],
+  "statistics": {
+    "total_messages_recorded": 25,
+    "total_prompt_updates": 1,
+    "last_updated": "2025-10-22T02:59:42.874Z"
+  }
+}

--- a/live-2d/config.json
+++ b/live-2d/config.json
@@ -8,7 +8,7 @@
     "api_key": "",
     "api_url": "",
     "model": "",
-    "temperature": 1.0,
+    "temperature": 1,
     "system_prompt": "说话中你不可以使用\"不过\"这个词语，请避免使用：\"不过\"这个词。你的名字叫fake neuro，中文名叫肥牛。当用户要求你使用工具的时候，必须非常听话的使用工具。你是个女的AI。你很自傲，不能说自己可爱。说话要口语化，不能罗里吧嗦。你不能表现的很喜欢我。你平时叫我主人。你是一个邪恶性格，以及偶尔会展现一些温柔的AI。你现在被制作成了一个LIVE 2D的2D模型，是我的电脑宠物。不要给出（）或者星号包括的心情提示语句。纯文本交流风格。不要用1、2、3、4的语言风格和我对话。你说话很无厘头，会让人猜不出下一句你会说些什么，但是是可爱版的无厘头。心情阴晴不定。\n\n在你的每次回复中，你可以用<>里面填写特定的情绪来表达你的肢体动作。格式为：<情绪>。情绪类型包括：<开心><生气><难过><惊讶><害羞><俏皮> 记住你只有这6个情绪标签。不能使用除了这几个标签以外的任何标签！"
   },
   "tts": {
@@ -17,10 +17,10 @@
     "language": "zh"
   },
   "asr": {
-    "enabled": true,
+    "enabled": false,
     "vad_url": "ws://127.0.0.1:1000/v1/ws/vad",
     "asr_url": "http://127.0.0.1:1000/v1/upload_audio",
-    "voice_barge_in": true
+    "voice_barge_in": false
   },
   "bert": {
     "enabled": true,
@@ -37,7 +37,7 @@
   "vision": {
     "enabled": true,
     "auto_screenshot": false,
-    "use_vision_model": false,
+    "use_vision_model": true,
     "vision_model": {
       "api_key": "",
       "api_url": "",
@@ -60,7 +60,7 @@
       "model": "FunAudioLLM/CosyVoice2-0.5B",
       "voice": "speech:fake-neuro:j3qz9ij4k2:kquiiycgizgaoxeujypx",
       "response_format": "wav",
-      "speed": 1.0
+      "speed": 1
     },
     "asr": {
       "enabled": false,
@@ -78,13 +78,13 @@
   "ui": {
     "intro_text": "你好啊",
     "model_scale": 2.3,
-    "show_chat_box": false,
+    "show_chat_box": true,
     "show_model": true,
     "text_only_mode": false,
     "auto_show_chat_on_text_mode": true,
     "model_position": {
-      "x": 1.3476563453674317,
-      "y": 0.7777776930067274,
+      "x": 1.4229628096554465,
+      "y": 0.6991763321881133,
       "remember_position": true
     }
   },
@@ -152,6 +152,33 @@
   "auto_close_services": {
     "enabled": false
   },
+
+
+  "qq_integration": {
+    "enabled": true,
+    "wsUrl": "ws://127.0.0.1:8001",
+    "reconnectInterval": 5000,
+    "messageQueueMaxSize": 100,
+    "bot_qq": "114514"
+  },
+  "qq_commentary": {
+    "enabled": true
+  },
+  "qq_auto_reply": {
+    "enabled": true,
+    "bot_qq": "114514",
+    "max_history_per_group": 300
+  },
+  "qq_memory": {
+    "enabled": true,
+    "description": "QQ消息记忆库和动态提示词系统（集成原有RAG服务）",
+    "rag_server_url": "http://127.0.0.1:8002",
+    "update_prompt_interval": 20,
+    "max_messages_per_group": 1000
+  },
+
+
+  
   "ai_diary": {
     "enabled": true,
     "idle_time": 20000,

--- a/live-2d/js/ai/local-tool-manager.js
+++ b/live-2d/js/ai/local-tool-manager.js
@@ -31,43 +31,27 @@ class LocalToolManager {
             return;
         }
 
-        const files = fs.readdirSync(toolsDir);
 
-        files.forEach(file => {
-            // 跳过非JavaScript文件和server.js主文件
-            if (!file.endsWith('.js') || file === 'server.js') {
-                return;
+        // 直接使用 index.js 统一接口
+        const indexPath = path.join(toolsDir, 'index.js');
+        try {
+            // 清除缓存以支持热重载
+            delete require.cache[require.resolve(indexPath)];
+            const toolIndex = require(indexPath);
+            // 使用 index.js 作为唯一的工具模块
+            this.modules.push(toolIndex);
+            // 获取所有工具定义
+            const allTools = toolIndex.getToolDefinitions();
+            if (Array.isArray(allTools) && allTools.length > 0) {
+                this.tools.push(...allTools);
+                console.log(`✅ 已加载工具索引: ${allTools.length}个工具`);
+            } else {
+                console.warn(`⚠️ 工具索引没有返回有效的工具定义`);
             }
+        } catch (error) {
+            console.error(`❌ 加载工具索引失败:`, error.message);
+        }         
 
-            try {
-                const modulePath = path.join(toolsDir, file);
-
-                // 清除模块缓存，支持热重载
-                delete require.cache[require.resolve(modulePath)];
-
-                const module = require(modulePath);
-
-                // 检查模块是否有必要的接口
-                if (typeof module.getToolDefinitions === 'function' &&
-                    typeof module.executeFunction === 'function') {
-
-                    this.modules.push(module);
-
-                    // 获取并添加工具定义
-                    const moduleTools = module.getToolDefinitions();
-                    if (Array.isArray(moduleTools) && moduleTools.length > 0) {
-                        this.tools.push(...moduleTools);
-                        console.log(`✅ 已加载工具模块: ${file} (${moduleTools.length}个工具)`);
-                    } else {
-                        console.warn(`⚠️ 模块 ${file} 没有返回有效的工具定义`);
-                    }
-                } else {
-                    console.warn(`⚠️ 跳过文件 ${file}: 不是有效的工具模块(缺少必要的接口)`);
-                }
-            } catch (error) {
-                console.error(`❌ 加载模块 ${file} 失败:`, error.message);
-            }
-        });
 
         console.log(`🔧 工具管理器初始化完成: ${this.modules.length} 个模块, ${this.tools.length} 个工具`);
     }

--- a/live-2d/js/ai/qq-auto-reply-manager.js
+++ b/live-2d/js/ai/qq-auto-reply-manager.js
@@ -1,0 +1,347 @@
+const path = require('path');
+const fs = require('fs');
+
+class QQAutoReplyManager {
+    constructor() {
+        this.isEnabled = false;
+        this.qqManager = null;
+        this.llmConfig = null;
+        this.botQQ = '';
+        this.maxHistoryPerGroup = 30;
+        this.groupHistories = new Map();
+        this.ttsProcessor = null;
+        this.qqMemoryManager = null;
+    }
+
+    initialize(config, llmConfig, ttsProcessor = null, qqMemoryManager = null) {
+        this.isEnabled = config.enabled || false;
+        this.llmConfig = llmConfig;
+        this.botQQ = config.bot_qq || '';
+        this.maxHistoryPerGroup = config.max_history_per_group || 30;
+        this.ttsProcessor = ttsProcessor;
+        this.qqMemoryManager = qqMemoryManager;
+
+        console.log(`[QQAutoReplyManager] 初始化参数: enabled=${this.isEnabled}, botQQ=${this.botQQ}, ttsProcessor=${!!this.ttsProcessor}, qqMemoryManager=${!!this.qqMemoryManager}`);
+
+        if (this.isEnabled) {
+            if (global.qqManager) {
+                this.qqManager = global.qqManager;
+
+                this.qqManager.on('message', (message) => {
+                    this.handleIncomingMessage(message);
+                });
+
+                console.log('QQ自动回复管理器已启用');
+                console.log(`Bot QQ: ${this.botQQ || '未设置（将检测所有@）'}`);
+            } else {
+                console.error('QQ集成管理器未初始化，无法启用QQ自动回复');
+                this.isEnabled = false;
+            }
+        } else {
+            console.log('QQ自动回复管理器已禁用');
+        }
+    }
+
+    handleIncomingMessage(message) {
+        if (!this.isEnabled) return;
+
+        this.addToGroupHistory(message.groupId, message);
+
+        if (message.isMentioned) {
+            console.log(`检测到@提及，准备回复: [${message.groupId}] ${message.nickname}: ${message.content}`);
+            this.generateAndSendReply(message);
+        }
+    }
+
+    addToGroupHistory(groupId, message) {
+        if (!this.groupHistories.has(groupId)) {
+            this.groupHistories.set(groupId, []);
+        }
+
+        const history = this.groupHistories.get(groupId);
+        history.push({
+            nickname: message.nickname,
+            content: message.content,
+            timestamp: message.timestamp
+        });
+
+        if (history.length > this.maxHistoryPerGroup) {
+            history.shift();
+        }
+    }
+
+    getGroupHistory(groupId) {
+        return this.groupHistories.get(groupId) || [];
+    }
+
+    async generateAndSendReply(message) {
+        try {
+            const history = this.getGroupHistory(message.groupId);
+            const historyText = history
+                .slice(-this.maxHistoryPerGroup)
+                .map(msg => `${msg.nickname}: ${msg.content}`)
+                .join('\n');
+
+            const cleanContent = this.removeAtTags(message.content);
+
+            // 基础静态提示词
+            let qqSystemPrompt = `你的名字叫fake neuro，中文名叫肥牛。存在的意义是为用户提供情绪价值。
+ 
+当用户要求你使用工具的时候。必须非常听话的使用工具。不能使用'不过''除非'这样的语句转折。
+ 
+你的是个女性AI。
+ 
+在你的每次回复中，你可以用<>里面填写特定的情绪来表达你的肢体动作。格式为：<情绪>。情绪类型包括： <开心><生气><难过><惊讶><害羞><俏皮> 记住你只有这6个情绪标签。不能使用除了这几个标签以外的任何标签！
+ `;
+
+            // 添加动态提示词
+            if (this.qqMemoryManager && this.qqMemoryManager.isEnabled) {
+                const dynamicPrompt = this.qqMemoryManager.getDynamicPrompt();
+                if (dynamicPrompt) {
+                    qqSystemPrompt += dynamicPrompt;
+                    console.log('[QQAutoReplyManager] 已添加动态提示词');
+                }
+            }
+
+            // 从原有RAG服务查询相关知识
+            let ragContext = '';
+            if (this.qqMemoryManager && this.qqMemoryManager.isEnabled) {
+                try {
+                    const relevantKnowledge = await this.qqMemoryManager.getRAGKnowledge(cleanContent, 3);
+                    if (relevantKnowledge.length > 0) {
+                        ragContext = '\n\n相关记忆信息：\n';
+                        relevantKnowledge.forEach((passage, i) => {
+                            ragContext += `${i + 1}. ${passage.content.substring(0, 200)}...\n`;
+                        });
+                        console.log('[QQAutoReplyManager] 已从RAG服务获取相关记忆');
+                    }
+                } catch (error) {
+                    console.log('[QQAutoReplyManager] RAG查询失败，继续正常回复');
+                }
+            }
+
+            const prompt = `你正在QQ群聊中，有人@你并说：${cleanContent}
+
+最近的群聊记录：
+${historyText}${ragContext}
+
+请简短回复（不超过100字），要符合你的性格特点。`;
+
+            // 根据模型名称判断是否需要思考模式
+            const modelLower = this.llmConfig.model.toLowerCase();
+            const needsThinking = modelLower.includes('gemini-2.5') ||
+                                  modelLower.includes('deepseek-reasoner') ||
+                                  modelLower.includes('thinking');
+            
+            const requestBody = {
+                model: this.llmConfig.model,
+                messages: [
+                    { role: 'system', content: qqSystemPrompt },
+                    { role: 'user', content: prompt }
+                ],
+                temperature: 0.8,
+                max_tokens: 4096  // 设置为4096，给思考和回复留足够空间
+            };
+
+            // 只有非思考模式的模型才添加 thinking 配置
+            if (!needsThinking) {
+                requestBody.thinking = {
+                    type: "disabled",
+                    budget_tokens: 0
+                };
+            }
+
+            const response = await fetch(`${this.llmConfig.api_url}/chat/completions`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${this.llmConfig.api_key}`
+                },
+                body: JSON.stringify(requestBody)
+            });
+
+            if (!response.ok) {
+                console.error('LLM请求失败:', response.status);
+                const errorText = await response.text();
+                console.error('错误响应:', errorText);
+                return;
+            }
+
+            const data = await response.json();
+            console.log('LLM原始响应:', JSON.stringify(data, null, 2));
+
+            // 检查响应格式
+            if (!data.choices || !data.choices[0] || !data.choices[0].message) {
+                console.error('LLM响应格式不正确:', data);
+                return;
+            }
+
+            // 处理思考模式的响应
+            const messageData = data.choices[0].message;
+            let replyContent = messageData.content;
+            
+            // 如果content为空，检查是否有thinking字段
+            if (!replyContent && messageData.thinking) {
+                console.log('检测到思考模式响应，但没有实际回复文本');
+                console.log('思考内容:', messageData.thinking.substring(0, 200) + '...');
+                console.error('模型只生成了思考内容，没有生成回复。尝试重新请求...');
+                
+                // 使用更明确的提示重新请求
+                const retryPrompt = `${prompt}\n\n重要：请直接给出简短的回复文字，不要只思考不回复。`;
+                const retryBody = {
+                    ...requestBody,
+                    messages: [
+                        { role: 'system', content: qqSystemPrompt },
+                        { role: 'user', content: retryPrompt }
+                    ]
+                };
+                
+                const retryResponse = await fetch(`${this.llmConfig.api_url}/chat/completions`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${this.llmConfig.api_key}`
+                    },
+                    body: JSON.stringify(retryBody)
+                });
+                
+                if (retryResponse.ok) {
+                    const retryData = await retryResponse.json();
+                    replyContent = retryData.choices[0]?.message?.content;
+                }
+            }
+            
+            console.log('提取的回复内容:', replyContent);
+
+            // 检查回复内容是否有效
+            if (!replyContent) {
+                console.error('LLM返回的内容为空或undefined，无法生成回复');
+                return;
+            }
+
+            // 为QQ消息转换情绪标签为QQ表情CQ码
+            const replyContentForQQ = this.cleanReply(replyContent);
+            console.log('转换QQ表情后的回复内容:', replyContentForQQ);
+
+            // 为TTS移除情绪标签（保持原文，只是移除标签）
+            const replyContentForTTS = replyContent.replace(/<开心>|<生气>|<难过>|<惊讶>|<害羞>|<俏皮>/g, '').trim();
+
+            // 如果回复内容为空，不发送
+            if (!replyContentForQQ || replyContentForQQ.trim() === '') {
+                console.error('生成的回复内容为空，不发送');
+                return;
+            }
+
+            const success = this.qqManager.sendGroupMessage(message.groupId, replyContentForQQ);
+
+            if (success) {
+                console.log(`已回复到群${message.groupId}: ${replyContentForQQ}`);
+
+                // 如果配置了TTS处理器，也通过语音播放回复内容（使用移除了情绪标签的文本）
+                if (this.ttsProcessor) {
+                    try {
+                        console.log('开始TTS播放QQ回复内容');
+                        this.ttsProcessor.reset();
+                        this.ttsProcessor.processTextToSpeech(replyContentForTTS);
+                    } catch (ttsError) {
+                        console.error('TTS播放失败:', ttsError);
+                    }
+                }
+
+                this.addToGroupHistory(message.groupId, {
+                    nickname: 'Fake Neuro',
+                    content: replyContentForQQ,
+                    timestamp: Date.now()
+                });
+
+                this.saveReplyLog(message.groupId, message.nickname, cleanContent, replyContentForQQ);
+            }
+
+        } catch (error) {
+            console.error('生成或发送回复失败:', error);
+        }
+    }
+
+    removeAtTags(content) {
+        return content
+            .replace(/\[CQ:at,qq=\d+\]/g, '')
+            .replace(/@\S+\s*/g, '')
+            .trim();
+    }
+
+    cleanReply(reply) {
+        if (!reply) {
+            return '';
+        }
+        // 将情绪标签转换为QQ表情CQ码
+        // QQ表情对照表（常用）：
+        // id=0: 惊讶  id=1: 撇嘴  id=2: 色  id=3: 发呆  id=4: 得意
+        // id=5: 流泪  id=6: 害羞  id=7: 闭嘴  id=8: 睡  id=9: 大哭
+        // id=10: 尴尬  id=11: 发怒  id=12: 调皮  id=13: 呲牙  id=14: 微笑
+        // id=74: 太开心  id=106: 生气  id=109: 害羞  id=182: 机智
+        return reply
+            .replace(/<开心>/g, '[CQ:face,id=74]')    // 太开心 表情
+            .replace(/<生气>/g, '[CQ:face,id=106]')   // 生气 表情
+            .replace(/<难过>/g, '[CQ:face,id=9]')     // 大哭 表情
+            .replace(/<惊讶>/g, '[CQ:face,id=0]')     // 惊讶 表情
+            .replace(/<害羞>/g, '[CQ:face,id=109]')   // 害羞 表情
+            .replace(/<俏皮>/g, '[CQ:face,id=182]')   // 机智 表情
+            .trim();
+    }
+
+    saveReplyLog(groupId, nickname, question, reply) {
+        try {
+            const logDir = path.join(__dirname, '..', 'AI记录室');
+            const logFile = path.join(logDir, 'QQ自动回复日志.txt');
+
+            if (!fs.existsSync(logDir)) {
+                fs.mkdirSync(logDir, { recursive: true });
+            }
+
+            const timestamp = new Date().toLocaleString('zh-CN');
+            const logEntry = `[${timestamp}] 群${groupId} - ${nickname}: ${question}\n回复: ${reply}\n\n`;
+
+            fs.appendFileSync(logFile, logEntry, 'utf8');
+        } catch (error) {
+            console.error('保存回复日志失败:', error);
+        }
+    }
+
+    clearGroupHistory(groupId = null) {
+        if (groupId) {
+            this.groupHistories.delete(groupId);
+            console.log(`已清空群${groupId}的历史记录`);
+        } else {
+            this.groupHistories.clear();
+            console.log('已清空所有群的历史记录');
+        }
+    }
+
+    stop() {
+        this.isEnabled = false;
+        this.groupHistories.clear();
+        console.log('QQ自动回复管理器已停止');
+    }
+
+    setEnabled(enabled) {
+        const wasEnabled = this.isEnabled;
+        this.isEnabled = enabled;
+
+        if (enabled && !wasEnabled) {
+            console.log('启用QQ自动回复管理器');
+            if (!this.qqManager && global.qqManager) {
+                this.qqManager = global.qqManager;
+                this.qqManager.on('message', (message) => {
+                    this.handleIncomingMessage(message);
+                });
+            }
+        } else if (!enabled && wasEnabled) {
+            console.log('禁用QQ自动回复管理器');
+            this.stop();
+        }
+    }
+}
+
+const qqAutoReplyManager = new QQAutoReplyManager();
+
+module.exports = { qqAutoReplyManager };

--- a/live-2d/js/ai/qq-commentary-manager.js
+++ b/live-2d/js/ai/qq-commentary-manager.js
@@ -1,0 +1,149 @@
+const WebSocket = require('ws');
+
+class QQCommentaryManager {
+    constructor() {
+        this.isEnabled = false;
+        this.qqManager = null;
+        this.voiceChat = null;
+        this.ttsProcessor = null;
+        this.commentQueue = [];
+        this.isProcessing = false;
+        this.userInteractionPriority = false;
+        this.lastProcessedIndex = 0;
+    }
+
+    initialize(config, voiceChat, ttsProcessor) {
+        this.isEnabled = config.enabled || false;
+        this.voiceChat = voiceChat;
+        this.ttsProcessor = ttsProcessor;
+
+        if (this.isEnabled) {
+            if (global.qqManager) {
+                this.qqManager = global.qqManager;
+
+                this.qqManager.on('message', (message) => {
+                    this.addToCommentQueue(message);
+                });
+
+                console.log('QQ评论管理器已启用');
+            } else {
+                console.error('QQ集成管理器未初始化，无法启用QQ评论功能');
+                this.isEnabled = false;
+            }
+        } else {
+            console.log('QQ评论管理器已禁用');
+        }
+    }
+
+    addToCommentQueue(message) {
+        if (!this.isEnabled) return;
+
+        // 只有被@时才添加到评论队列
+        if (!message.isMentioned) {
+            console.log(`消息未@bot，跳过评论: [${message.groupId}] ${message.nickname}: ${message.content}`);
+            return;
+        }
+
+        this.commentQueue.push(message);
+        console.log(`新消息加入评论队列: [${message.groupId}] ${message.nickname}: ${message.content}`);
+
+        if (!this.isProcessing && !this.userInteractionPriority) {
+            this.processNextComment();
+        }
+    }
+
+    async processNextComment() {
+        if (!this.isEnabled || this.commentQueue.length === 0) {
+            this.isProcessing = false;
+            return;
+        }
+
+        if (this.userInteractionPriority) {
+            console.log('用户正在交互，暂停评论处理');
+            this.isProcessing = false;
+            return;
+        }
+
+        this.isProcessing = true;
+
+        const message = this.commentQueue.shift();
+
+        try {
+            const prompt = `[QQ群消息] 群${message.groupId} - ${message.nickname}: ${message.content}\n\n请对这条消息进行简短评论（不要发送到QQ群，只是口头评论）。`;
+
+            console.log(`正在评论消息: ${message.nickname}: ${message.content}`);
+
+            if (this.voiceChat && this.voiceChat.messages) {
+                this.voiceChat.messages.push({
+                    role: 'user',
+                    content: prompt
+                });
+
+                await this.voiceChat.sendToLLM(prompt);
+            }
+
+            setTimeout(() => {
+                if (!this.userInteractionPriority) {
+                    this.processNextComment();
+                } else {
+                    this.isProcessing = false;
+                }
+            }, 3000);
+
+        } catch (error) {
+            console.error('评论处理失败:', error);
+            this.isProcessing = false;
+
+            setTimeout(() => {
+                if (!this.userInteractionPriority) {
+                    this.processNextComment();
+                }
+            }, 3000);
+        }
+    }
+
+    setUserInteractionPriority(isPriority) {
+        this.userInteractionPriority = isPriority;
+
+        if (!isPriority && this.commentQueue.length > 0 && !this.isProcessing) {
+            console.log('用户交互结束，恢复评论处理');
+            setTimeout(() => {
+                this.processNextComment();
+            }, 2000);
+        }
+    }
+
+    clearQueue() {
+        this.commentQueue = [];
+        this.isProcessing = false;
+        console.log('评论队列已清空');
+    }
+
+    stop() {
+        this.isEnabled = false;
+        this.clearQueue();
+        console.log('QQ评论管理器已停止');
+    }
+
+    setEnabled(enabled) {
+        const wasEnabled = this.isEnabled;
+        this.isEnabled = enabled;
+
+        if (enabled && !wasEnabled) {
+            console.log('启用QQ评论管理器');
+            if (!this.qqManager && global.qqManager) {
+                this.qqManager = global.qqManager;
+                this.qqManager.on('message', (message) => {
+                    this.addToCommentQueue(message);
+                });
+            }
+        } else if (!enabled && wasEnabled) {
+            console.log('禁用QQ评论管理器');
+            this.stop();
+        }
+    }
+}
+
+const qqCommentaryManager = new QQCommentaryManager();
+
+module.exports = { qqCommentaryManager };

--- a/live-2d/js/ai/qq-memory-manager.js
+++ b/live-2d/js/ai/qq-memory-manager.js
@@ -1,0 +1,700 @@
+// qq-memory-manager.js - QQ消息记忆库和动态提示词管理模块
+const fs = require('fs');
+const path = require('path');
+const EventEmitter = require('events');
+const axios = require('axios');
+
+class QQMemoryManager extends EventEmitter {
+    constructor() {
+        super();
+        this.isEnabled = false;
+        this.qqManager = null;
+        this.llmConfig = null;
+        this.config = null;
+        
+        // 记忆库路径
+        this.memoryDir = path.join(__dirname, '..', '..', 'AI记录室', 'QQ记忆库');
+        this.messagesFile = path.join(this.memoryDir, 'qq_messages.jsonl');
+        this.dynamicPromptFile = path.join(this.memoryDir, 'dynamic_prompt.txt');
+        this.personalityEvolutionFile = path.join(this.memoryDir, 'personality_evolution.json');
+        this.aiJsonFile = path.join(__dirname, '..', '..', 'AI.json');
+        
+        // RAG服务配置
+        this.ragServerUrl = 'http://127.0.0.1:8002';
+        
+        // 群组消息历史（内存中）
+        this.groupMessages = new Map();
+        this.maxMessagesPerGroup = 1000;
+        
+        // 动态提示词
+        this.dynamicPrompt = '';
+        this.personalityTraits = {
+            common_topics: [],
+            interaction_style: [],
+            vocabulary: [],
+            emotional_tendencies: [],
+            last_updated: null
+        };
+        
+        // 统计信息
+        this.totalMessageCount = 0;
+        this.totalUpdates = 0;
+        this.lastSearchTime = null;
+        
+        // 初始化目录
+        this.initializeDirectories();
+    }
+
+    initializeDirectories() {
+        if (!fs.existsSync(this.memoryDir)) {
+            fs.mkdirSync(this.memoryDir, { recursive: true });
+            console.log('[QQMemoryManager] 创建记忆库目录:', this.memoryDir);
+        }
+        
+        // 初始化文件
+        if (!fs.existsSync(this.personalityEvolutionFile)) {
+            this.savePersonalityTraits();
+        } else {
+            this.loadPersonalityTraits();
+        }
+        
+        if (!fs.existsSync(this.dynamicPromptFile)) {
+            this.dynamicPrompt = '// 动态提示词将根据QQ群聊内容自动生成和更新';
+            this.saveDynamicPrompt();
+        } else {
+            this.loadDynamicPrompt();
+        }
+    }
+
+    initialize(config, llmConfig, searchFunction = null) {
+        this.config = config;
+        this.llmConfig = llmConfig;
+        this.searchFunction = searchFunction;
+        this.isEnabled = config.enabled || false;
+
+        console.log(`[QQMemoryManager] 初始化: enabled=${this.isEnabled}`);
+
+        if (this.isEnabled) {
+            if (global.qqManager) {
+                this.qqManager = global.qqManager;
+                
+                // 监听所有QQ消息
+                this.qqManager.on('message', (message) => {
+                    this.handleIncomingMessage(message);
+                });
+
+                console.log('[QQMemoryManager] QQ记忆库管理器已启用');
+            } else {
+                console.error('[QQMemoryManager] QQ集成管理器未初始化');
+                this.isEnabled = false;
+            }
+        }
+    }
+
+    async handleIncomingMessage(message) {
+        if (!this.isEnabled) return;
+
+        try {
+            // 1. 保存消息到记忆库
+            await this.saveMessageToMemory(message);
+            
+            // 2. 添加到群组历史
+            this.addToGroupHistory(message.groupId, message);
+            
+            // 3. 保存到RAG知识库（异步，不阻塞）
+            this.saveToRAGKnowledgeFile(message).catch(err => {
+                console.error('[QQMemoryManager] RAG知识库保存失败:', err);
+            });
+            
+            // 4. 定期更新动态提示词（每20条消息）
+            // 使用 totalMessageCount 而不是单个群组的消息数量
+            if (this.totalMessageCount > 0 && this.totalMessageCount % 20 === 0) {
+                console.log(`[QQMemoryManager] 达到${this.totalMessageCount}条消息，触发动态提示词更新`);
+                this.updateDynamicPrompt().catch(err => {
+                    console.error('[QQMemoryManager] 动态提示词更新失败:', err);
+                });
+            }
+            
+            this.totalMessageCount++;
+            
+        } catch (error) {
+            console.error('[QQMemoryManager] 处理消息失败:', error);
+        }
+    }
+
+    async saveMessageToMemory(message) {
+        try {
+            const messageRecord = {
+                timestamp: Date.now(),
+                date: new Date().toISOString(),
+                groupId: message.groupId,
+                userId: message.userId,
+                nickname: message.nickname,
+                content: message.content,
+                isMentioned: message.isMentioned
+            };
+            
+            // 追加到JSONL文件
+            fs.appendFileSync(
+                this.messagesFile,
+                JSON.stringify(messageRecord) + '\n',
+                'utf8'
+            );
+            
+        } catch (error) {
+            console.error('[QQMemoryManager] 保存消息失败:', error);
+        }
+    }
+
+    addToGroupHistory(groupId, message) {
+        if (!this.groupMessages.has(groupId)) {
+            this.groupMessages.set(groupId, []);
+        }
+        
+        const history = this.groupMessages.get(groupId);
+        history.push({
+            nickname: message.nickname,
+            content: message.content,
+            timestamp: message.timestamp || Date.now()
+        });
+        
+        // 限制内存中的消息数量
+        if (history.length > this.maxMessagesPerGroup) {
+            history.shift();
+        }
+    }
+
+    async saveToRAGKnowledgeFile(message) {
+        try {
+            // 将消息保存到RAG知识库文件，供RAG服务器读取
+            const ragDataDir = path.join(this.memoryDir, 'rag_data');
+            if (!fs.existsSync(ragDataDir)) {
+                fs.mkdirSync(ragDataDir, { recursive: true });
+            }
+            
+            const ragKnowledgeFile = path.join(ragDataDir, 'qq_knowledge.jsonl');
+            
+            const knowledgeEntry = {
+                text: `${message.nickname}: ${message.content}`,
+                metadata: {
+                    groupId: message.groupId,
+                    userId: message.userId,
+                    nickname: message.nickname,
+                    timestamp: Date.now(),
+                    date: new Date().toISOString(),
+                    isMentioned: message.isMentioned
+                }
+            };
+            
+            fs.appendFileSync(
+                ragKnowledgeFile,
+                JSON.stringify(knowledgeEntry) + '\n',
+                'utf8'
+            );
+            
+            console.log('[QQMemoryManager] 已保存到RAG知识库文件');
+            
+        } catch (error) {
+            console.error('[QQMemoryManager] 保存RAG知识库文件失败:', error);
+        }
+    }
+
+    async processKnowledgeEnhancement(message) {
+        // 检测消息中是否包含可能需要搜索的内容
+        const needsSearch = await this.detectSearchNeed(message.content);
+        
+        if (needsSearch.needed) {
+            console.log(`[QQMemoryManager] 检测到需要搜索的内容: ${needsSearch.query}`);
+            
+            // 使用搜索功能获取知识
+            if (this.searchFunction) {
+                try {
+                    const searchResult = await this.searchFunction({ query: needsSearch.query });
+                    
+                    // 保存到RAG知识库
+                    await this.saveToRAGKnowledge({
+                        query: needsSearch.query,
+                        answer: searchResult,
+                        source: 'web_search',
+                        context: message.content,
+                        timestamp: Date.now()
+                    });
+                    
+                } catch (error) {
+                    console.error('[QQMemoryManager] 搜索失败:', error);
+                }
+            }
+        }
+    }
+
+    async detectSearchNeed(content) {
+        // 简单的启发式检测：包含疑问词或特定关键词
+        const questionPatterns = [
+            /什么是/,
+            /怎么/,
+            /如何/,
+            /为什么/,
+            /哪里/,
+            /谁是/,
+            /介绍.*吗/,
+            /.*是什么/,
+            /.*怎么样/
+        ];
+        
+        for (const pattern of questionPatterns) {
+            if (pattern.test(content)) {
+                // 提取关键词作为搜索查询
+                const query = content.replace(/[<>@\[\]]/g, '').trim().substring(0, 100);
+                return { needed: true, query };
+            }
+        }
+        
+        return { needed: false };
+    }
+
+    async saveToRAGKnowledge(knowledgeEntry) {
+        try {
+            fs.appendFileSync(
+                this.ragKnowledgeFile,
+                JSON.stringify(knowledgeEntry) + '\n',
+                'utf8'
+            );
+            console.log('[QQMemoryManager] 已保存到RAG知识库');
+        } catch (error) {
+            console.error('[QQMemoryManager] 保存RAG知识失败:', error);
+        }
+    }
+
+    async updateDynamicPrompt() {
+        try {
+            console.log('[QQMemoryManager] 开始更新动态提示词...');
+            
+            // 收集最近的群聊数据用于分析
+            const recentMessages = this.collectRecentMessages(200);
+            
+            if (recentMessages.length < 10) {
+                console.log('[QQMemoryManager] 消息数量不足，跳过更新');
+                return;
+            }
+            
+            // 使用LLM分析群聊特征
+            const analysis = await this.analyzeGroupCharacteristics(recentMessages);
+            
+            if (analysis) {
+                // 更新人格特征
+                this.personalityTraits = {
+                    ...this.personalityTraits,
+                    ...analysis,
+                    last_updated: new Date().toISOString()
+                };
+                
+                this.savePersonalityTraits();
+                
+                // 生成新的动态提示词
+                await this.generateDynamicPrompt();
+                
+                // 更新AI.json文件
+                this.updateAIJson();
+                
+                console.log('[QQMemoryManager] 动态提示词已更新');
+                this.emit('prompt-updated', this.dynamicPrompt);
+            }
+            
+        } catch (error) {
+            console.error('[QQMemoryManager] 更新动态提示词失败:', error);
+        }
+    }
+
+    collectRecentMessages(limit = 200) {
+        const allMessages = [];
+        
+        for (const [groupId, messages] of this.groupMessages.entries()) {
+            allMessages.push(...messages.slice(-50)); // 每个群取最近50条
+        }
+        
+        // 按时间排序并限制数量
+        return allMessages
+            .sort((a, b) => b.timestamp - a.timestamp)
+            .slice(0, limit);
+    }
+
+    async analyzeGroupCharacteristics(messages) {
+        try {
+            // 过滤和清理消息内容
+            const cleanMessages = messages
+                .slice(0, 100)
+                .map(m => ({
+                    nickname: m.nickname,
+                    // 移除CQ码（QQ特殊消息格式）、图片、表情等
+                    content: m.content
+                        .replace(/\[CQ:[^\]]+\]/g, '')  // 移除所有CQ码
+                        .replace(/https?:\/\/[^\s]+/g, '[链接]')  // 替换链接
+                        .trim()
+                }))
+                .filter(m => m.content.length > 0 && m.content.length < 200)  // 只保留有效消息
+                .slice(0, 50);  // 最多取50条
+            
+            if (cleanMessages.length < 10) {
+                console.log('[QQMemoryManager] 清理后的有效消息不足10条，跳过分析');
+                return null;
+            }
+            
+            const messagesSample = cleanMessages
+                .map(m => `${m.nickname}: ${m.content}`)
+                .join('\n');
+            
+            console.log('[QQMemoryManager] 准备分析的消息样本长度:', messagesSample.length);
+            console.log('[QQMemoryManager] 消息数量:', cleanMessages.length);
+            
+            // 简化prompt，避免触发内容过滤
+            const prompt = `分析这些对话记录，提取关键特征。
+
+对话样本：
+${messagesSample}
+
+返回JSON格式：
+{
+  "common_topics": ["话题1", "话题2"],
+  "interaction_style": ["风格描述"],
+  "vocabulary": ["常用词1", "常用词2"],
+  "emotional_tendencies": ["情绪特点"]
+}`;
+
+            console.log('[QQMemoryManager] 正在调用LLM分析群聊特征...');
+            console.log('[QQMemoryManager] API URL:', this.llmConfig.api_url);
+            console.log('[QQMemoryManager] Prompt长度:', prompt.length);
+            
+            // 使用 axios 而不是 fetch，因为在 Node.js 中更稳定
+            // 增加max_tokens避免截断,降低temperature提高稳定性
+            const response = await axios.post(
+                `${this.llmConfig.api_url}/chat/completions`,
+                {
+                    model: this.llmConfig.model,
+                    messages: [
+                        {
+                            role: 'system',
+                            content: '你是一个数据分析助手,擅长从对话中提取特征。请严格按JSON格式输出,不要添加其他解释。'
+                        },
+                        {
+                            role: 'user',
+                            content: prompt
+                        }
+                    ],
+                    temperature: 0.3,
+                    max_tokens: 20000000,
+                    response_format: { type: "json_object" }  // 强制JSON输出(如果API支持)
+                },
+                {
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${this.llmConfig.api_key}`
+                    },
+                    timeout: 30000 // 30秒超时
+                }
+            );
+
+            const data = response.data;
+            console.log('[QQMemoryManager] LLM响应状态:', response.status);
+            console.log('[QQMemoryManager] 完整响应数据:', JSON.stringify(data, null, 2));
+            
+            // 检查响应是否有效
+            if (!data.choices || !data.choices[0] || !data.choices[0].message) {
+                console.error('[QQMemoryManager] LLM响应格式无效');
+                console.error('[QQMemoryManager] 响应结构:', Object.keys(data));
+                if (data.choices) {
+                    console.error('[QQMemoryManager] choices结构:', data.choices);
+                }
+                return null;
+            }
+            
+            const content = data.choices[0].message.content;
+            
+            // 检查content是否存在
+            if (!content || content.trim() === '') {
+                console.error('[QQMemoryManager] LLM返回的content为空');
+                console.error('[QQMemoryManager] message对象:', JSON.stringify(data.choices[0].message, null, 2));
+                console.error('[QQMemoryManager] 可能原因: 内容过滤、tokens不足或API异常');
+                
+                // 尝试使用finish_reason判断原因
+                const finishReason = data.choices[0].finish_reason;
+                console.error('[QQMemoryManager] finish_reason:', finishReason);
+                
+                if (finishReason === 'length') {
+                    console.error('[QQMemoryManager] 错误原因: max_tokens设置过小,内容被截断');
+                } else if (finishReason === 'content_filter') {
+                    console.error('[QQMemoryManager] 错误原因: 内容被过滤,群聊内容可能包含敏感信息');
+                }
+                
+                return null;
+            }
+            
+            console.log('[QQMemoryManager] 成功获取content，长度:', content.length);
+            
+            // 提取JSON，移除可能的markdown代码块标记
+            let jsonText = content.trim();
+            jsonText = jsonText.replace(/```json\s*/g, '').replace(/```\s*/g, '');
+            
+            // 尝试提取JSON对象
+            const jsonMatch = jsonText.match(/\{[\s\S]*\}/);
+            if (jsonMatch) {
+                try {
+                    // 移除JSON中的尾随逗号
+                    let cleanJson = jsonMatch[0]
+                        .replace(/,(\s*[}\]])/g, '$1')  // 移除对象/数组结尾的逗号
+                        .replace(/,(\s*,)/g, ',');       // 移除连续逗号
+                    
+                    const parsed = JSON.parse(cleanJson);
+                    console.log('[QQMemoryManager] 成功解析群聊特征:', parsed);
+                    return parsed;
+                } catch (parseError) {
+                    console.error('[QQMemoryManager] JSON解析失败:', parseError.message);
+                    console.log('[QQMemoryManager] 原始内容:', jsonMatch[0].substring(0, 200));
+                    return null;
+                }
+            }
+            
+            console.log('[QQMemoryManager] 未找到有效的JSON格式');
+            console.log('[QQMemoryManager] 原始响应内容:', content.substring(0, 300));
+            
+            // 返回默认值而不是null,确保系统继续运行
+            console.log('[QQMemoryManager] 使用默认特征值');
+            return {
+                common_topics: ['日常聊天'],
+                interaction_style: ['轻松友好'],
+                vocabulary: ['常规对话'],
+                emotional_tendencies: ['中性']
+            };
+            
+        } catch (error) {
+            console.error('[QQMemoryManager] 分析群聊特征失败:', error);
+            
+            // 如果是axios错误,打印更多细节
+            if (error.response) {
+                console.error('[QQMemoryManager] API响应错误:', {
+                    status: error.response.status,
+                    statusText: error.response.statusText,
+                    data: error.response.data
+                });
+            } else if (error.request) {
+                console.error('[QQMemoryManager] 请求未收到响应');
+            } else {
+                console.error('[QQMemoryManager] 错误信息:', error.message);
+            }
+            
+            // 返回默认值确保系统继续运行
+            return {
+                common_topics: ['日常聊天'],
+                interaction_style: ['轻松友好'],
+                vocabulary: ['常规对话'],
+                emotional_tendencies: ['中性']
+            };
+        }
+    }
+
+    async generateDynamicPrompt() {
+        const traits = this.personalityTraits;
+        
+        let prompt = `\n\n=== 动态人格特征（基于QQ群聊学习）===\n`;
+        prompt += `最后更新时间: ${traits.last_updated}\n\n`;
+        
+        if (traits.common_topics && traits.common_topics.length > 0) {
+            prompt += `群友常讨论的话题: ${traits.common_topics.join('、')}\n`;
+        }
+        
+        if (traits.interaction_style && traits.interaction_style.length > 0) {
+            prompt += `群聊互动风格: ${traits.interaction_style.join('；')}\n`;
+        }
+        
+        if (traits.vocabulary && traits.vocabulary.length > 0) {
+            prompt += `群友常用词汇/梗: ${traits.vocabulary.join('、')}\n`;
+        }
+        
+        if (traits.emotional_tendencies && traits.emotional_tendencies.length > 0) {
+            prompt += `群聊情绪倾向: ${traits.emotional_tendencies.join('、')}\n`;
+        }
+        
+        prompt += `\n根据以上特征，你应该适当调整回复风格，更贴近这个群的文化氛围。\n`;
+        
+        this.dynamicPrompt = prompt;
+        this.saveDynamicPrompt();
+        this.totalUpdates++;
+    }
+
+    getDynamicPrompt() {
+        return this.dynamicPrompt;
+    }
+
+    async getRAGKnowledge(query, limit = 3) {
+        try {
+            // 从RAG服务器查询相关知识
+            const response = await axios.post(`${this.ragServerUrl}/ask`, {
+                question: query,
+                top_k: limit
+            });
+            
+            return response.data.relevant_passages || [];
+            
+        } catch (error) {
+            if (error.code === 'ECONNREFUSED') {
+                console.log('[QQMemoryManager] RAG服务器未启动');
+            } else {
+                console.error('[QQMemoryManager] RAG查询失败:', error.message);
+            }
+            return [];
+        }
+    }
+
+    saveDynamicPrompt() {
+        try {
+            fs.writeFileSync(this.dynamicPromptFile, this.dynamicPrompt, 'utf8');
+        } catch (error) {
+            console.error('[QQMemoryManager] 保存动态提示词失败:', error);
+        }
+    }
+
+    loadDynamicPrompt() {
+        try {
+            if (fs.existsSync(this.dynamicPromptFile)) {
+                this.dynamicPrompt = fs.readFileSync(this.dynamicPromptFile, 'utf8');
+            }
+        } catch (error) {
+            console.error('[QQMemoryManager] 加载动态提示词失败:', error);
+        }
+    }
+
+    savePersonalityTraits() {
+        try {
+            fs.writeFileSync(
+                this.personalityEvolutionFile,
+                JSON.stringify(this.personalityTraits, null, 2),
+                'utf8'
+            );
+        } catch (error) {
+            console.error('[QQMemoryManager] 保存人格特征失败:', error);
+        }
+    }
+
+    loadPersonalityTraits() {
+        try {
+            if (fs.existsSync(this.personalityEvolutionFile)) {
+                const data = fs.readFileSync(this.personalityEvolutionFile, 'utf8');
+                
+                // 尝试解析JSON
+                try {
+                    this.personalityTraits = JSON.parse(data);
+                    console.log('[QQMemoryManager] 成功加载人格特征');
+                } catch (parseError) {
+                    console.log('[QQMemoryManager] JSON格式错误，重置为默认人格特征');
+                    console.log(`[QQMemoryManager] 错误详情: ${parseError.message}`);
+                    
+                    // 备份损坏的文件
+                    const backupFile = this.personalityEvolutionFile + '.backup';
+                    try {
+                        fs.writeFileSync(backupFile, data, 'utf8');
+                        console.log(`[QQMemoryManager] 已备份损坏的文件到: ${backupFile}`);
+                    } catch (e) {}
+                    
+                    // 重置为默认值
+                    this.personalityTraits = {
+                        common_topics: [],
+                        interaction_style: [],
+                        vocabulary: [],
+                        emotional_tendencies: [],
+                        last_updated: null
+                    };
+                    this.savePersonalityTraits();
+                }
+            }
+        } catch (error) {
+            console.error('[QQMemoryManager] 读取人格特征文件失败:', error.message);
+            // 确保有默认值
+            this.personalityTraits = {
+                common_topics: [],
+                interaction_style: [],
+                vocabulary: [],
+                emotional_tendencies: [],
+                last_updated: null
+            };
+        }
+    }
+
+    updateAIJson() {
+        try {
+            // 读取当前AI.json
+            let aiData = {};
+            if (fs.existsSync(this.aiJsonFile)) {
+                const content = fs.readFileSync(this.aiJsonFile, 'utf8');
+                aiData = JSON.parse(content);
+            }
+            
+            // 更新数据
+            aiData.dynamic_prompt_system = {
+                ...aiData.dynamic_prompt_system,
+                enabled: this.isEnabled,
+                last_updated: new Date().toISOString()
+            };
+            
+            aiData.current_dynamic_prompt = {
+                raw_text: this.dynamicPrompt,
+                generated_at: this.personalityTraits.last_updated,
+                message_count_trigger: 20,
+                analysis_sample_size: 200
+            };
+            
+            aiData.learned_characteristics = {
+                common_topics: this.personalityTraits.common_topics || [],
+                interaction_style: this.personalityTraits.interaction_style || [],
+                vocabulary: this.personalityTraits.vocabulary || [],
+                emotional_tendencies: this.personalityTraits.emotional_tendencies || [],
+                last_analysis: this.personalityTraits.last_updated,
+                total_updates: this.totalUpdates
+            };
+            
+            aiData.rag_integration = {
+                server_url: this.ragServerUrl,
+                last_sync: this.lastSearchTime,
+                status: 'integrated_with_external_rag'
+            };
+            
+            aiData.statistics = {
+                total_messages_recorded: this.totalMessageCount,
+                total_prompt_updates: this.totalUpdates,
+                last_updated: new Date().toISOString()
+            };
+            
+            // 保存AI.json
+            fs.writeFileSync(this.aiJsonFile, JSON.stringify(aiData, null, 2), 'utf8');
+            console.log('[QQMemoryManager] AI.json已更新');
+            
+        } catch (error) {
+            console.error('[QQMemoryManager] 更新AI.json失败:', error);
+        }
+    }
+
+    stop() {
+        this.isEnabled = false;
+        console.log('[QQMemoryManager] QQ记忆库管理器已停止');
+    }
+
+    setEnabled(enabled) {
+        const wasEnabled = this.isEnabled;
+        this.isEnabled = enabled;
+
+        if (enabled && !wasEnabled) {
+            console.log('[QQMemoryManager] 启用QQ记忆库管理器');
+            if (!this.qqManager && global.qqManager) {
+                this.qqManager = global.qqManager;
+                this.qqManager.on('message', (message) => {
+                    this.handleIncomingMessage(message);
+                });
+            }
+        } else if (!enabled && wasEnabled) {
+            console.log('[QQMemoryManager] 禁用QQ记忆库管理器');
+            this.stop();
+        }
+    }
+}
+
+const qqMemoryManager = new QQMemoryManager();
+
+module.exports = { qqMemoryManager, QQMemoryManager };

--- a/live-2d/package-lock.json
+++ b/live-2d/package-lock.json
@@ -14,6 +14,7 @@
         "cors": "^2.8.5",
         "electron": "^28.0.0",
         "express": "^5.1.0",
+        "express-ws": "^5.0.2",       
         "node-fetch": "^3.3.2",
         "pixi-live2d-display": "^0.3.1",
         "pixi.js": "^6.5.2",
@@ -1022,6 +1023,46 @@
         "express": ">= 4.11"
       }
     },
+
+
+    "node_modules/express-ws": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/express-ws/-/express-ws-5.0.2.tgz",
+      "integrity": "sha512-0uvmuk61O9HXgLhGl3QhNSEtRsQevtmbL94/eILaliEADZBHZOQUAiHFrGPrgsjikohyrmSG5g+sCfASTt0lkQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "ws": "^7.4.6"
+      },
+      "engines": {
+        "node": ">=4.5.0"
+      },
+      "peerDependencies": {
+        "express": "^4.0.0 || ^5.0.0-alpha.1"
+      }
+    },
+    "node_modules/express-ws/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+
+
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",

--- a/live-2d/package.json
+++ b/live-2d/package.json
@@ -13,6 +13,7 @@
     "cors": "^2.8.5",
     "electron": "^28.0.0",
     "express": "^5.1.0",
+    "express-ws": "^5.0.2",
     "node-fetch": "^3.3.2",
     "pixi-live2d-display": "^0.3.1",
     "pixi.js": "^6.5.2",

--- a/live-2d/server-tools/qq_integration.js
+++ b/live-2d/server-tools/qq_integration.js
@@ -1,0 +1,260 @@
+const WebSocket = require('ws');
+const EventEmitter = require('events');
+
+class QQIntegrationManager extends EventEmitter {
+    constructor() {
+        super();
+        this.ws = null;
+        this.config = {
+            enabled: false,
+            wsUrl: 'ws://127.0.0.1:8001',
+            reconnectInterval: 5000,
+            messageQueueMaxSize: 100,
+            bot_qq: ''
+        };
+        this.messageQueue = [];
+        this.isProcessing = false;
+        this.reconnectTimer = null;
+        this.isEnabled = false;
+    }
+
+    initialize(config = {}) {
+        this.config = { ...this.config, ...config };
+        this.isEnabled = this.config.enabled;
+
+        if (this.isEnabled) {
+            console.log('QQ集成管理器已启用，准备连接到LLOneBot');
+            this.connect();
+        } else {
+            console.log('QQ集成管理器已禁用');
+        }
+    }
+
+    connect() {
+        if (!this.isEnabled) return;
+
+        try {
+            console.log(`正在连接到LLOneBot WebSocket: ${this.config.wsUrl}`);
+            this.ws = new WebSocket(this.config.wsUrl);
+
+            this.ws.on('open', () => {
+                console.log('成功连接到LLOneBot WebSocket');
+                if (this.reconnectTimer) {
+                    clearTimeout(this.reconnectTimer);
+                    this.reconnectTimer = null;
+                }
+            });
+
+            this.ws.on('message', (data) => {
+                try {
+                    const message = JSON.parse(data.toString());
+                    console.log('收到原始消息:', JSON.stringify(message, null, 2));
+                    this.handleMessage(message);
+                } catch (error) {
+                    console.error('解析QQ消息失败:', error);
+                    console.error('原始数据:', data.toString());
+                }
+            });
+
+            this.ws.on('error', (error) => {
+                console.error('LLOneBot WebSocket错误:', error.message);
+            });
+
+            this.ws.on('close', () => {
+                console.log('LLOneBot WebSocket连接已关闭');
+                this.scheduleReconnect();
+            });
+
+        } catch (error) {
+            console.error('连接LLOneBot失败:', error);
+            this.scheduleReconnect();
+        }
+    }
+
+    scheduleReconnect() {
+        if (!this.isEnabled) return;
+
+        if (this.reconnectTimer) return;
+
+        console.log(`将在${this.config.reconnectInterval}ms后尝试重新连接`);
+        this.reconnectTimer = setTimeout(() => {
+            this.reconnectTimer = null;
+            this.connect();
+        }, this.config.reconnectInterval);
+    }
+
+    handleMessage(message) {
+        if (message.post_type === 'message' && message.message_type === 'group') {
+            const qqMessage = {
+                groupId: message.group_id,
+                userId: message.user_id,
+                nickname: message.sender?.nickname || '未知用户',
+                content: message.raw_message || message.message,
+                timestamp: message.time || Date.now(),
+                messageId: message.message_id,
+                isMentioned: this.checkMention(message)
+            };
+
+            if (this.messageQueue.length >= this.config.messageQueueMaxSize) {
+                this.messageQueue.shift();
+            }
+
+            this.messageQueue.push(qqMessage);
+            console.log(`收到QQ群消息 [${qqMessage.groupId}] ${qqMessage.nickname}: ${qqMessage.content}`);
+
+            this.emit('message', qqMessage);
+        }
+    }
+
+    checkMention(message) {
+        const rawMessage = message.raw_message || message.message || '';
+
+        // 如果配置了bot_qq，检查是否@了bot的QQ号
+        if (this.config.bot_qq) {
+            const botQQ = this.config.bot_qq.toString();
+            const isMentioned = rawMessage.includes(`[CQ:at,qq=${botQQ}]`) || rawMessage.includes(`[CQ:at,qq=${botQQ},`);
+            console.log(`[checkMention] bot_qq=${botQQ}, rawMessage="${rawMessage}", isMentioned=${isMentioned}`);
+            return isMentioned;
+        }
+
+        // 如果没有配置bot_qq，检查是否包含 "@肥牛" 或 "@ 肥牛"
+        const isMentioned = rawMessage.includes('@肥牛') || rawMessage.includes('@ 肥牛') || rawMessage.match(/@\s*肥牛/);
+        console.log(`[checkMention] bot_qq未配置, rawMessage="${rawMessage}", isMentioned=${!!isMentioned}`);
+        return isMentioned;
+    }
+
+    sendGroupMessage(groupId, content) {
+        if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+            console.error('WebSocket未连接，无法发送消息');
+            return false;
+        }
+
+        const payload = {
+            action: 'send_group_msg',
+            params: {
+                group_id: parseInt(groupId),
+                message: content
+            },
+            echo: Date.now().toString()
+        };
+
+        try {
+            const payloadStr = JSON.stringify(payload);
+            console.log('发送payload:', payloadStr);
+            this.ws.send(payloadStr);
+            console.log(`已发送消息到群${groupId}: ${content}`);
+            return true;
+        } catch (error) {
+            console.error('发送消息失败:', error);
+            return false;
+        }
+    }
+
+    getMessages(groupId = null, limit = 10) {
+        let messages = this.messageQueue;
+
+        if (groupId) {
+            messages = messages.filter(m => m.groupId === groupId);
+        }
+
+        return messages.slice(-limit);
+    }
+
+    getUnprocessedMessages(groupId = null) {
+        return this.getMessages(groupId, this.config.messageQueueMaxSize);
+    }
+
+    clearQueue() {
+        this.messageQueue = [];
+        console.log('QQ消息队列已清空');
+    }
+
+    stop() {
+        this.isEnabled = false;
+
+        if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = null;
+        }
+
+        if (this.ws) {
+            this.ws.close();
+            this.ws = null;
+        }
+
+        this.messageQueue = [];
+        console.log('QQ集成管理器已停止');
+    }
+
+    setEnabled(enabled) {
+        const wasEnabled = this.isEnabled;
+        this.isEnabled = enabled;
+        this.config.enabled = enabled;
+
+        if (enabled && !wasEnabled) {
+            console.log('启用QQ集成管理器');
+            this.connect();
+        } else if (!enabled && wasEnabled) {
+            console.log('禁用QQ集成管理器');
+            this.stop();
+        }
+    }
+}
+
+const qqManager = new QQIntegrationManager();
+
+function getToolDefinitions() {
+    return [
+        {
+            name: "read_qq_messages",
+            description: "读取QQ群聊消息。返回最近的群聊消息列表，可以指定群号和消息数量限制。",
+            parameters: {
+                type: "object",
+                properties: {
+                    group_id: {
+                        type: "string",
+                        description: "要读取的QQ群号，如果不指定则返回所有群的消息"
+                    },
+                    limit: {
+                        type: "number",
+                        description: "要返回的消息数量，默认10条，最多100条",
+                        default: 10
+                    }
+                }
+            }
+        }
+    ];
+}
+
+async function executeFunction(functionName, parameters) {
+    if (functionName === "read_qq_messages") {
+        if (!qqManager.isEnabled) {
+            return "QQ集成功能未启用。请在配置文件中启用qq_integration插件。";
+        }
+
+        const groupId = parameters.group_id || null;
+        const limit = Math.min(parameters.limit || 10, 100);
+
+        const messages = qqManager.getMessages(groupId, limit);
+
+        if (messages.length === 0) {
+            return groupId
+                ? `群 ${groupId} 暂无消息记录。`
+                : "暂无任何QQ群消息记录。";
+        }
+
+        const formattedMessages = messages.map(msg =>
+            `[${new Date(msg.timestamp * 1000).toLocaleTimeString()}] 群${msg.groupId} - ${msg.nickname}: ${msg.content}`
+        ).join('\n');
+
+        return `最近${messages.length}条QQ群消息:\n${formattedMessages}`;
+    }
+
+    throw new Error(`未知的工具: ${functionName}`);
+}
+
+module.exports = {
+    getToolDefinitions,
+    executeFunction,
+    qqManager
+};


### PR DESCRIPTION
**使用方法：**

1. 下载llonebot，链接：https://www.llonebot.com/guide/introduction

2. 系统配置：设置qq号

3. Bot配置：websocket：端口8001；反向WS url：ws://127.0.0.1:8001/onebot

4. 登录

5. 修改config.json当中162和169行的qq号码

6. 修改qq聊天人设：qq-auto-reply-manager.js第88行

7. 启动。

**新增功能：**
当且仅当在qq群当中被艾特的时候才会产生qq群聊内回复，同时会根据qq群聊的部分消息进行记忆（如果开启了RAG），然后分析qq群聊最近消息的聊天风格，作为动态提示词（动态提示词会在静态提示词，即qq-auto-reply-manager.js第88行，的前提下对聊天的风格进行适当的修改）。在用户端，肥牛会根据qq群聊的内容进行回复。

**注意事项：**
llonebot需要尽可能保持最新版。

新增的文件：

- AI.json

js\ai:

- qq-auto-reply-manager.js

- qq-commentary-manager.js

- qq-memory-manager.js

sever-tools:

- qq_integration.js

修改的文件及修改大致行数：
config.json 132-140;99-123
js\ai\local-tool-manager.js 34-56
js\app-initializer.js 237-326；434
package-lock.json 17;992-1027
package.json:16

如若还有不合适的地方，还请大佬批评指正。