### PR TITLE
 修复频繁拖动皮套导致的electron未响应问题

### DIFF
--- a/live-2d/main.js
+++ b/live-2d/main.js
@@ -175,7 +175,7 @@ ipcMain.handle('take-screenshot', async (event) => {
         await new Promise(resolve => setTimeout(resolve, 100));
 
         // 1. 获取系统识别到的所有物理显示器
-        //TODO 目前截图一次大约需要250ms，此处可以加一个系统显示器信息缓存，能够省下50ms截图时间开销
+        //TO DO 目前截图一次大约需要250ms，此处可以加一个系统显示器信息缓存，能够省下50ms截图时间开销
         const displays = await screenshot.listDisplays();
 
         // 2. 计算当前鼠标所在的逻辑屏幕索引


### PR DESCRIPTION
【问题描述】
群里有人反馈electron经常出现未响应问题，主要两种触发场景：
1、连续、快速用鼠标拖动皮套，大概5秒后，electron就会未响应
2、开启主动对话和视觉能力后，长时间对话后偶尔会出现electron未响应问题

【排查结果】
问题代码
`ipcMain.on('save-model-position', (event, position) => {
...
console.log('模型位置已保存到配置文件:', position);
...
}`  

electron是单线程应用，在连续五秒内未回应windows的健康检查请求，就会被windows识别为未响应。
问题代码在每次移动模型的时候都会打印日志，其使用的console.log();方法除了本地打印一份日志以外，还会发给启动器一份（IPC 通信），问题就出在这个发送过程是同步阻塞的，这就导致连续5秒刷屏打日志后就会被windows认定为未响应。
所以，只有在通过启动器管理electron进程的时候会出现该问题，而用npm start直接启动TTY终端窗口时，不会出现未响应问题。
<img width="618" height="656" alt="image" src="https://github.com/user-attachments/assets/63d6a36d-683e-4dc1-a115-1e630b9c20a4" />

【修改】
1、删除了console.log('模型位置已保存到配置文件:', position);
2、删除了截图方法中的日志打印（可能会被高频调用的方法尽量不要用console.log）

已自测通过， 修复频繁拖动皮套导致的electron未响应问题，可能修复了主动对话导致的未响应问题