### PR TITLE
修复bug

### DIFF
--- a/live-2d/js/ai/conversation/VoiceChatFacade.js
+++ b/live-2d/js/ai/conversation/VoiceChatFacade.js
@@ -87,8 +87,8 @@ class VoiceChatFacade {
             this.gameIntegration,
             this.memoryManager,
             this.contextCompressor,
-            this.config,
-            this.memosClient
+            this.memosClient,
+            this.config
         );
         this.inputRouter.setUICallbacks(this.showSubtitle, this.hideSubtitle);
         this.inputRouter.setVoiceChatFacade(this);


### PR DESCRIPTION
修复熬夜兔InputRouter调用this.memosClient和this.config顺序错误bug （修复前会导致即便config.json里面的bert记忆关闭了，依旧会记录生成核心记忆.txt文件）