### PR TITLE
fix: 修复聊天框为input时，会导致应用意外崩溃的bug

### DIFF
--- a/live-2d/css/styles.css
+++ b/live-2d/css/styles.css
@@ -78,12 +78,26 @@ body {
     flex: 1;
     outline: none;
     transition: all 0.3s ease;
+    background: #ffffff;
+    border: 1px solid #cccccc;
+    padding: 10px;
+    font-size: 14px;
+    color: #333333;
+    min-height: 20px;
+    overflow-y: auto;
+}
+
+#chat-input:empty:before {
+    content: attr(placeholder);
+    color: #999999;
+    pointer-events: none;
 }
 
 #chat-send-btn {
     border: none;
     cursor: pointer;
     transition: all 0.3s ease;
+    height: 20px;
 }
 
 /* ==================== 样式1: 现代毛玻璃风格 (默认) ==================== */

--- a/live-2d/index.html
+++ b/live-2d/index.html
@@ -24,8 +24,8 @@
     <div id="text-chat-container">
         <div id="chat-messages"></div>
         <div id="chat-input-container">
-            <input type="text" id="chat-input" placeholder="输入消息...">
-            <button id="chat-send-btn">发送</button>
+            <div id="chat-input" contenteditable="true" placeholder="输入消息..."></div>
+            <div id="chat-send-btn">发送</div>
         </div>
     </div>
 

--- a/live-2d/js/ui/ui-controller.js
+++ b/live-2d/js/ui/ui-controller.js
@@ -43,8 +43,9 @@ class UIController {
     setupChatBoxEvents() {
         const chatInput = document.getElementById('chat-input');
         const textChatContainer = document.getElementById('text-chat-container');
+        const submitBtn = document.getElementById('chat-send-btn');
 
-        if (!chatInput || !textChatContainer) return;
+        if (!chatInput || !textChatContainer || !submitBtn) return;
 
         textChatContainer.addEventListener('mouseenter', () => {
             ipcRenderer.send('set-ignore-mouse-events', {
@@ -73,6 +74,7 @@ class UIController {
                 options: { forward: true }
             });
         });
+        
     }
 
     // 显示字幕
@@ -424,27 +426,35 @@ class UIController {
     // 设置聊天框消息发送
     setupChatInput(voiceChat) {
         const chatInput = document.getElementById('chat-input');
-        if (!chatInput) return;
+        const chatSendBtn = document.getElementById('chat-send-btn');
 
-        chatInput.addEventListener('keypress', (e) => {
+        if (!chatInput || !chatSendBtn) return;
+
+        const handleSendMessage = () => {
+            const message = chatInput.textContent.trim();
+            if (!message) return;
+
+            const chatMessages = document.getElementById('chat-messages');
+            if (chatMessages) {
+                const messageElement = document.createElement('div');
+                messageElement.innerHTML = `<strong>你:</strong> ${message}`;
+                chatMessages.appendChild(messageElement);
+                chatMessages.scrollTop = chatMessages.scrollHeight;
+            }
+
+            voiceChat.sendToLLM(message);
+            chatInput.textContent = '';
+        };
+
+        //新的Enter事件注册，不调用preventDefault，会换行
+        chatInput.addEventListener('keydown', (e) => {
             if (e.key === 'Enter') {
-                const message = chatInput.value.trim();
-                if (message) {
-                    // 显示用户消息
-                    const chatMessages = document.getElementById('chat-messages');
-                    if (chatMessages) {
-                        const messageElement = document.createElement('div');
-                        messageElement.innerHTML = `<strong>你:</strong> ${message}`;
-                        chatMessages.appendChild(messageElement);
-                        chatMessages.scrollTop = chatMessages.scrollHeight;
-                    }
-
-                    // 发送给LLM处理
-                    voiceChat.sendToLLM(message);
-                    chatInput.value = '';
-                }
+                e.preventDefault();
+                handleSendMessage();
             }
         });
+
+        chatSendBtn.addEventListener('click', handleSendMessage);
     }
 
     // 显示歌词气泡


### PR DESCRIPTION
修复显示输入框时，应用各种意外崩溃的问题。
不知为何为聊天为input，切其中有内容时，点击任意地方会导致应用崩溃。
修复方案，放弃使用input作为聊天输入框。
Related to #130 