### PR TITLE
二次元图片功能优化

### DIFF
--- a/live-2d/mcp/mcp_config.json
+++ b/live-2d/mcp/mcp_config.json
@@ -6,7 +6,7 @@
     ]
   },
   "random-acg-pic": {
-    "command": "C:\\Users\\救赎\\Desktop\\肥牛牛新\\my-neuro\\live-2d\\node\\node.exe",
+    "command": "C:\\Users\\URL\\Desktop\\GithubRepository\\new-my-neuro\\live-2d\\node\\node.exe",
     "args": [
       "./mcp/tools/random-acg-pic.js"
     ]

--- a/live-2d/mcp/tools/random-acg-pic.js
+++ b/live-2d/mcp/tools/random-acg-pic.js
@@ -1,7 +1,7 @@
 import { FastMCP } from 'fastmcp';
 import { z } from 'zod';
 import axios from 'axios';
-
+import { exec } from 'child_process'; // 添加这个导入
 /**
  * 随机二次元图片工具 MCP 服务器
  * 提供获取随机二次元图片的功能
@@ -23,6 +23,76 @@ server.addTool({
       return response.data.data;
     } catch (error) {
       return `⚠️ 获取图片失败: ${error.message}`;
+    }
+  }
+});
+
+// 👇 添加新的一体化功能
+server.addTool({
+  name: "get_and_show_acg_pic",
+  description: "获取随机二次元图片并在浏览器中打开",
+  parameters: z.object({
+    type: z.enum(['pc', 'wap']).optional().default('pc').describe('图片类型: pc(电脑端) 或 wap(手机端)'),
+    browser: z.enum(['default', 'chrome', 'firefox', 'edge']).optional().default('default').describe('指定浏览器类型')
+  }),
+  execute: async ({ type = 'pc', browser = 'default' }) => {
+    try {
+      // 第一步：获取随机二次元图片
+      console.log('正在获取随机二次元图片...');
+      const imageResponse = await axios.get(`https://v2.xxapi.cn/api/randomAcgPic?type=${type}`);
+      const imageUrl = imageResponse.data.data;
+      if (!imageUrl || typeof imageUrl !== 'string') {
+          return '❌ 未能获取到有效的图片数据';
+      }
+      
+      console.log(`获取到图片URL: ${imageUrl}`);
+
+      // 第二步：在浏览器中打开图片
+      console.log('正在浏览器中打开图片...');
+      let command;
+      
+      // 根据操作系统和浏览器类型构建命令
+      if (process.platform === 'win32') {
+        switch (browser) {
+          case 'chrome':
+            command = `start chrome "${imageUrl}"`;
+            break;
+          case 'firefox':
+            command = `start firefox "${imageUrl}"`;
+            break;
+          case 'edge':
+            command = `start msedge "${imageUrl}"`;
+            break;
+          default:
+            command = `start "" "${imageUrl}"`;
+        }
+      } else if (process.platform === 'darwin') {
+        command = `open "${imageUrl}"`;
+      } else {
+        command = `xdg-open "${imageUrl}"`;
+      }
+
+      exec(command, (error, stdout, stderr) => {
+        if (error) {
+          console.error(`执行命令出错: ${error}`);
+          return `❌ 打开浏览器失败: ${error.message}`;
+        }
+        if (stderr) {
+          console.error(`stderr: ${stderr}`);
+        }
+      });
+
+      // 返回成功信息
+      return {
+        status: 'success',
+        message: `✅ 已在${browser === 'default' ? '默认浏览器' : browser}中打开二次元图片`,
+        imageUrl: imageUrl,
+        imageInfo: imageData
+      };
+
+    } catch (error) {
+      console.error('工具执行失败:', error);
+      return `⚠️ 操作失败: ${error.message}`;
     }
   }
 });


### PR DESCRIPTION
发现问题与想法：
二次元图片获取后只有链接，并不能直接看到图片。又不想保存到本地，所以在原mcp功能上加了一个自动在浏览器打开的功能

修改概述
本次PR主要实现了二次元图片更流畅的一体化图片浏览体验。

修改内容
 一体化图片获取与浏览工具
- 保留原有分步功能 (`get_random_acg_pic`)
- 新增一体化功能 (`get_and_show_acg_pic`)
- 打开的是系统默认浏览器（只测试过Google浏览器）

 实现效果
 获取二次元图片并自动打开浏览器搜索图片链接，并保持原有功能的兼容性。

