### PR TITLE
fix: 适配心流API SSE格式，修复流式输出下data后无空格导致的空响应

### DIFF
--- a/live-2d/js/ai/llm-client.js
+++ b/live-2d/js/ai/llm-client.js
@@ -357,11 +357,11 @@ class LLMClient {
 
                 for (const line of lines) {
                     const trimmed = line.trim();
-                    if (!trimmed || trimmed === 'data: [DONE]') continue;
+                    if (!trimmed || trimmed === 'data: [DONE]' || trimmed === 'data:[DONE]') continue;//添加心流API支持
 
-                    if (trimmed.startsWith('data: ')) {
+                    if (trimmed.startsWith('data:')) {
                         try {
-                            const jsonStr = trimmed.slice(6); // 移除 "data: " 前缀
+                            const jsonStr = trimmed.startsWith('data: ') ? trimmed.slice(6) : trimmed.slice(5); // 移除 "data: " 前缀，自适应有无空格
                             const chunk = JSON.parse(jsonStr);
 
                             // 提取内容


### PR DESCRIPTION
心流API的SSE输出格式为data:{...}（比OpenAI少一个空格），导致原代码startsWith('data: ')校验失败，所有响应行被跳过。添加了对该格式的支持，在llm-client.js的360-364行进行了修改。