### PR TITLE
fix: VoiceChatFacade 安全引入 memos-client，防止模块缺失时启动崩溃

### DIFF
--- a/live-2d/js/ai/conversation/VoiceChatFacade.js
+++ b/live-2d/js/ai/conversation/VoiceChatFacade.js
@@ -6,7 +6,12 @@ const { InputRouter } = require('./InputRouter.js');
 const { DiaryManager } = require('../DiaryManager.js');
 const { ScreenshotManager } = require('../ScreenshotManager.js');
 const { ContextManager } = require('../ContextManager.js');
-const { MemosClient } = require('../memos-client.js');
+let MemosClient;
+try {
+    ({ MemosClient } = require('../memos-client.js'));
+} catch (_) {
+    MemosClient = null;
+}
 
 /**
  * VoiceChatFacade - 统一对外接口
@@ -68,7 +73,7 @@ class VoiceChatFacade {
         this.diaryManager = new DiaryManager(this);
         this.screenshotManager = new ScreenshotManager(this);
         // 创建MemOS客户端
-        this.memosClient = new MemosClient(this.config);
+        this.memosClient = MemosClient ? new MemosClient(this.config) : null;
 
         // 创建输入路由
         this.inputRouter = new InputRouter(


### PR DESCRIPTION
## 问题

`VoiceChatFacade.js` 第 9 行对 `memos-client.js` 使用硬 `require`：

`js
const { MemosClient } = require('../memos-client.js');
`

当 `js/ai/memos-client.js` 因任何原因缺失时（例如插件化重构后文件迁移、更新脚本未完整同步等），Electron 渲染进程会直接崩溃，报错：

`
Uncaught Error: Cannot find module '../memos-client.js'
`

导致整个应用无法启动。

## 修改内容

仅修改 `live-2d/js/ai/conversation/VoiceChatFacade.js` 一个文件：

- 将硬 `require` 改为 `try-catch` 安全引入
- 当模块存在时，行为与之前完全一致
- 当模块不存在时，`MemosClient` 回退为 `null`，`memosClient` 实例也为 `null`
- 已有的 `if (!this.memosClient)` 检查逻辑确保不会产生任何运行时错误

`js
let MemosClient;
try {
    ({ MemosClient } = require('../memos-client.js'));
} catch (_) {
    MemosClient = null;
}
`

`js
this.memosClient = MemosClient ? new MemosClient(this.config) : null;
`

## 影响范围

- 零破坏性变更：`memos-client.js` 存在时行为不变
- 仅增加了一层防御性检查，提升启动鲁棒性