### PR TITLE
feat: 为 Live2D 模型添加可配置的聚焦跟踪强度

### DIFF
--- a/live-2d/js/model/model-setup.js
+++ b/live-2d/js/model/model-setup.js
@@ -22,6 +22,19 @@ class ModelSetup {
         const model = await PIXI.live2d.Live2DModel.from("2D/肥牛/feiniu.model3.json");
         app.stage.addChild(model);
 
+        // 视线跟踪幅度控制（config.json 中 ui.focus_factor）
+        // 必须拦截 focusController.focus() 而非 model.focus()，
+        // 因为 model.focus() 内部用 atan2+cos/sin 仅传递方向，缩放坐标无效
+        const focusFactor = config.ui?.focus_factor ?? 1;
+        if (focusFactor < 1) {
+            const fc = model.internalModel.focusController;
+            const originalFcFocus = fc.focus.bind(fc);
+            fc.focus = function(x, y, instant) {
+                originalFcFocus(x * focusFactor, y * focusFactor, instant);
+            };
+            console.log(`视线跟踪幅度: ${(focusFactor * 100).toFixed(0)}%`);
+        }
+
         // 根据配置控制模型显示/隐藏
         const showModel = config.ui?.show_model !== false; // 默认显示
         model.visible = showModel;


### PR DESCRIPTION
## 概述
为 Live2D 模型添加可配置的视线跟踪幅度控制，解决模型跟随鼠标时头部/眼球转动幅度过大的问题。
## 问题背景
pixi-live2d-display 库内置的鼠标跟踪功能默认使用 100% 幅度，导致模型头部转动最大 ±30°、身体转动 ±10°、眼球偏移 ±1.0，视觉上非常夸张。
### 正确方案
直接拦截 focusController.focus()，缩放其归一化方向值 [-1, 1]，等比例降低所有跟踪参数（头部/身体/眼球）。
## 改动内容
- live-2d/js/model/model-setup.js：模型加载后拦截 focusController.focus()，根据 config.json 中 ui.focus_factor 缩放跟踪幅度
- 默认值为 1（不改变原有行为），完全向后兼容
## 使用方式
在 config.json 的 ui 部分：
```json
\"focus_factor\": 0.3
 效果 0 | 完全不跟踪 |
0.1-0.3 | 轻微跟踪（推荐） 
0.5 | 中等幅度 |
 1 | 原始幅度（默认） |