### PR TITLE
fix: ASR关闭时文本输入绕过InputRouter导致记忆系统失效

### DIFF
--- a/live-2d/js/ai/conversation/InputRouter.js
+++ b/live-2d/js/ai/conversation/InputRouter.js
@@ -130,6 +130,9 @@ class InputRouter {
         // 发送到LLM
         await this.llmHandler(promptWithContext);
 
+        // 保存到记忆库
+        this.saveToMemoryLog();
+
         // 触发用户消息已接收事件（用于心情系统）
         eventBus.emit(Events.USER_MESSAGE_RECEIVED);
     }

--- a/live-2d/js/ui/ui-controller.js
+++ b/live-2d/js/ui/ui-controller.js
@@ -434,15 +434,7 @@ class UIController {
             const message = chatInput.textContent.trim();
             if (!message) return;
 
-            const chatMessages = document.getElementById('chat-messages');
-            if (chatMessages) {
-                const messageElement = document.createElement('div');
-                messageElement.innerHTML = `<strong>你:</strong> ${message}`;
-                chatMessages.appendChild(messageElement);
-                chatMessages.scrollTop = chatMessages.scrollHeight;
-            }
-
-            voiceChat.sendToLLM(message);
+            voiceChat.handleTextMessage(message);
             chatInput.textContent = '';
         };
 


### PR DESCRIPTION
## 问题描述

关闭 ASR（语音识别）后，使用聊天框进行纯文本对话时，记忆库为空白，MemOS 长期记忆注入不生效。

## 根因分析

聊天框的 setupChatInput 方法直接调用 voiceChat.sendToLLM(message)，完全绕过了 InputRouter，导致：

- 插件 onUserInput 钩子不触发（MemOS 记忆搜索/注入失效）
- 记忆库.txt 不写入（saveToMemoryLog 未调用）
- USER_MESSAGE_RECEIVED 事件不发出（心情系统等受影响）

## 修改内容

### 1. live-2d/js/ui/ui-controller.js

将聊天框发送从 voiceChat.sendToLLM(message) 改为 voiceChat.handleTextMessage(message)，使文本输入经过 InputRouter.handleTextInput()，触发完整的插件钩子链。

同时移除了重复的消息显示代码（InputRouter.handleTextInput 内部已通过 addChatMessage 处理）。

### 2. live-2d/js/ai/conversation/InputRouter.js

在 handleTextInput 方法末尾添加 this.saveToMemoryLog() 调用，使文本对话也能写入记忆库.txt（此前仅 handleVoiceInput 有此调用）。

## 测试方式

- [x] 关闭 ASR，通过聊天框发送文本消息
- [x] 确认记忆库.txt 正常写入对话记录
- [x] 确认 MemOS 长期记忆能正常搜索并注入到对话中
- [x] 确认消息不会重复显示在聊天界面