### PR TITLE
fix: filter model thinking/reasoning from TTS and subtitles

### DIFF
--- a/live-2d/js/ai/llm-client.js
+++ b/live-2d/js/ai/llm-client.js
@@ -97,9 +97,15 @@ class LLMClient {
             const message = responseData.choices[0].message;
 
             // 🔥 处理 Qwen3 等模型的 reasoning_content 字段
-            // 如果 content 为空但有 reasoning_content，则使用 reasoning_content
-            if ((!message.content || message.content.trim() === '') && message.reasoning_content) {
+            // 仅在没有 tool_calls 时才用 reasoning_content 替代空 content（Qwen3 推理模式）
+            // 有 tool_calls 时 reasoning_content 是思考过程，不应作为回复内容（Gemini 等）
+            if ((!message.content || message.content.trim() === '') && message.reasoning_content && !message.tool_calls) {
                 message.content = message.reasoning_content;
+            }
+
+            // 🔥 过滤思考内容（Gemini / DeepSeek 等模型可能在 content 中混入思考）
+            if (message.content) {
+                message.content = this._filterThinkingContent(message.content);
             }
 
             // 🔥 解析 Qwen 模型的文本格式工具调用（Hermes/XML style）
@@ -129,33 +135,8 @@ class LLMClient {
      * @returns {Array} 清理后的消息数组
      */
     _cleanMessagesForAPI(messages) {
-        // 🔥 第一步：移除孤立的 tool 消息（前面没有 tool_calls 的 assistant 消息）
-        const filtered = [];
-        for (let i = 0; i < messages.length; i++) {
-            if (messages[i].role === 'tool') {
-                // 向前查找最近的 assistant 消息，检查是否有 tool_calls
-                let hasToolCalls = false;
-                for (let j = filtered.length - 1; j >= 0; j--) {
-                    if (filtered[j].role === 'assistant' && filtered[j].tool_calls) {
-                        hasToolCalls = true;
-                        break;
-                    }
-                    // 如果遇到非 tool 且非 assistant 的消息，说明没有匹配的 tool_calls
-                    if (filtered[j].role !== 'tool') {
-                        break;
-                    }
-                }
-                if (!hasToolCalls) {
-                    logToTerminal('warn', `⚠️ 跳过孤立的 tool 消息 (tool_call_id: ${messages[i].tool_call_id})`);
-                    continue; // 跳过这条孤立的 tool 消息
-                }
-            }
-            filtered.push(messages[i]);
-        }
-
-        // 🔥 第二步：清理消息格式
-        return filtered.map(msg => {
-            // 处理 assistant 消息的 content 为 null 的情况
+        return messages.map(msg => {
+            // 🔥 处理 assistant 消息的 content 为 null 的情况
             if (msg.role === 'assistant') {
                 // 如果有 tool_calls 但 content 为 null,设为空字符串
                 if (msg.content === null && msg.tool_calls) {
@@ -166,7 +147,7 @@ class LLMClient {
                 }
             }
 
-            // 处理 tool 消息,确保格式正确
+            // 🔥 处理 tool 消息,确保格式正确
             if (msg.role === 'tool') {
                 let content = msg.content;
 
@@ -185,6 +166,7 @@ class LLMClient {
                 }
 
                 // 🔥 确保字符串不包含控制字符(可能导致JSON解析失败)
+                // 移除所有不可见的控制字符,但保留换行符(\n)和制表符(\t)
                 content = content.replace(/[\x00-\x08\x0B-\x0C\x0E-\x1F\x7F]/g, '');
 
                 // 🔥 确保字符串长度不超过限制(避免超大响应)
@@ -337,6 +319,37 @@ class LLMClient {
     }
 
     /**
+     * 过滤模型思考/推理内容，防止思考过程被TTS播放或显示为字幕
+     * 支持 Gemini、DeepSeek 等模型的多种思考格式
+     * @param {string} text - 原始文本
+     * @returns {string} 过滤后的文本
+     */
+    _filterThinkingContent(text) {
+        if (!text) return text;
+
+        let filtered = text;
+
+        // 过滤 <think>...</think> 块（DeepSeek、部分 Gemini 格式）
+        filtered = filtered.replace(/<think>[\s\S]*?<\/think>/gi, '');
+
+        // 过滤 <thinking>...</thinking> 块
+        filtered = filtered.replace(/<thinking>[\s\S]*?<\/thinking>/gi, '');
+
+        // 过滤 Gemini 中文思考格式：整段以"思考"开头（独占一行）的内容
+        // 仅在整段内容都是思考时才清除（避免误杀正常对话中的"思考"二字）
+        if (/^思考\s*\n/.test(filtered)) {
+            filtered = '';
+        }
+
+        // 过滤 Gemini 英文思考格式：整段以"Thinking"开头（独占一行）
+        if (/^Thinking\s*\n/i.test(filtered)) {
+            filtered = '';
+        }
+
+        return filtered.trim();
+    }
+
+    /**
      * 从内容中移除工具调用部分
      * @private
      * @param {string} content - 原始内容
@@ -425,6 +438,11 @@ class LLMClient {
             }
 
 //            logToTerminal('info', `✅ 流式响应接收完成`);
+
+            // 🔥 过滤思考内容（Gemini 等模型可能在流式 content 中混入思考过程）
+            if (fullContent) {
+                fullContent = this._filterThinkingContent(fullContent);
+            }
 
             // 构建完整的消息对象
             const message = {

--- a/live-2d/js/ai/llm-handler.js
+++ b/live-2d/js/ai/llm-handler.js
@@ -6,6 +6,20 @@ const { appState } = require('../core/app-state.js');
 const { LLMClient } = require('./llm-client.js');
 const { toolExecutor } = require('./tool-executor.js');
 
+/**
+ * 过滤模型思考内容，与 LLMClient._filterThinkingContent 保持一致
+ * 作为 TTS/字幕前的二次安全过滤
+ */
+function filterThinkingContent(text) {
+    if (!text) return text;
+    let filtered = text;
+    filtered = filtered.replace(/<think>[\s\S]*?<\/think>/gi, '');
+    filtered = filtered.replace(/<thinking>[\s\S]*?<\/thinking>/gi, '');
+    if (/^思考\s*\n/.test(filtered)) return '';
+    if (/^Thinking\s*\n/i.test(filtered)) return '';
+    return filtered.trim();
+}
+
 class LLMHandler {
     // 创建增强的sendToLLM方法
     static createEnhancedSendToLLM(voiceChat, ttsProcessor, asrEnabled, config) {
@@ -243,16 +257,18 @@ class LLMHandler {
                         logToolAction('info', formatToolCalls(result.tool_calls));
 
                         // 🎙️ 如果AI在调用工具前说了话,必须等播放完才继续
-                        if (result.content && result.content.trim()) {
-                            console.log(`💬 AI中间过程: ${result.content}`);
-                            logToTerminal('info', `💬 AI中间过程: ${result.content}`);
+                        // 🔥 二次安全过滤：跳过模型思考内容（Gemini 等模型可能在 content 中输出思考过程）
+                        const filteredIntermediateContent = filterThinkingContent(result.content);
+                        if (filteredIntermediateContent && filteredIntermediateContent.trim()) {
+                            console.log(`💬 AI中间过程: ${filteredIntermediateContent}`);
+                            logToTerminal('info', `💬 AI中间过程: ${filteredIntermediateContent}`);
 
                             // 🔥 中间过程播放TTS（工具调用的中间内容）
                             if (iteration === 0) {
                                 // 第一轮才reset
                                 ttsProcessor.reset();
                             }
-                            ttsProcessor.processTextToSpeech(result.content);
+                            ttsProcessor.processTextToSpeech(filteredIntermediateContent);
 
                             // 等待TTS_END或TTS_INTERRUPTED事件触发
                             await new Promise(resolve => {
@@ -406,13 +422,15 @@ class LLMHandler {
                                     console.log(`AI分析图片后想继续调用工具，进入第 ${iteration} 轮`);
 
                                     // 🎙️ 如果AI在调用工具前说了话,必须等播放完才继续
-                                    if (visionResult.content && visionResult.content.trim()) {
-                                        console.log(`💬 AI图片分析后的中间过程: ${visionResult.content}`);
-                                        logToTerminal('info', `💬 AI图片分析后的中间过程: ${visionResult.content}`);
+                                    // 🔥 过滤思考内容
+                                    const filteredVisionContent = filterThinkingContent(visionResult.content);
+                                    if (filteredVisionContent && filteredVisionContent.trim()) {
+                                        console.log(`💬 AI图片分析后的中间过程: ${filteredVisionContent}`);
+                                        logToTerminal('info', `💬 AI图片分析后的中间过程: ${filteredVisionContent}`);
 
                                         // 播放TTS并等待真正的播放完成(监听TTS_END事件)
                                         ttsProcessor.reset();
-                                        ttsProcessor.processTextToSpeech(visionResult.content);
+                                        ttsProcessor.processTextToSpeech(filteredVisionContent);
 
                                         // 等待TTS_END或TTS_INTERRUPTED事件触发
                                         await new Promise(resolve => {
@@ -652,8 +670,11 @@ class LLMHandler {
                     // 🎙️ 播放最终回复的TTS（统一在这里播放，参考旧版本的设计）
                     console.log('✅ 最终回复已处理完成，开始播放TTS');
 
+                    // 🔥 过滤最终回复中的思考内容
+                    const filteredFinalContent = filterThinkingContent(finalResponseContent);
+
                     // 触发插件 onLLMResponse 钩子（插件可修改 responseObj.text，影响 TTS 内容）
-                    const responseObj = { text: finalResponseContent };
+                    const responseObj = { text: filteredFinalContent || finalResponseContent };
                     if (global.pluginManager) {
                         await global.pluginManager.runLLMResponseHooks(responseObj).catch(() => {});
                     }


### PR DESCRIPTION
概述
为 Live2D 对话链路增加模型思考/推理内容的过滤，避免 Gemini 等模型在工具调用前输出的「思考过程」被 TTS 朗读或进入字幕/中间过程日志，提升观感与沉浸感。

问题背景
在使用 OpenAI 兼容接口（如 OpenRouter + google/gemini-*）时，常见现象包括：

在即将发起 tool_calls 的轮次里，content 可能整段为内部推理（例如以单独一行的「思考」开头，后跟长段说明）。
部分网关会在 reasoning_content 中返回推理片段；若在无 content 时误将其当作对用户回复，会同样进入 TTS。
部分实现还会用 </think>、<thinking>...</thinking> 等形式包裹推理文本。
上述内容若不做剥离，会出现：终端里出现「AI 中间过程」、TTS 念思考、字幕显示推理等问题。

解决思路
在 LLM 客户端层：对助手 content 做统一清洗（标签块、常见「思考」起首整段等）；并修正 reasoning_content 回填逻辑——仅当没有 tool_calls 时，才在 content 为空时用 reasoning_content 补全（兼顾 Qwen 等「纯推理字段」场景，又避免 Gemini 工具轮把推理当台词）。
在 LLM 处理层（TTS 前）：对工具轮中间播报与最终回复播报再做一次相同规则的二次过滤，防止网关字段差异导致漏网。
