### PR TITLE
feat(live-2d): 修复开启视觉/截图时，皮套闪烁的问题

### DIFF
--- a/live-2d/main.js
+++ b/live-2d/main.js
@@ -169,50 +169,36 @@ ipcMain.handle('get-config', async (event) => {
 });
 
 ipcMain.handle('take-screenshot', async (event) => {
-    const win = BrowserWindow.fromWebContents(event.sender);
     try {
-        // 截图前隐藏皮套窗口，截完再恢复，避免皮套出现在截图里
-        win.setOpacity(0);
         await new Promise(resolve => setTimeout(resolve, 100));
 
-        // 1. 获取系统识别到的所有物理显示器
-        //TO DO 目前截图一次大约需要250ms，此处可以加一个系统显示器信息缓存，能够省下50ms截图时间开销
         const displays = await screenshot.listDisplays();
 
-        // 2. 计算当前鼠标所在的逻辑屏幕索引
         const cursorPoint = screen.getCursorScreenPoint();
         const currentDisplay = screen.getDisplayNearestPoint(cursorPoint);
 
-        // 3. 对 Electron 识别的屏幕按 X 轴坐标排序 (bounds.x)
         const electronDisplays = screen.getAllDisplays().sort((a, b) => a.bounds.x - b.bounds.x);
         const targetIndex = electronDisplays.findIndex(d => d.id === currentDisplay.id);
 
-        // 对screenshot-desktop原生库识别的屏幕按 X 轴坐标排序 (left)，以确保索引一致
         const nativeDisplays = displays.sort((a, b) => (a.left || 0) - (b.left || 0));
 
-        // 越界防御检查
         if (targetIndex >= nativeDisplays.length) {
             throw new Error(`屏幕索引越界：鼠标在 Index ${targetIndex}，但原生只检测到 ${nativeDisplays.length} 个屏幕`);
         }
 
         const targetNativeDisplay = nativeDisplays[targetIndex];
 
-        // 4. 执行截图
         const imgBuffer = await screenshot({
             screen: targetNativeDisplay.id,
             format: 'jpg'
         });
 
-        // 5. 返回结果 (Base64)
         return imgBuffer.toString('base64');
-
     } catch (error) {
         console.error('截图错误:', error)
         throw error;
-    } finally {
-        win.setOpacity(1);
     }
-});
+})
 
 // 添加IPC处理器，允许从渲染进程手动更新模型
 ipcMain.handle('update-live2d-model', async (event) => {


### PR DESCRIPTION
## 概述

在 `live-2d/main.js` 中采用 `screenshot-desktop` 按**鼠标所在显示器**截图，并保存 `model_scale`；与上游「截图前隐藏皮套」不同，本 PR **不**使用 `setOpacity` 隐藏/恢复窗口，皮套可能出现在截图中（为有意识取舍）。`
## 改动说明

### 截图（`take-screenshot`）
- 使用 `screenshot-desktop` + 显示器与鼠标位置对齐逻辑，改善多屏场景。
- 截图前短暂延迟。
- **不**在截图前后调整窗口透明度。

