### PR TITLE
feat(live-2d): 插件系统热加载与启用列表自动同步

### DIFF
--- a/live-2d/js/app-initializer.js
+++ b/live-2d/js/app-initializer.js
@@ -334,6 +334,9 @@ class AppInitializer {
                     logToTerminal('error', `❌ 插件 startAll 失败: ${err.message}`);
                 });
 
+                // 启动热加载文件监听
+                this.pluginManager.startWatching();
+
                 // 监听 TTS_END 事件，触发插件 onTTSEnd 钩子
                 eventBus.on(Events.TTS_END, () => {
                     if (this.pluginManager) {

--- a/live-2d/js/core/plugin-manager.js
+++ b/live-2d/js/core/plugin-manager.js
@@ -1,4 +1,4 @@
-// plugin-manager.js - 插件管理器
+// plugin-manager.js - 插件管理器（支持热加载）
 const fs = require('fs');
 const path = require('path');
 const { PluginContext } = require('./plugin-context.js');
@@ -7,25 +7,33 @@ const { logToTerminal } = require('../api-utils.js');
 class PluginManager {
     constructor(config) {
         this._config = config;
-        /** @type {Map<string, {plugin: Plugin, metadata: object}>} */
+        /** @type {Map<string, {plugin: Plugin, metadata: object, pluginDir: string}>} */
         this._plugins = new Map();
         /** 动态注册的工具（由 context.registerTool 调用）*/
         this._dynamicTools = new Map(); // pluginName -> toolDef[]
 
-        // 插件根目录、内置插件目录和社区插件目录
         this._pluginsDir = path.join(__dirname, '..', '..', 'plugins');
         this._builtinDir = path.join(__dirname, '..', '..', 'plugins', 'built-in');
         this._communityDir = path.join(__dirname, '..', '..', 'plugins', 'community');
 
         /** 已启用的插件相对路径集合，null 表示尚未加载 */
         this._enabledPlugins = null;
+
+        /** 文件监听器引用 */
+        this._enabledListWatcher = null;
+        this._sourceWatchers = [];
+        this._syncDebounceTimer = null;
+        this._reloadDebounceTimers = new Map();
     }
 
+    // ===== enabled_plugins.json 读取 =====
+
     /**
-     * 加载 enabled_plugins.json，结果缓存到 this._enabledPlugins
+     * 从磁盘读取 enabled_plugins.json 并返回 Set
+     * @param {boolean} [forceReload=false] - 是否强制从磁盘重新读取
      */
-    _loadEnabledList() {
-        if (this._enabledPlugins !== null) return;
+    _loadEnabledList(forceReload = false) {
+        if (!forceReload && this._enabledPlugins !== null) return;
 
         const listPath = path.join(this._pluginsDir, 'enabled_plugins.json');
         if (!fs.existsSync(listPath)) {
@@ -35,7 +43,6 @@ class PluginManager {
         }
         try {
             const data = JSON.parse(fs.readFileSync(listPath, 'utf8'));
-            // 统一使用正斜杠，方便跨平台匹配
             this._enabledPlugins = new Set(
                 (data.plugins || []).map(p => p.replace(/\\/g, '/'))
             );
@@ -45,17 +52,33 @@ class PluginManager {
         }
     }
 
+    /**
+     * 扫描插件目录，返回 { relPath -> pluginDir } 映射
+     */
+    _scanAllPluginDirs() {
+        const result = new Map();
+        for (const baseDir of [this._builtinDir, this._communityDir]) {
+            if (!fs.existsSync(baseDir)) continue;
+            let entries;
+            try { entries = fs.readdirSync(baseDir, { withFileTypes: true }); } catch { continue; }
+            for (const entry of entries) {
+                if (!entry.isDirectory()) continue;
+                const pluginDir = path.join(baseDir, entry.name);
+                const metaPath = path.join(pluginDir, 'metadata.json');
+                if (!fs.existsSync(metaPath)) continue;
+                const relPath = path.relative(this._pluginsDir, pluginDir).replace(/\\/g, '/');
+                result.set(relPath, pluginDir);
+            }
+        }
+        return result;
+    }
+
     // ===== 加载 =====
 
-    /**
-     * 扫描并加载所有插件（内置 + 社区）
-     */
     async loadAll() {
         logToTerminal('info', '🔌 开始加载插件...');
-
         await this._loadFromDir(this._builtinDir, 'built-in');
         await this._loadFromDir(this._communityDir, 'community');
-
         logToTerminal('info', `🔌 插件加载完成，共 ${this._plugins.size} 个插件`);
     }
 
@@ -96,10 +119,8 @@ class PluginManager {
 
         const { name, main = 'index.js', lang } = metadata;
 
-        // config key 由 name 自动转换：连字符换下划线（auto-chat → auto_chat）
         const configKey = name.replace(/-/g, '_');
 
-        // 检查是否启用：从 enabled_plugins.json 白名单中查找
         this._loadEnabledList();
         const relPath = path.relative(this._pluginsDir, pluginDir).replace(/\\/g, '/');
         if (!this._enabledPlugins.has(relPath)) {
@@ -107,7 +128,11 @@ class PluginManager {
             return;
         }
 
-        // 根据 lang 决定入口文件
+        if (this._plugins.has(name)) {
+            logToTerminal('info', `⏭️ 插件已加载，跳过: ${name}`);
+            return;
+        }
+
         const isPython = lang === 'python';
         const resolvedMain = main !== 'index.js' ? main : (isPython ? 'index.py' : 'index.js');
         const mainPath = path.join(pluginDir, resolvedMain);
@@ -116,10 +141,8 @@ class PluginManager {
             throw new Error(`入口文件不存在: ${mainPath}`);
         }
 
-        // 创建插件上下文
         const context = new PluginContext(configKey, this._config, this, pluginDir);
 
-        // 加载插件
         let plugin;
         if (isPython) {
             const { PythonPluginBridge } = require('./python-plugin-bridge.js');
@@ -128,7 +151,6 @@ class PluginManager {
             let PluginClass;
             try {
                 const mod = require(mainPath);
-                // 支持 module.exports = class 或 module.exports = { default: class }
                 PluginClass = mod.default || mod[Object.keys(mod)[0]] || mod;
             } catch (e) {
                 throw new Error(`加载插件模块失败: ${e.message}`);
@@ -136,10 +158,9 @@ class PluginManager {
             plugin = new PluginClass(metadata, context);
         }
 
-        // onInit
         await plugin.onInit();
 
-        this._plugins.set(name, { plugin, metadata });
+        this._plugins.set(name, { plugin, metadata, pluginDir });
         logToTerminal('info', `✅ 插件已加载: ${name} v${metadata.version || '?'}${isPython ? ' [Python]' : ''}`);
     }
 
@@ -159,22 +180,21 @@ class PluginManager {
     }
 
     /**
-     * 热重载插件
+     * 热重载插件（兼容 JS 和 Python 插件）
      * @param {string} name
      */
     async reload(name) {
         const entry = this._plugins.get(name);
         if (!entry) throw new Error(`插件不存在: ${name}`);
 
-        // 找到插件目录
-        const pluginDir = this._findPluginDir(name);
-        if (!pluginDir) throw new Error(`找不到插件目录: ${name}`);
+        const { pluginDir, metadata } = entry;
 
         await this.unload(name);
 
-        // 清除 require 缓存
-        const mainPath = path.join(pluginDir, entry.metadata.main || 'index.js');
-        delete require.cache[require.resolve(mainPath)];
+        if (metadata.lang !== 'python') {
+            const mainPath = path.join(pluginDir, metadata.main || 'index.js');
+            try { delete require.cache[require.resolve(mainPath)]; } catch {}
+        }
 
         await this.load(pluginDir);
         const newEntry = this._plugins.get(name);
@@ -183,7 +203,175 @@ class PluginManager {
         logToTerminal('info', `🔄 插件已热重载: ${name}`);
     }
 
+    /**
+     * 重载所有已加载的插件
+     */
+    async reloadAll() {
+        const names = Array.from(this._plugins.keys());
+        for (const name of names) {
+            try {
+                await this.reload(name);
+            } catch (e) {
+                logToTerminal('error', `❌ 热重载失败 (${name}): ${e.message}`);
+            }
+        }
+    }
+
+    /**
+     * 同步 enabled_plugins.json 的变更：加载新启用的、卸载被禁用的
+     */
+    async syncEnabledPlugins() {
+        logToTerminal('info', '🔄 检测到插件启用列表变更，开始同步...');
+
+        this._loadEnabledList(true);
+
+        const allDirs = this._scanAllPluginDirs();
+        const enabledRelPaths = this._enabledPlugins;
+
+        const currentlyLoaded = new Map();
+        for (const [name, entry] of this._plugins) {
+            const relPath = path.relative(this._pluginsDir, entry.pluginDir).replace(/\\/g, '/');
+            currentlyLoaded.set(relPath, name);
+        }
+
+        // 卸载被禁用的插件
+        for (const [relPath, name] of currentlyLoaded) {
+            if (!enabledRelPaths.has(relPath)) {
+                try {
+                    await this.unload(name);
+                    logToTerminal('info', `🔌 插件已因禁用而卸载: ${name}`);
+                } catch (e) {
+                    logToTerminal('error', `❌ 卸载插件失败 (${name}): ${e.message}`);
+                }
+            }
+        }
+
+        // 加载新启用的插件
+        for (const relPath of enabledRelPaths) {
+            if (currentlyLoaded.has(relPath)) continue;
+            const pluginDir = allDirs.get(relPath);
+            if (!pluginDir) continue;
+            try {
+                await this.load(pluginDir);
+                const metaPath = path.join(pluginDir, 'metadata.json');
+                const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+                const newEntry = this._plugins.get(meta.name);
+                if (newEntry) await newEntry.plugin.onStart();
+                logToTerminal('info', `🔌 插件已因启用而加载: ${meta.name}`);
+            } catch (e) {
+                logToTerminal('error', `❌ 加载新启用插件失败 (${relPath}): ${e.message}`);
+            }
+        }
+
+        logToTerminal('info', `🔌 插件同步完成，当前共 ${this._plugins.size} 个插件`);
+    }
+
+    /**
+     * 获取所有插件信息列表（供 API 使用）
+     */
+    getPluginList() {
+        const list = [];
+        for (const [name, { metadata, pluginDir }] of this._plugins) {
+            list.push({
+                name,
+                displayName: metadata.displayName || name,
+                version: metadata.version || '?',
+                lang: metadata.lang || 'js',
+                dir: pluginDir,
+            });
+        }
+        return list;
+    }
+
+    // ===== 文件监听（热加载）=====
+
+    startWatching() {
+        this._watchEnabledList();
+        this._watchSourceFiles();
+        logToTerminal('info', '👁️ 插件热加载监听已启动');
+    }
+
+    stopWatching() {
+        if (this._enabledListWatcher) {
+            this._enabledListWatcher.close();
+            this._enabledListWatcher = null;
+        }
+        for (const w of this._sourceWatchers) {
+            w.close();
+        }
+        this._sourceWatchers = [];
+        clearTimeout(this._syncDebounceTimer);
+        for (const t of this._reloadDebounceTimers.values()) clearTimeout(t);
+        this._reloadDebounceTimers.clear();
+        logToTerminal('info', '👁️ 插件热加载监听已停止');
+    }
+
+    /**
+     * 监听 enabled_plugins.json，肥牛.exe 修改后自动同步
+     */
+    _watchEnabledList() {
+        const listPath = path.join(this._pluginsDir, 'enabled_plugins.json');
+        if (!fs.existsSync(listPath)) return;
+
+        try {
+            this._enabledListWatcher = fs.watch(listPath, () => {
+                clearTimeout(this._syncDebounceTimer);
+                this._syncDebounceTimer = setTimeout(() => {
+                    this.syncEnabledPlugins().catch(e => {
+                        logToTerminal('error', `❌ 同步插件启用列表失败: ${e.message}`);
+                    });
+                }, 500);
+            });
+        } catch (e) {
+            logToTerminal('warn', `⚠️ 无法监听 enabled_plugins.json: ${e.message}`);
+        }
+    }
+
+    /**
+     * 监听插件源码文件变更，自动重载对应插件
+     */
+    _watchSourceFiles() {
+        for (const baseDir of [this._builtinDir, this._communityDir]) {
+            if (!fs.existsSync(baseDir)) continue;
+            try {
+                const watcher = fs.watch(baseDir, { recursive: true }, (eventType, filename) => {
+                    if (!filename) return;
+                    const ext = path.extname(filename).toLowerCase();
+                    if (ext !== '.js' && ext !== '.py') return;
+
+                    const parts = filename.replace(/\\/g, '/').split('/');
+                    if (parts.length < 1) return;
+                    const pluginFolderName = parts[0];
+
+                    let targetName = null;
+                    for (const [name, entry] of this._plugins) {
+                        const dirBasename = path.basename(entry.pluginDir);
+                        if (dirBasename === pluginFolderName) {
+                            targetName = name;
+                            break;
+                        }
+                    }
+                    if (!targetName) return;
+
+                    clearTimeout(this._reloadDebounceTimers.get(targetName));
+                    this._reloadDebounceTimers.set(targetName, setTimeout(() => {
+                        this._reloadDebounceTimers.delete(targetName);
+                        logToTerminal('info', `👁️ 检测到源码变更: ${filename}，重载插件 ${targetName}`);
+                        this.reload(targetName).catch(e => {
+                            logToTerminal('error', `❌ 源码变更热重载失败 (${targetName}): ${e.message}`);
+                        });
+                    }, 500));
+                });
+                this._sourceWatchers.push(watcher);
+            } catch (e) {
+                logToTerminal('warn', `⚠️ 无法监听插件源码目录 (${baseDir}): ${e.message}`);
+            }
+        }
+    }
+
     _findPluginDir(name) {
+        const entry = this._plugins.get(name);
+        if (entry) return entry.pluginDir;
         for (const baseDir of [this._builtinDir, this._communityDir]) {
             const dir = path.join(baseDir, name);
             if (fs.existsSync(dir)) return dir;

--- a/live-2d/js/services/http-server.js
+++ b/live-2d/js/services/http-server.js
@@ -193,6 +193,40 @@ class HttpServer {
                 .catch(error => res.json({ success: false, message: error.toString() }));
         });
 
+        // ===== 插件管理接口 =====
+
+        this.emotionApp.get('/plugins', (req, res) => {
+            const pm = global.pluginManager;
+            if (!pm) return res.json({ success: false, message: '插件管理器未初始化' });
+            res.json({ success: true, plugins: pm.getPluginList() });
+        });
+
+        this.emotionApp.post('/plugins/reload', (req, res) => {
+            const pm = global.pluginManager;
+            if (!pm) return res.json({ success: false, message: '插件管理器未初始化' });
+            const { name } = req.body || {};
+            if (!name) return res.json({ success: false, message: '缺少 name 参数' });
+            pm.reload(name)
+                .then(() => res.json({ success: true, message: `插件 ${name} 已重载` }))
+                .catch(e => res.json({ success: false, message: e.message }));
+        });
+
+        this.emotionApp.post('/plugins/reload-all', (req, res) => {
+            const pm = global.pluginManager;
+            if (!pm) return res.json({ success: false, message: '插件管理器未初始化' });
+            pm.reloadAll()
+                .then(() => res.json({ success: true, message: '所有插件已重载' }))
+                .catch(e => res.json({ success: false, message: e.message }));
+        });
+
+        this.emotionApp.post('/plugins/sync', (req, res) => {
+            const pm = global.pluginManager;
+            if (!pm) return res.json({ success: false, message: '插件管理器未初始化' });
+            pm.syncEnabledPlugins()
+                .then(() => res.json({ success: true, message: '插件列表已同步' }))
+                .catch(e => res.json({ success: false, message: e.message }));
+        });
+
         this.emotionApp.listen(3002, () => {
             console.log('情绪控制服务启动在端口3002');
         });

--- a/live-2d/main.js
+++ b/live-2d/main.js
@@ -91,6 +91,9 @@ app.whenReady().then(() => {
 
 
 app.on('window-all-closed', () => {
+    if (global.pluginManager) {
+        global.pluginManager.stopWatching();
+    }
     if (process.platform !== 'darwin') {
         app.quit()
     }


### PR DESCRIPTION
## 概述

为 Live2D 桌宠的 **插件系统** 增加完整热加载能力（配置/能力可热更新、减少重启）。

用户通过 **肥牛 UI** 等工具修改 `plugins/enabled_plugins.json` 勾选/取消插件时，**运行中的桌宠会自动同步**：新勾选的插件会加载并执行 `onStart`，取消勾选的会走 `onStop`/`onDestroy` 卸载，**无需重启桌宠**。

同时支持开发时修改插件 `.js` / `.py` 源码后自动重载对应已加载插件。

## 改动内容

### PluginManager（`live-2d/js/core/plugin-manager.js`）

- 修复 `reload()`：记录 `pluginDir`；Python 插件不再对 `.py` 执行 `require.cache` 清理，避免抛错。
- 新增 `syncEnabledPlugins()`：对比磁盘上的 `enabled_plugins.json` 与当前已加载插件，增量 **加载 / 卸载**。
- 新增 `reloadAll()`、`getPluginList()`。
- `load()` 增加已加载去重，避免重复注册。
- **文件监听**（`startWatching` / `stopWatching`）：
  - 监听 `plugins/enabled_plugins.json`（防抖 500ms）→ 调用 `syncEnabledPlugins()`。
  - 递归监听 `built-in` / `community` 下 `.js`、`.py` 变更（防抖）→ 对已加载插件调用 `reload()`。

### HTTP API（`live-2d/js/services/http-server.js`，端口 3002）

- `GET /plugins`：当前已加载插件列表。
- `POST /plugins/reload`：body `{ "name": "插件名" }` 热重载指定插件。
- `POST /plugins/reload-all`：热重载全部已加载插件。
- `POST /plugins/sync`：手动触发与 `enabled_plugins.json` 同步。

### 生命周期集成

- `app-initializer.js`：在插件 `startAll()` 之后调用 `startWatching()`。
- `main.js`：窗口全部关闭时 `stopWatching()`，释放监听器。

## 使用说明

1. 保持桌宠运行，在肥牛或其它工具中修改插件启用列表并保存 `enabled_plugins.json`，约 0.5 秒内自动生效。
2. 开发插件时直接保存 `index.js` / `index.py` 等，已启用插件会自动重载。
3. 可选：对 `http://127.0.0.1:3002` 调用上述接口做手动同步或重载。
