### PR TITLE
Fix #215: [Bug] 6.3.2版本torch不兼容

### DIFF
--- a/live-2d/song-library/requirements_txt.txt
+++ b/live-2d/song-library/requirements_txt.txt
@@ -1,9 +1,9 @@
 numpy<2
-audio-separator==0.28.5
-torch==2.4.1+cu118
-torchvision==0.19.1+cu118
-torchaudio==2.4.1+cu118
-onnxruntime-gpu==1.16.3
+audio-separator>=0.29.0
+torch>=2.5.0
+torchvision>=0.20.0
+torchaudio>=2.5.0
+onnxruntime-gpu>=1.16.3
 librosa>=0.10
 pydub>=0.25
 requests>=2

--- a/live-2d/song-library/部署教程.txt
+++ b/live-2d/song-library/部署教程.txt
@@ -3,7 +3,7 @@
 pip install -r requirements.txt
 
 然后运行：
-pip install -r requirements.txt --index-url https://download.pytorch.org/whl/cu118
+pip install -r requirements.txt --index-url https://download.pytorch.org/whl/cu128
 
 最后启动：
 python test.py


### PR DESCRIPTION
Closes #215

Upgrades PyTorch and audio-separator dependencies in `live-2d/song-library/requirements_txt.txt` to resolve version conflicts with RTX 5060 memory system requirements.

## Changes

**`live-2d/song-library/requirements_txt.txt`**
- `audio-separator==0.28.5` → `audio-separator>=0.29.0` (unpins to allow versions that support torch>=2.5)
- `torch==2.4.1+cu118` → `torch>=2.5.0` (drops hard pin and CUDA 11.8 suffix)
- `torchvision==0.19.1+cu118` → `torchvision>=0.20.0`
- `torchaudio==2.4.1+cu118` → `torchaudio>=2.5.0`
- `onnxruntime-gpu==1.16.3` → `onnxruntime-gpu>=1.16.3`

**`live-2d/song-library/部署教程.txt`**
- PyTorch install index URL updated from `cu118` to `cu128` to match the new minimum torch version and support modern NVIDIA hardware.

## Motivation

`audio-separator==0.28.5` enforces `torch<2.5,>=2.3`, which conflicts with the RTX 5060's memory system requirement for torch>=2.5. Pinning to `torch==2.4.1+cu118` made it impossible to run the song library on that hardware. Upgrading to `audio-separator>=0.29.0` (which removes the `torch<2.5` upper bound) and raising the torch floor to `>=2.5.0` resolves the conflict. The CUDA wheel index is updated to `cu128` accordingly, as CUDA 11.8 wheels are not published for torch 2.5+.

## Testing

- Install dependencies on a machine with an RTX 5060 using the updated `cu128` index URL and confirm `torch>=2.5.0` resolves without conflict.
- Run `python test.py` to verify the song library starts and audio separation executes successfully with the upgraded packages.
- Confirm `numpy<2` constraint is still satisfied by the resolved environment (audio-separator 0.29+ retains that requirement).

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*