### PR TITLE
feat: multi-screen support and stability improvements

### DIFF
--- a/live-2d/config.json
+++ b/live-2d/config.json
@@ -47,8 +47,8 @@
     "api_key": "",
     "volcengine_tts": {
       "enabled": false,
-      "appid": "9753924061",
-      "access_token": "yEN5RNemTswZHcmb91asiEdSv4Biw0XS",
+      "appid": "",
+      "access_token": "",
       "voice_type": "saturn_zh_female_tiaopigongzhu_tob"
     },
     "aliyun_tts": {
@@ -72,8 +72,8 @@
     "baidu_asr": {
       "enabled": false,
       "url": "ws://vop.baidu.com/realtime_asr",
-      "appid": 121933442,
-      "appkey": "WZt66qwOHojtVm4MSLPFzQ7F",
+      "appid": "",
+      "appkey": "",
       "dev_pid": 15372
     }
   },
@@ -99,6 +99,11 @@
       "x": 1.1431250000000002,
       "y": 0.59,
       "remember_position": true
+    },
+    "screen_extend": {
+      "extend": false,
+      "left": false,
+      "right": true
     }
   },
   "context": {

--- a/live-2d/css/styles.css
+++ b/live-2d/css/styles.css
@@ -13,6 +13,9 @@ body {
     left: 0;
     width: 100%;
     height: 100%;
+    image-rendering: auto; 
+    image-rendering: crisp-edges;
+    image-rendering: pixelated;
 }
 
 #subtitle-container {
@@ -49,14 +52,21 @@ body {
 }
 
 #text-chat-container {
-    position: fixed;
-    bottom: 20px;
-    right: 20px;
-    width: 350px;
-    max-height: 400px;
-    z-index: 1000;
+    position: fixed !important;
+    bottom: 50px !important;
+    right: 390px !important;
+    left: auto !important;
+    width: 350px !important;
+    max-height: 400px !important;
+    z-index: 10000 !important;
     display: none;
-    pointer-events: auto;
+    pointer-events: auto !important;
+}
+
+/* 当副屏在主屏左侧时，对话框显示在左下角 */
+body.screen-left #text-chat-container {
+    right: auto !important;
+    left: 20px !important;
 }
 
 /* VRM模型控制面板（展开式） */

--- a/live-2d/js/model/model-interaction.js
+++ b/live-2d/js/model/model-interaction.js
@@ -35,6 +35,64 @@ class ModelInteractionController {
         this.interactionY = this.model.y + (this.model.height - this.interactionHeight) / 2;
     }
 
+    getVisibleBounds() {
+        const actualWidth = window.actualWindowWidth || window.innerWidth;
+        const actualHeight = window.actualWindowHeight || window.innerHeight;
+        const scaleFactor = window.canvasScaleFactor || 2;
+
+        if (!this.model) {
+            return {
+                minX: 0,
+                maxX: actualWidth * scaleFactor,
+                minY: 0,
+                maxY: actualHeight * scaleFactor
+            };
+        }
+
+        return {
+            minX: -this.model.width * 0.2,
+            maxX: Math.max(-this.model.width * 0.2, actualWidth * scaleFactor - this.model.width * 0.35),
+            minY: -this.model.height * 0.05,
+            maxY: Math.max(-this.model.height * 0.05, actualHeight * scaleFactor - this.model.height * 0.2)
+        };
+    }
+
+    clampPosition(x, y) {
+        const bounds = this.getVisibleBounds();
+        return {
+            x: Math.min(bounds.maxX, Math.max(bounds.minX, x)),
+            y: Math.min(bounds.maxY, Math.max(bounds.minY, y))
+        };
+    }
+
+    getDefaultVisiblePosition() {
+        const actualWidth = window.actualWindowWidth || window.innerWidth;
+        const actualHeight = window.actualWindowHeight || window.innerHeight;
+        const scaleFactor = window.canvasScaleFactor || 2;
+
+        if (!this.model) {
+            return {
+                x: actualWidth * 0.6 * scaleFactor,
+                y: actualHeight * 0.25 * scaleFactor
+            };
+        }
+
+        const preferredX = actualWidth * scaleFactor - this.model.width * 0.7;
+        const preferredY = actualHeight * scaleFactor - this.model.height * 0.92;
+        return this.clampPosition(preferredX, preferredY);
+    }
+
+    resetToDefaultPosition() {
+        if (!this.model) return false;
+
+        const defaultPosition = this.getDefaultVisiblePosition();
+        this.model.x = defaultPosition.x;
+        this.model.y = defaultPosition.y;
+        this.updateInteractionArea();
+        this.saveModelPosition();
+        return true;
+    }
+
     // 设置交互性
     setupInteractivity() {
         if (!this.model) return;
@@ -72,7 +130,6 @@ class ModelInteractionController {
             const chatTopInPixi = (chatRect.top - canvasRect.top) * (pixiView.height / canvasRect.height);
             const chatBottomInPixi = (chatRect.bottom - canvasRect.top) * (pixiView.height / canvasRect.height);
 
-            // const chatRect = chatContainer.getBoundingClientRect();
             const isOverChat = (
                 point.x >= chatLeftInPixi &&
                 point.x <= chatRightInPixi &&
@@ -102,8 +159,16 @@ class ModelInteractionController {
         // 鼠标移动事件
         this.model.on('mousemove', (e) => {
             if (this.isDragging) {
-                const newX = e.data.global.x - this.dragOffset.x;
-                const newY = e.data.global.y - this.dragOffset.y;
+                let newX = e.data.global.x - this.dragOffset.x;
+                let newY = e.data.global.y - this.dragOffset.y;
+
+                if (this.config && this.config.ui && this.config.ui.screen_extend) {
+                    const extend = this.config.ui.screen_extend;
+                    if (extend.extend && extend.left) {
+                        if (newX < 0) newX = 0;
+                    }
+                }
+
                 this.model.position.set(newX, newY);
                 this.updateInteractionArea();
             }
@@ -148,13 +213,11 @@ class ModelInteractionController {
             if (this.isDraggingChat) {
                 chatContainer.style.left = `${e.clientX - this.chatDragOffset.x}px`;
                 chatContainer.style.top = `${e.clientY - this.chatDragOffset.y}px`;
-                // 注意: 拖动聊天框时不需要修改模型位置
             }
         });
 
         // 鼠标释放时停止拖动
         document.addEventListener('mouseup', () => {
-            // this.isDraggingChat = false;
             if (this.isDraggingChat) {
                 this.isDraggingChat = false;
                 setTimeout(() => {
@@ -167,25 +230,6 @@ class ModelInteractionController {
                 }, 100);
             }
         });
-
-
-// 拖动结束时，再次检查穿透状态
-// window.addEventListener('mouseup', () => {
-//     if (this.isDraggingChat) {
-//         this.isDraggingChat = false;
-//         this.updateMouseIgnore(); // 确保拖动结束后状态正确
-//     }
-// });
-
-// 鼠标离开事件
-// document.addEventListener('mouseout', () => {
-//     if (!this.isDraggingChat) {
-//         ipcRenderer.send('set-ignore-mouse-events', {
-//             ignore: true,
-//             options: { forward: true }
-//         });
-//     }
-// });
 
         // 鼠标悬停事件
         this.model.on('mouseover', () => {
@@ -245,9 +289,11 @@ class ModelInteractionController {
         // 窗口大小改变事件
         window.addEventListener('resize', () => {
             if (this.app && this.app.renderer) {
-                this.app.renderer.resize(window.innerWidth * 2, window.innerHeight * 2);
-                this.app.stage.position.set(window.innerWidth / 2, window.innerHeight / 2);
-                this.app.stage.pivot.set(window.innerWidth / 2, window.innerHeight / 2);
+                const actualWidth = window.actualWindowWidth || window.innerWidth;
+                const actualHeight = window.actualWindowHeight || window.innerHeight;
+                const scaleFactor = window.canvasScaleFactor || 2;
+                this.app.renderer.resize(actualWidth * scaleFactor, actualHeight * scaleFactor);
+                //多屏幕坐标系统，不设置pivot/position,舞台从0,0开始
                 this.updateInteractionArea();
             }
         });
@@ -273,7 +319,6 @@ class ModelInteractionController {
             v = Math.max(0, Math.min(v, 3.0));
             const coreModel = this.model.internalModel.coreModel;
 
-            // 同时尝试所有可能的组合，不要return，让所有的都执行
             try {
                 coreModel.setParameterValueById('PARAM_MOUTH_OPEN_Y', v);
             } catch (e) {}
@@ -299,27 +344,41 @@ class ModelInteractionController {
     setupInitialModelProperties(scaleMultiplier = 2.3) {
         if (!this.model || !this.app) return;
 
-        // const scaleX = (window.innerWidth * scaleMultiplier) / this.model.width;
-        // const scaleY = (window.innerHeight * scaleMultiplier) / this.model.height;
+        const actualWidth = window.actualWindowWidth || window.innerWidth;
+        const actualHeight = window.actualWindowHeight || window.innerHeight;
+        const scaleFactor = window.canvasScaleFactor || 2;
+
         this.model.scale.set(scaleMultiplier);
 
         // 检查是否有保存的位置
         if (this.config && this.config.ui && this.config.ui.model_position && this.config.ui.model_position.remember_position) {
             const savedPos = this.config.ui.model_position;
-            if (savedPos.x !== null && savedPos.y !== null) {
-                // 使用保存的位置（相对比例转换为绝对坐标）
-                this.model.x = savedPos.x * window.innerWidth;
-                this.model.y = savedPos.y * window.innerHeight;
-                console.log('加载保存的模型位置:', { x: this.model.x, y: this.model.y });
+            // 允许负值和大于1的值以支持多屏幕，合理范围：x：-0.5~2.5，y：-0.5~2.0
+            const isValidPosition = savedPos.x !== null && savedPos.y !== null &&
+                                savedPos.x >= -0.5 && savedPos.x <= 2.5 &&
+                                savedPos.y >= -0.5 && savedPos.y <= 2.0;
+            if (isValidPosition) {
+                this.model.x = savedPos.x * actualWidth * scaleFactor;
+                this.model.y = savedPos.y * actualHeight * scaleFactor;
+                console.log('加载保存的位置:', { 
+                    relativePos: savedPos,
+                    canvasX: this.model.x,
+                    canvasY: this.model.y,
+                    scaleFactor
+                });
             } else {
-                // 使用默认位置
-                this.model.y = window.innerHeight * 0.8;
-                this.model.x = window.innerWidth * 1.35;
+                console.warn('保存的位置无效，使用默认位置', savedPos);
+                const defaultPosition = this.getDefaultVisiblePosition();
+                this.model.x = defaultPosition.x;
+                this.model.y = defaultPosition.y;
+                this.config.ui.model_position.x = 0.5;
+                this.config.ui.model_position.y = 0.5;
+                this.saveModelPosition();
             }
         } else {
-            // 使用默认位置
-            this.model.y = window.innerHeight * 0.8;
-            this.model.x = window.innerWidth * 1.35;
+            const defaultPosition = this.getDefaultVisiblePosition();
+            this.model.x = defaultPosition.x;
+            this.model.y = defaultPosition.y;
         }
 
         this.updateInteractionArea();
@@ -329,27 +388,36 @@ class ModelInteractionController {
     saveModelPosition() {
         if (!this.model || !this.config) return;
 
-        // 检查是否启用位置记忆
         if (!this.config.ui || !this.config.ui.model_position || !this.config.ui.model_position.remember_position) {
             return;
         }
 
-        // 计算相对位置（0-1之间的比例）
-        const relativeX = this.model.x / window.innerWidth;
-        const relativeY = this.model.y / window.innerHeight;
+        const actualWidth = window.actualWindowWidth || window.innerWidth;
+        const actualHeight = window.actualWindowHeight || window.innerHeight;
+        const scaleFactor = window.canvasScaleFactor || 2;
 
-        // 更新配置对象
+        // 将canvas坐标转换为相对于窗口的坐标，再计算相对位置
+        const windowX = this.model.x / scaleFactor;
+        const windowY = this.model.y / scaleFactor;
+
+        const relativeX = windowX / actualWidth;
+        const relativeY = windowY / actualHeight;
+
         this.config.ui.model_position.x = relativeX;
         this.config.ui.model_position.y = relativeY;
 
-        // 发送IPC消息保存位置
         ipcRenderer.send('save-model-position', {
             x: relativeX,
             y: relativeY,
-            scale:this.model.scale.x
+            scale: this.model.scale.x
         });
 
-        console.log('保存模型位置:', { x: relativeX, y: relativeY });
+        console.log('保存模型位置:', { 
+            canvasPos: { x: this.model.x, y: this.model.y },
+            windowPos: { x: windowX, y: windowY },
+            relativePos: { x: relativeX, y: relativeY },
+            scaleFactor
+        });
     }
 }
 

--- a/live-2d/js/model/model-setup.js
+++ b/live-2d/js/model/model-setup.js
@@ -6,20 +6,55 @@ const { MusicPlayer } = require('../services/music-player.js');
 class ModelSetup {
     // 初始化PIXI应用和Live2D模型
     static async initialize(modelController, config, ttsEnabled, asrEnabled, ttsProcessor, voiceChat) {
-        // 创建PIXI应用
+        const { ipcRenderer } = require('electron');
+        
+        // 获取所有显示器信息
+        const displays = await ipcRenderer.invoke('get-all-displays');
+        const windowBounds = await ipcRenderer.invoke('get-window-bounds');
+        
+        console.log(`=== PIXI 渲染器初始化 ===`);
+        console.log(`检测到 ${displays.length} 个显示器`);
+        displays.forEach((display, index) => {
+            console.log(`显示器 ${index}: ${display.bounds.width}x${display.bounds.height} at (${display.bounds.x}, ${display.bounds.y})`);
+        });
+        console.log(`窗口尺寸: ${windowBounds.width}x${windowBounds.height}`);
+        console.log(`window.innerWidth/Height: ${window.innerWidth}x${window.innerHeight}`);
+        
+        // 使用窗口的实际尺寸
+        const actualWidth = windowBounds.width;
+        const actualHeight = windowBounds.height;
+        
+        // 创建PIXI应用 - 使用窗口实际尺寸的2倍以支持高分辨率
         const app = new PIXI.Application({
             view: document.getElementById("canvas"),
             autoStart: true,
             transparent: true,
-            width: window.innerWidth * 2,
-            height: window.innerHeight * 2
+            width: actualWidth * 2,
+            height: actualHeight * 2
         });
 
-        app.stage.position.set(window.innerWidth / 2, window.innerHeight / 2);
-        app.stage.pivot.set(window.innerWidth / 2, window.innerHeight / 2);
+        // 设置Canvas的CSS尺寸以正确显示
+        app.view.style.width = `${actualWidth}px`;
+        app.view.style.height = `${actualHeight}px`;
+
+        // 多屏幕坐标系统：舞台从左上角开始，不使用pivot和position偏移
+        // 模型坐标需要乘以2来匹配Canvas的2倍分辨率
+        
+        // 保存实际尺寸和缩放因子到全局
+        window.actualWindowWidth = actualWidth;
+        window.actualWindowHeight = actualHeight;
+        window.canvasScaleFactor = 2; // Canvas相对于窗口的缩放因子
+        
+        console.log(`Canvas内部尺寸: ${app.view.width}x${app.view.height}`);
+        console.log(`Canvas CSS尺寸: ${app.view.style.width} x ${app.view.style.height}`);
+        console.log(`窗口尺寸: ${actualWidth}x${actualHeight}`);
+        console.log(`缩放因子: ${window.canvasScaleFactor}`);
+        console.log(`坐标系统: Canvas坐标 = 窗口坐标 × 2`);
+        console.log(`=========================`);
 
         // 加载Live2D模型
-        const model = await PIXI.live2d.Live2DModel.from("2D/肥牛/feiniu.model3.json");
+        const model = await PIXI.live2d.Live2DModel.from("2D/肥牛/",
+        );
         app.stage.addChild(model);
 
         // 根据配置控制模型显示/隐藏
@@ -30,6 +65,16 @@ class ModelSetup {
         // 初始化模型交互控制器
         modelController.init(model, app, config);
         modelController.setupInitialModelProperties(config.ui.model_scale || 2.3);
+
+        // 调试输出：检查模型位置和尺寸
+        console.log(`=== 模型调试信息 ===`);
+        console.log(`模型位置: (${model.x}, ${model.y})`);
+        console.log(`模型尺寸: ${model.width}x${model.height}`);
+        console.log(`模型缩放: ${model.scale.x}`);
+        console.log(`模型可见: ${model.visible}`);
+        console.log(`Canvas尺寸: ${app.view.width}x${app.view.height}`);
+        console.log(`窗口尺寸: ${actualWidth}x${actualHeight}`);
+        console.log(`==================`);
 
         // 创建情绪动作映射器
         const emotionMapper = new EmotionMotionMapper(model);

--- a/live-2d/js/model/model-setup.js
+++ b/live-2d/js/model/model-setup.js
@@ -53,8 +53,7 @@ class ModelSetup {
         console.log(`=========================`);
 
         // 加载Live2D模型
-        const model = await PIXI.live2d.Live2DModel.from("2D/肥牛/",
-        );
+        const model = await PIXI.live2d.Live2DModel.from("2D/肥牛/feiniu.model3.json");
         app.stage.addChild(model);
 
         // 根据配置控制模型显示/隐藏

--- a/live-2d/js/ui/ui-controller.js
+++ b/live-2d/js/ui/ui-controller.js
@@ -24,8 +24,25 @@ class UIController {
 
     // 设置鼠标穿透
     setupMouseIgnore() {
-        const updateMouseIgnore = () => {
+        // 肥牛棋盘等浮层在屏中，指针不在 Live2D 模型上；若不排除则每次 mousemove 都会把窗口设回穿透，导致盘面无法点击
+        const pointerOverFeiniuBoardPanel = (clientX, clientY) => {
+            const panel = document.querySelector('#feiniu-board-game-root .feiniu-panel');
+            if (!panel || !panel.isConnected) return false;
+            const r = panel.getBoundingClientRect();
+            if (r.width <= 0 || r.height <= 0) return false;
+            return clientX >= r.left && clientX <= r.right && clientY >= r.top && clientY <= r.bottom;
+        };
+
+        const updateMouseIgnore = (e) => {
             if (!global.currentModel) return;
+
+            if (e && pointerOverFeiniuBoardPanel(e.clientX, e.clientY)) {
+                ipcRenderer.send('set-ignore-mouse-events', {
+                    ignore: false,
+                    options: { forward: false }
+                });
+                return;
+            }
 
             const shouldIgnore = !global.currentModel.containsPoint(
                 global.pixiApp.renderer.plugins.interaction.mouse.global
@@ -46,6 +63,9 @@ class UIController {
         const submitBtn = document.getElementById('chat-send-btn');
 
         if (!chatInput || !textChatContainer || !submitBtn) return;
+
+        // 跨屏定位（异步，不阻塞渲染线程）
+        this._setupCrossScreenPositioning(textChatContainer);
 
         textChatContainer.addEventListener('mouseenter', () => {
             ipcRenderer.send('set-ignore-mouse-events', {
@@ -75,6 +95,59 @@ class UIController {
             });
         });
         
+    }
+
+    async _setupCrossScreenPositioning(textChatContainer) {
+        try {
+            const screenExtend = this.config.ui?.screen_extend || { extend: false, left: false, right: true };
+
+            textChatContainer.style.setProperty('position', 'fixed', 'important');
+            textChatContainer.style.setProperty('z-index', '10000', 'important');
+            textChatContainer.style.setProperty('width', '350px', 'important');
+            textChatContainer.style.setProperty('height', 'auto', 'important');
+            textChatContainer.style.setProperty('pointer-events', 'auto', 'important');
+
+            const screenInfo = await ipcRenderer.invoke('get-screen-info');
+            if (screenInfo) {
+                const { primaryDisplay, windowBounds } = screenInfo;
+                
+                const winX = windowBounds ? windowBounds.x : 0;
+                const winY = windowBounds ? windowBounds.y : 0;
+                const winH = windowBounds ? windowBounds.height : window.innerHeight;
+                
+                const primaryLeftOffset = primaryDisplay.bounds.x - winX;
+                const primaryTopOffset = primaryDisplay.bounds.y - winY;
+                const primaryBottomOffset = winH - (primaryTopOffset + primaryDisplay.bounds.height);
+
+                const rightPos = primaryLeftOffset + primaryDisplay.bounds.width - 350 - 20;
+                
+                textChatContainer.style.setProperty('left', rightPos + 'px', 'important');
+                textChatContainer.style.setProperty('right', 'auto', 'important');
+                textChatContainer.style.setProperty('bottom', (primaryBottomOffset + 50) + 'px', 'important');
+
+                const subtitleContainer = document.getElementById('subtitle-container');
+                if (subtitleContainer) {
+                    subtitleContainer.style.setProperty('position', 'fixed', 'important');
+                    subtitleContainer.style.setProperty('bottom', (primaryBottomOffset + 20) + 'px', 'important');
+                    const subtitleLeft = primaryLeftOffset + (primaryDisplay.bounds.width / 2);
+                    subtitleContainer.style.setProperty('left', subtitleLeft + 'px', 'important');
+                    subtitleContainer.style.setProperty('transform', 'translateX(-50%)', 'important');
+                }
+
+                console.log('跨屏定位调试:', {
+                    winX, winY, winH,
+                    primaryX: primaryDisplay.bounds.x,
+                    primaryY: primaryDisplay.bounds.y,
+                    primaryW: primaryDisplay.bounds.width,
+                    primaryH: primaryDisplay.bounds.height,
+                    primaryLeftOffset,
+                    primaryBottomOffset,
+                    rightPos
+                });
+            }
+        } catch (e) {
+            console.error('跨屏定位失败:', e);
+        }
     }
 
     // 显示字幕
@@ -195,11 +268,11 @@ class UIController {
                 toolBubblesContainer.style.top = `${this.toolBubblesCurrentY}px`;
             }
 
-            // 更新歌词气泡位置 (身体左侧或上方)
+            // 更新歌词气泡位置 (支持插件配置覆盖)
             const lyricsBubbleContainer = document.getElementById('lyrics-bubble-container');
             if (this.lyricsBubbleVisible && lyricsBubbleContainer) {
-                const lyricsOffsetX = -20;  // 再向右移 (原-150)
-                const lyricsOffsetY = -20;  // 再向下移 (原-100)
+                const lyricsOffsetX = (typeof global._lyricsBubbleOffsetX === 'number') ? global._lyricsBubbleOffsetX : -20;
+                const lyricsOffsetY = (typeof global._lyricsBubbleOffsetY === 'number') ? global._lyricsBubbleOffsetY : -20;
                 const lyricsTargetX = screenX + lyricsOffsetX;
                 const lyricsTargetY = screenY + lyricsOffsetY;
 
@@ -377,10 +450,18 @@ class UIController {
 
         textChatContainer.style.display = shouldShowChatBox ? 'block' : 'none';
 
-        // 如果启用了text_only_mode或者TTS/ASR任一被禁用，自动显示聊天框
         if ((this.config.ui && this.config.ui.text_only_mode) || !ttsEnabled || !asrEnabled) {
             textChatContainer.style.display = 'block';
             console.log('检测到纯文本模式或TTS/ASR禁用，自动显示聊天框');
+        }
+
+        // 显示时确保跨屏定位样式正确
+        if (textChatContainer.style.display !== 'none') {
+            textChatContainer.style.setProperty('visibility', 'visible', 'important');
+            textChatContainer.style.setProperty('opacity', '1', 'important');
+            textChatContainer.style.setProperty('z-index', '10000', 'important');
+            textChatContainer.style.setProperty('pointer-events', 'auto', 'important');
+            this._setupCrossScreenPositioning(textChatContainer);
         }
 
         // 从localStorage加载保存的样式
@@ -390,7 +471,6 @@ class UIController {
                 textChatContainer.setAttribute('data-style', savedStyle);
                 console.log(`加载保存的聊天框样式: ${savedStyle}`);
             } else {
-                // 默认样式1
                 textChatContainer.setAttribute('data-style', '1');
             }
         } catch (e) {
@@ -401,7 +481,6 @@ class UIController {
         // Alt键切换聊天框显示/隐藏
         // Alt+数字键切换样式
         document.addEventListener('keydown', (e) => {
-            // Alt键单独按下：切换聊天框显示/隐藏
             if (e.key === 'Alt' && !e.shiftKey && !e.ctrlKey) {
                 e.preventDefault();
                 const chatContainer = document.getElementById('text-chat-container');
@@ -410,7 +489,6 @@ class UIController {
                 }
             }
 
-            // Alt+1~6：切换聊天框样式
             if (e.altKey && !e.shiftKey && !e.ctrlKey) {
                 const num = parseInt(e.key);
                 if (num >= 1 && num <= 6) {
@@ -436,9 +514,11 @@ class UIController {
 
             chatInput.textContent = '';
 
-            // 走 inputRouter.handleTextInput，触发插件 hooks（含 memos 记忆注入）
+            // 兼容多种API：优先 inputRouter，其次 handleTextMessage，最后 sendToLLM
             if (voiceChat.inputRouter) {
                 voiceChat.inputRouter.handleTextInput(message);
+            } else if (voiceChat.handleTextMessage) {
+                voiceChat.handleTextMessage(message);
             } else {
                 voiceChat.sendToLLM(message);
             }

--- a/live-2d/js/ui/ui-controller.js
+++ b/live-2d/js/ui/ui-controller.js
@@ -129,9 +129,11 @@ class UIController {
                 if (subtitleContainer) {
                     subtitleContainer.style.setProperty('position', 'fixed', 'important');
                     subtitleContainer.style.setProperty('bottom', (primaryBottomOffset + 20) + 'px', 'important');
-                    const subtitleLeft = primaryLeftOffset + (primaryDisplay.bounds.width / 2);
+                    const subtitleLeft = primaryLeftOffset + primaryDisplay.bounds.width - 800;
                     subtitleContainer.style.setProperty('left', subtitleLeft + 'px', 'important');
-                    subtitleContainer.style.setProperty('transform', 'translateX(-50%)', 'important');
+                    subtitleContainer.style.setProperty('width', '400px', 'important');
+                    subtitleContainer.style.setProperty('max-width', '400px', 'important');
+                    subtitleContainer.style.setProperty('transform', 'none', 'important');
                 }
 
                 console.log('跨屏定位调试:', {

--- a/live-2d/main.js
+++ b/live-2d/main.js
@@ -6,11 +6,72 @@ const { ModelPathUpdater } = require('./js/model/model-path-updater')
 const { ShortcutManager } = require('./js/shortcut-manager')
 const screenshot = require('screenshot-desktop');
 
-// 添加配置文件路径
 const configPath = path.join(app.getAppPath(), 'config.json');
+const runtimeRootPath = path.join(app.getAppPath(), '.runtime');
+const userDataPath = path.join(runtimeRootPath, 'user-data');
+const sessionDataPath = path.join(runtimeRootPath, 'session-data');
+const runtimeLogPath = path.join(app.getAppPath(), 'runtime.log');
+
+/** 在 app ready 之前读取；用于缓解 Win 上 WebGL/Live2D 渲染进程崩溃 */
+function readUiStartupFlags() {
+    try {
+        const configData = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+        const fromConfig = configData.ui?.disable_hardware_acceleration === true;
+        const fromEnv = process.env.MY_NEURO_DISABLE_GPU === '1';
+        const fromArgv = process.argv.includes('--disable-gpu');
+        return { disableHardwareAcceleration: fromConfig || fromEnv || fromArgv };
+    } catch {
+        return {
+            disableHardwareAcceleration:
+                process.env.MY_NEURO_DISABLE_GPU === '1' ||
+                process.argv.includes('--disable-gpu')
+        };
+    }
+}
+
+const uiStartupFlags = readUiStartupFlags();
+if (uiStartupFlags.disableHardwareAcceleration) {
+    app.disableHardwareAcceleration();
+}
 
 // Live2D模型优先级配置（Python程序会修改这个列表来切换模型）
 const priorityFolders = ['肥牛', 'Hiyouri', 'Default', 'Main'];
+
+function ensureDirSync(dirPath) {
+    fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function writeMainRuntimeLog(level, message) {
+    const formattedMessage = `[${level.toUpperCase()}] ${message}`;
+    try {
+        fs.appendFileSync(runtimeLogPath, formattedMessage + '\n', 'utf8');
+    } catch (error) {
+        console.error('写入runtime.log失败:', error);
+    }
+}
+
+try {
+    ensureDirSync(runtimeRootPath);
+    ensureDirSync(userDataPath);
+    ensureDirSync(sessionDataPath);
+    app.setPath('userData', userDataPath);
+    app.setPath('sessionData', sessionDataPath);
+    app.commandLine.appendSwitch('disable-gpu-shader-disk-cache');
+    if (uiStartupFlags.disableHardwareAcceleration) {
+        writeMainRuntimeLog('info', '已禁用硬件加速（config ui.disable_hardware_acceleration / MY_NEURO_DISABLE_GPU=1 / --disable-gpu）');
+    }
+} catch (error) {
+    writeMainRuntimeLog('error', `初始化运行目录失败: ${error.message}`);
+}
+
+process.on('uncaughtException', (error) => {
+    writeMainRuntimeLog('error', `主进程未捕获异常: ${error.stack || error.message}`);
+});
+
+process.on('unhandledRejection', (reason) => {
+    const message = reason && reason.stack ? reason.stack : String(reason);
+    writeMainRuntimeLog('error', `主进程未处理Promise拒绝: ${message}`);
+});
 
 
 function ensureTopMost(win) {
@@ -20,11 +81,69 @@ function ensureTopMost(win) {
 }
 
 function createWindow () {
-    const primaryDisplay = screen.getPrimaryDisplay()
-    const { width: screenWidth, height: screenHeight } = primaryDisplay.workAreaSize
+    // 读取配置
+    let config = {};
+    try {
+        config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    } catch (e) {
+        console.error('读取配置失败:', e);
+    }
+
+    const screenExtend = config.ui?.screen_extend || { extend: false, left: false, right: true };
+    
+    // 获取所有显示器信息
+    const displays = screen.getAllDisplays()
+    const primaryDisplay = screen.getPrimaryDisplay();
+    
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+
+    if (screenExtend.extend) {
+        if (screenExtend.right && !screenExtend.left) {
+            displays.forEach((display, index) => {
+                const { x, y, width, height } = display.bounds
+                console.log(`显示器 ${index}: x=${x}, y=${y}, width=${width}, height=${height}`)
+                minX = Math.min(minX, x)
+                minY = Math.min(minY, y)
+                maxX = Math.max(maxX, x + width)
+                maxY = Math.max(maxY, y + height)
+            })
+        } else if (screenExtend.left) {
+            displays.forEach((display, index) => {
+                const { x, y, width, height } = display.bounds;
+                if (x <= primaryDisplay.bounds.x) {
+                    console.log(`显示器 ${index} (左侧/主屏): x=${x}, y=${y}, width=${width}, height=${height}`);
+                    minX = Math.min(minX, x);
+                    minY = Math.min(minY, y);
+                    maxX = Math.max(maxX, x + width);
+                    maxY = Math.max(maxY, y + height);
+                }
+            });
+        } else {
+            minX = primaryDisplay.bounds.x;
+            minY = primaryDisplay.bounds.y;
+            maxX = primaryDisplay.bounds.x + primaryDisplay.bounds.width;
+            maxY = primaryDisplay.bounds.y + primaryDisplay.bounds.height;
+        }
+    } else {
+        minX = primaryDisplay.bounds.x;
+        minY = primaryDisplay.bounds.y;
+        maxX = primaryDisplay.bounds.x + primaryDisplay.bounds.width;
+        maxY = primaryDisplay.bounds.y + primaryDisplay.bounds.height;
+    }
+    
+    const totalWidth = maxX - minX
+    const totalHeight = maxY - minY
+    
+    console.log(`=== 窗口创建信息 ===`)
+    console.log(`总边界: minX=${minX}, minY=${minY}, maxX=${maxX}, maxY=${maxY}`)
+    console.log(`计算的窗口尺寸: ${totalWidth}x${totalHeight}`)
+    console.log(`窗口位置: (${minX}, ${minY})`)
+    
     const win = new BrowserWindow({
-        width: screenWidth,
-        height: screenHeight,
+        x: minX,
+        y: minY,
+        width: totalWidth,
+        height: totalHeight,
         transparent: true,
         frame: false,
         alwaysOnTop: true,
@@ -47,20 +166,49 @@ function createWindow () {
     win.setAlwaysOnTop(true, 'screen-saver')
     win.setIgnoreMouseEvents(true, { forward: true });
     win.setMenu(null)
-    win.setPosition(0, 0)
+    
+    // 立即验证窗口尺寸
+    const immediateBounds = win.getBounds()
+    console.log(`窗口创建后立即尺寸: ${immediateBounds.width}x${immediateBounds.height}`)
+    console.log(`窗口创建后立即位置: (${immediateBounds.x}, ${immediateBounds.y})`)
+    
+    // 延迟验证窗口实际尺寸
+    setTimeout(() => {
+        const actualBounds = win.getBounds()
+        console.log(`窗口实际尺寸: ${actualBounds.width}x${actualBounds.height}`)
+        console.log(`窗口实际位置: (${actualBounds.x}, ${actualBounds.y})`)
+        
+        if (actualBounds.width !== totalWidth || actualBounds.height !== totalHeight) {
+            console.log(`⚠️ 窗口尺寸不匹配！尝试强制设置为 ${totalWidth}x${totalHeight}`)
+            win.setBounds({
+                x: minX,
+                y: minY,
+                width: totalWidth,
+                height: totalHeight
+            })
+            
+            setTimeout(() => {
+                const finalBounds = win.getBounds()
+                console.log(`强制设置后尺寸: ${finalBounds.width}x${finalBounds.height}`)
+            }, 100)
+        }
+        console.log(`======================`)
+    }, 100)
+    
     win.loadFile('index.html')
+
+    win.webContents.on('did-fail-load', (event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+        writeMainRuntimeLog('error', `页面加载失败: code=${errorCode}, desc=${errorDescription}, url=${validatedURL}, mainFrame=${isMainFrame}`);
+    })
+    win.webContents.on('render-process-gone', (event, details) => {
+        writeMainRuntimeLog('error', `渲染进程退出: reason=${details.reason}, exitCode=${details.exitCode}`);
+    })
+
     win.on('minimize', (event) => {
         event.preventDefault()
         win.restore()
     })
-    win.on('will-move', (event, newBounds) => {
-        const { width, height } = primaryDisplay.workAreaSize
-        if (newBounds.x < 0 || newBounds.y < 0 || 
-            newBounds.x + newBounds.width > width || 
-            newBounds.y + newBounds.height > height) {
-            event.preventDefault()
-        }
-    })
+    // 移除 will-move 限制,允许跨屏幕移动
     win.on('blur', () => {
         ensureTopMost(win)
     })
@@ -121,12 +269,44 @@ app.on('activate', () => {
 ipcMain.on('window-move', (event, { mouseX, mouseY }) => {
     const win = BrowserWindow.fromWebContents(event.sender)
     const [currentX, currentY] = win.getPosition()
-    const { width: screenWidth, height: screenHeight } = screen.getPrimaryDisplay().workAreaSize
+    // 不限制窗口移动范围,允许自由移动到任何位置(包括副屏)
     let newX = currentX + mouseX
     let newY = currentY + mouseY
-    newX = Math.max(-win.getBounds().width + 100, Math.min(newX, screenWidth - 100))
-    newY = Math.max(-win.getBounds().height + 100, Math.min(newY, screenHeight - 100))
+
     win.setPosition(newX, newY)
+
+    // 动态调整窗口大小以覆盖当前位置所在的所有屏幕
+    const displays = screen.getAllDisplays()
+    const winBounds = win.getBounds()
+    
+    let minX = winBounds.x
+    let minY = winBounds.y
+    let maxX = winBounds.x + winBounds.width
+    let maxY = winBounds.y + winBounds.height
+    
+    displays.forEach(display => {
+        const { x, y, width, height } = display.bounds
+        if (!(winBounds.x + winBounds.width < x || winBounds.x > x + width ||
+              winBounds.y + winBounds.height < y || winBounds.y > y + height)) {
+            minX = Math.min(minX, x)
+            minY = Math.min(minY, y)
+            maxX = Math.max(maxX, x + width)
+            maxY = Math.max(maxY, y + height)
+        }
+    })
+    
+    const newWidth = maxX - minX
+    const newHeight = maxY - minY
+    
+    if (newWidth !== winBounds.width || newHeight !== winBounds.height || minX !== winBounds.x || minY !== winBounds.y) {
+        win.setBounds({
+            x: minX,
+            y: minY,
+            width: newWidth,
+            height: newHeight
+        })
+        console.log(`窗口调整: ${newWidth}x${newHeight} at (${minX}, ${minY})`)
+    }
 })
 
 ipcMain.on('set-ignore-mouse-events', (event, { ignore, options }) => {
@@ -136,6 +316,20 @@ ipcMain.on('set-ignore-mouse-events', (event, { ignore, options }) => {
 ipcMain.on('set-window-opacity', (event, opacity) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     if (win) win.setOpacity(Math.max(0, Math.min(1, opacity)));
+})
+
+ipcMain.handle('get-screen-info', async (event) => {
+    try {
+        const win = BrowserWindow.fromWebContents(event.sender);
+        return {
+            primaryDisplay: screen.getPrimaryDisplay(),
+            allDisplays: screen.getAllDisplays(),
+            windowBounds: win ? win.getBounds() : null
+        };
+    } catch (e) {
+        console.error('获取屏幕信息失败:', e);
+        return null;
+    }
 })
 
 ipcMain.on('request-top-most', (event) => {
@@ -230,11 +424,9 @@ ipcMain.handle('take-screenshot', async (event) => {
 // 添加IPC处理器，允许从渲染进程手动更新模型
 ipcMain.handle('update-live2d-model', async (event) => {
     try {
-        // 调用更新模型的函数
         const modelPathUpdater = new ModelPathUpdater(app.getAppPath(), priorityFolders);
         modelPathUpdater.update();
 
-        // 通知渲染进程需要重新加载以应用新模型
         const win = BrowserWindow.fromWebContents(event.sender)
         win.reload()
 
@@ -250,47 +442,36 @@ ipcMain.handle('switch-live2d-model', async (event, modelName) => {
     try {
         console.log(`切换模型到: ${modelName}`);
 
-        // 更新priorityFolders，将选中的模型放在第一位
         const index = priorityFolders.indexOf(modelName);
         if (index > 0) {
-            // 如果模型已存在，移到第一位
             priorityFolders.splice(index, 1);
             priorityFolders.unshift(modelName);
         } else if (index === -1) {
-            // 如果模型不在列表中，添加到第一位
             priorityFolders.unshift(modelName);
         }
-        // 如果已经在第一位(index === 0)，不需要操作
 
         console.log(`更新后的优先级列表: ${priorityFolders.join(', ')}`);
 
-        // 保存priorityFolders到main.js文件
         try {
             const mainJsPath = path.join(app.getAppPath(), 'main.js');
             let mainJsContent = fs.readFileSync(mainJsPath, 'utf8');
 
-            // 构建新的priorityFolders数组字符串
             const newPriorityString = `['${priorityFolders.join("', '")}']`;
 
-            // 替换main.js中的priorityFolders定义
             mainJsContent = mainJsContent.replace(
                 /const priorityFolders = \[.*?\];/,
                 `const priorityFolders = ${newPriorityString};`
             );
 
-            // 写回文件
             fs.writeFileSync(mainJsPath, mainJsContent, 'utf8');
             console.log('已保存模型优先级到main.js');
         } catch (saveError) {
             console.error('保存优先级到main.js失败:', saveError);
-            // 不影响继续执行
         }
 
-        // 调用更新模型的函数
         const modelPathUpdater = new ModelPathUpdater(app.getAppPath(), priorityFolders);
         modelPathUpdater.update();
 
-        // 通知渲染进程需要重新加载以应用新模型
         const win = BrowserWindow.fromWebContents(event.sender)
         win.reload()
 
@@ -301,13 +482,37 @@ ipcMain.handle('switch-live2d-model', async (event, modelName) => {
     }
 })
 
+
+// 添加获取窗口实际尺寸的IPC处理器
+ipcMain.handle('get-window-bounds', (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    const bounds = win.getBounds();
+    return {
+        width: bounds.width,
+        height: bounds.height,
+        x: bounds.x,
+        y: bounds.y
+    };
+});
+
+// 添加获取所有显示器信息的IPC处理器
+ipcMain.handle('get-all-displays', (event) => {
+    const displays = screen.getAllDisplays();
+    return displays.map(display => ({
+        id: display.id,
+        bounds: display.bounds,
+        workArea: display.workArea,
+        scaleFactor: display.scaleFactor,
+        rotation: display.rotation
+    }));
+});
+
+
 // 添加保存模型位置的IPC处理器
 ipcMain.on('save-model-position', (event, position) => {
     try {
-        // 读取当前配置
         const configData = JSON.parse(fs.readFileSync(configPath, 'utf8'));
 
-        // 更新位置信息
         if (!configData.ui) {
             configData.ui = {};
         }
@@ -323,7 +528,6 @@ ipcMain.on('save-model-position', (event, position) => {
         configData.ui.model_position.y = position.y;
         configData.ui.model_scale = position.scale;
 
-        // 保存到文件
         fs.writeFileSync(configPath, JSON.stringify(configData, null, 2), 'utf8');
 
     } catch (error) {
@@ -336,7 +540,6 @@ ipcMain.handle('switch-vrm-model', async (event, vrmFileName) => {
     try {
         console.log(`切换VRM模型到: ${vrmFileName}`);
 
-        // 更新config.json
         const configData = JSON.parse(fs.readFileSync(configPath, 'utf8'));
         if (!configData.ui) configData.ui = {};
         configData.ui.model_type = 'vrm';
@@ -344,7 +547,6 @@ ipcMain.handle('switch-vrm-model', async (event, vrmFileName) => {
         configData.ui.vrm_model_path = `3D/${vrmFileName}`;
         fs.writeFileSync(configPath, JSON.stringify(configData, null, 2), 'utf8');
 
-        // 重新加载窗口
         const win = BrowserWindow.fromWebContents(event.sender);
         win.reload();
 


### PR DESCRIPTION
## 概述

本 PR作者是**cuniq**， 为 my-neuro 添加 **多屏幕/副屏扩展支持** 和 **主进程稳定性改进**，使 Live2D 桌宠可以跨多个显示器运行，同时增强了应用的健壮性。PS:初次加载不显示皮套的话可以重置皮套位置试试

## 新增功能

### 多屏幕/副屏扩展支持

- **跨屏窗口管理**：通过 `config.ui.screen_extend` 配置项，支持将窗口扩展到多个显示器。支持右侧副屏 (`right: true`) 和左侧副屏 (`left: true`) 两种模式
- **窗口动态调整**：拖动窗口时自动计算与相交显示器的边界，动态调整窗口大小以覆盖所有涉及的屏幕
- **PIXI 多屏坐标系统**：渲染器初始化时通过 IPC 获取实际窗口尺寸，使用 2 倍分辨率 Canvas 适配多屏显示
- **模型跨屏定位**：模型位置保存/恢复使用 canvas 坐标到窗口坐标的正确转换，位置验证范围扩展到 `x: -0.5~2.5, y: -0.5~2.0` 以支持多屏负坐标
- **UI 跨屏适配**：聊天框和字幕容器自动定位到主屏显示器，通过异步 IPC 获取屏幕信息（不阻塞渲染线程）
- **新增 IPC 处理器**：`get-screen-info`、`get-window-bounds`、`get-all-displays`

### 主进程稳定性改进

- **运行目录隔离**：新增 `.runtime/` 目录管理，将 `userData` 和 `sessionData` 隔离到独立路径，避免与系统目录冲突
- **硬件加速控制**：新增 `config.ui.disable_hardware_acceleration` 配置，可通过配置文件、环境变量 (`MY_NEURO_DISABLE_GPU=1`) 或命令行参数 (`--disable-gpu`) 禁用硬件加速，缓解部分 Windows 系统上的 WebGL/Live2D 渲染崩溃
- **全局异常捕获**：新增 `uncaughtException` 和 `unhandledRejection` 处理器，防止未处理的异常导致主进程无声退出
- **渲染进程崩溃检测**：新增 `did-fail-load` 和 `render-process-gone` 事件监听，记录页面加载失败和渲染进程退出信息
- **运行时日志**：新增 `runtime.log` 文件，记录主进程启动、异常、崩溃等关键事件

## 兼容性说明

- `screen_extend` 未配置时自动回退到单屏模式，**不影响现有用户**
- `disable_hardware_acceleration` 默认为 `false`，**不改变现有行为**
- 消息发送 API 兼容 `inputRouter.handleTextInput` / `handleTextMessage` / `sendToLLM` 多种接口
- 保留棋盘游戏插件 (`feiniu-board-game`) 鼠标穿透兼容逻辑
- 保留歌词气泡可配置偏移量（`global._lyricsBubbleOffsetX/Y`）


## 修改的文件

| 文件 | 变更说明 |
|------|---------|
| `live-2d/main.js` | 多屏窗口创建、动态窗口调整、稳定性基础设施、新增 IPC 处理器 |
| `live-2d/js/model/model-setup.js` | 多屏 PIXI 渲染初始化、IPC 获取显示器信息 |
| `live-2d/js/model/model-interaction.js` | 多屏位置管理、跨屏拖动、坐标转换适配 |
| `live-2d/js/ui/ui-controller.js` | 跨屏 UI 定位、棋盘游戏兼容、歌词气泡偏移 |
| `live-2d/css/styles.css` | 多屏聊天框定位、Canvas 渲染优化、左侧副屏布局 |

## 测试计划

- [ ] 单屏模式下功能正常（screen_extend 未配置或 extend: false）
- [ ] 右侧副屏扩展模式正常
- [ ] 左侧副屏扩展模式正常
- [ ] 模型跨屏拖动和位置记忆正常
- [ ] 聊天框正确定位在主屏
- [ ] 禁用硬件加速后 Live2D 渲染正常
- [ ] runtime.log 正确记录启动和异常信息
