### PR TITLE
修复复位皮套，对话框开关及拖动功能失效的问题

### DIFF
--- a/live-2d/css/styles.css
+++ b/live-2d/css/styles.css
@@ -51,6 +51,29 @@ body {
           1.5px 1.5px 0 black;
 }
 
+#chat-drag-handle {
+    width: 50%;
+    height: 15px;
+    background: rgba(100, 150, 200, 0.4);
+    cursor: move;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 12px;
+    font-weight: bold;
+    user-select: none;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    transition: background 0.2s ease;
+    margin: 0 auto 8px auto;
+}
+
+#chat-drag-handle:hover {
+    background: rgba(100, 150, 200, 0.6);
+    color: rgba(255, 255, 255, 0.9);
+}
+
 #text-chat-container {
     position: fixed !important;
     bottom: 50px !important;
@@ -59,16 +82,21 @@ body {
     width: 350px !important;
     max-height: 400px !important;
     z-index: 10000 !important;
-    display: block !important;
-    pointer-events: auto !important;
-    visibility: visible !important;
-    opacity: 1 !important;
+    display: block;
+    pointer-events: auto;
+    visibility: visible;
+    opacity: 1;
 }
 
 /* 当副屏在主屏左侧时，对话框显示在左下角 */
 body.screen-left #text-chat-container {
     right: auto !important;
     left: 20px !important;
+}
+
+/* 拖动后的对话框位置样式 */
+#text-chat-container.dragging {
+    transition: none !important;
 }
 
 /* VRM模型控制面板（展开式） */
@@ -167,6 +195,7 @@ body.screen-left #text-chat-container {
     color: #333333;
     min-height: 20px;
     overflow-y: auto;
+    cursor: text;
 }
 
 #chat-input:empty:before {

--- a/live-2d/index.html
+++ b/live-2d/index.html
@@ -34,6 +34,7 @@
     </div>
 
     <div id="text-chat-container">
+        <div id="chat-drag-handle" title="拖动对话框">⋯</div>
         <div id="chat-messages"></div>
         <div id="chat-input-container">
             <div id="chat-input" contenteditable="true" placeholder="输入消息..."></div>

--- a/live-2d/js/model/model-interaction.js
+++ b/live-2d/js/model/model-interaction.js
@@ -138,47 +138,6 @@ class ModelInteractionController {
             }
         });
 
-        const chatContainer = document.getElementById('text-chat-container');
-
-        // 鼠标按下时开始拖动
-        chatContainer.addEventListener('mousedown', (e) => {
-            // 仅当点击聊天框背景或消息区域时触发拖动（避免误触输入框和按钮）
-            if (e.target === chatContainer || e.target.id === 'chat-messages') {
-                this.isDraggingChat = true;
-                this.chatDragOffset.x = e.clientX - chatContainer.getBoundingClientRect().left;
-                this.chatDragOffset.y = e.clientY - chatContainer.getBoundingClientRect().top;
-                e.preventDefault(); // 防止文本选中
-                ipcRenderer.send('set-ignore-mouse-events', {
-                    ignore: false
-                });
-                
-            }
-        });
-
-        // 鼠标移动时更新位置
-        document.addEventListener('mousemove', (e) => {
-            if (this.isDraggingChat) {
-                chatContainer.style.left = `${e.clientX - this.chatDragOffset.x}px`;
-                chatContainer.style.top = `${e.clientY - this.chatDragOffset.y}px`;
-                // 注意: 拖动聊天框时不需要修改模型位置
-            }
-        });
-
-        // 鼠标释放时停止拖动
-        document.addEventListener('mouseup', () => {
-            // this.isDraggingChat = false;
-            if (this.isDraggingChat) {
-                this.isDraggingChat = false;
-                setTimeout(() => {
-                    if (!this.model.containsPoint(this.app.renderer.plugins.interaction.mouse.global)) {
-                        ipcRenderer.send('set-ignore-mouse-events', {
-                            ignore: true,
-                            options: { forward: true }
-                        });
-                    }
-                }, 100);
-            }
-        });
 
 
 // 拖动结束时，再次检查穿透状态
@@ -314,27 +273,74 @@ class ModelInteractionController {
         if (!this.model || !this.app) return;
 
         //使用实际窗口尺寸（如果可用
-        const actualWidth = window.actualWidth || window.innerWidth;
-        const actualHeight = window.actualHeight || window.innerHeight;
+        const actualWidth = window.actualWindowWidth || window.innerWidth;
+        const actualHeight = window.actualWindowHeight || window.innerHeight;
         const scaleFactor = window.canvasScaleFactor || 2;
 
-        const scaleX = (actualWidth * scaleMultiplier) / this.model.width;
-        const scaleY = (actualHeight * scaleMultiplier) / this.model.height;
         this.model.scale.set(scaleMultiplier);
 
         // 检查是否有保存的位置
         if (this.config && this.config.ui && this.config.ui.model_position && this.config.ui.model_position.remember_position) {
             const savedPos = this.config.ui.model_position;
-            //验证保存模型位置是否合法
-            //允许负值和大于1的值以支持多屏幕
-            //合理范围：x：-0.5--2.5，y：-0.5--2.0
+            
+            // 特殊逻辑：如果 x=1.35 且 y=0.8，则动态计算位置使其始终在对话框上方
+            if (Math.abs(savedPos.x - 1.35) < 0.001 && Math.abs(savedPos.y - 0.8) < 0.001) {
+                const screenInfo = ipcRenderer.sendSync('get-screen-info-sync');
+                if (screenInfo) {
+                    const { primaryDisplay, windowBounds } = screenInfo;
+                    const winX = windowBounds ? windowBounds.x : 0;
+                    const winY = windowBounds ? windowBounds.y : 0;
+                    const winH = windowBounds ? windowBounds.height : actualHeight;
+                    
+                    const primaryLeftOffset = primaryDisplay.bounds.x - winX;
+                    const primaryTopOffset = primaryDisplay.bounds.y - winY;
+                    const primaryBottomOffset = winH - (primaryTopOffset + primaryDisplay.bounds.height);
+
+                    // 对话框位置：left = primaryLeftOffset + primaryW - 350 - 20
+                    // 对话框 bottom = primaryBottomOffset + 50
+                    // 对话框距离屏幕底部的距离 D = 50
+                    // 皮套距离对话框距离 = 3 * D = 150
+                    // 皮套中心点 Y = 窗口底部 - primaryBottomOffset - 50 - 150
+                    // 皮套中心点 X = 对话框左侧 + 175 (对话框宽度一半)
+                    
+                    const dialogLeft = primaryLeftOffset + primaryDisplay.bounds.width - 350 - 20;
+                    const targetWindowX = dialogLeft + 175;
+                    
+                    // 修正：当 y=0.8 时，让皮套在主屏幕垂直居中
+                    // 主屏幕在 Canvas 中的垂直中心点 = primaryTopOffset + primaryDisplay.bounds.height / 2
+                    const primaryCenterY = primaryTopOffset + primaryDisplay.bounds.height / 2;
+                    const targetWindowY = primaryCenterY;
+
+                    // 修正：考虑模型自身的宽度和高度，使其中心对齐目标点
+                    const modelWidth = this.model.width / scaleFactor;
+                    const modelHeight = this.model.height / scaleFactor;
+
+                    this.model.x = (targetWindowX - modelWidth / 2) * scaleFactor;
+                    this.model.y = (targetWindowY - modelHeight / 2) * scaleFactor;
+                    
+                    console.log('动态计算皮套位置(x=1.35, y=0.8):', {
+                        targetWindowX,
+                        targetWindowY,
+                        modelWidth,
+                        modelHeight,
+                        canvasX: this.model.x,
+                        canvasY: this.model.y
+                    });
+                    this.updateInteractionArea();
+                    return;
+                }
+            }
+
+            // 验证保存模型位置是否合法
+            // 允许负值和大于1的值以支持多屏幕
+            // 合理范围：x：-0.5--2.5，y：-0.5--2.0
             const isVlidPosition = savedPos.x !== null && savedPos.y !== null &&
                                 savedPos.x >= -0.5 && savedPos.x <= 2.5 &&
                                 savedPos.y >= -0.5 && savedPos.y <= 2.0;
             if (isVlidPosition) {
                 this.model.x = savedPos.x * actualWidth * scaleFactor;
                 this.model.y = savedPos.y * actualHeight * scaleFactor;
-                console.log('加载保存的位置:', { 
+                console.log('加载保存的位置:', {
                     relativePos: savedPos,
                     canvasX: this.model.x,
                     canvasY: this.model.y,
@@ -369,8 +375,8 @@ class ModelInteractionController {
         }
 
         // 使用实际窗口尺寸计算相对位置
-        const actualWidth = window.actualWidth || window.innerWidth;
-        const actualHeight = window.actualHeight || window.innerHeight;
+        const actualWidth = window.actualWindowWidth || window.innerWidth;
+        const actualHeight = window.actualWindowHeight || window.innerHeight;
         const scaleFactor = window.canvasScaleFactor || 2;
 
         //将canvas坐标转换为相对于窗口的坐标，在计算相对位置

--- a/live-2d/js/services/http-server.js
+++ b/live-2d/js/services/http-server.js
@@ -208,14 +208,12 @@ class HttpServer {
 		
 		            const { ipcRenderer } = require('electron');
 		            const model = mc.model;
-		            const defaultX = window.innerWidth * 1.35;
-		            const defaultY = window.innerHeight * 0.8;
-		            const scale = 0.65;
-                    // 复位到默认位置
-		            model.x = defaultX;
-		            model.y = defaultY;
-		            model.scale.set(scale);
-		            mc.updateInteractionArea();
+		            const scale = model.scale.x; // 保持当前皮套的大小比例
+		                  
+		                  // 触发重新初始化位置逻辑，利用我们刚才在 setupInitialModelProperties 中添加的动态计算
+		                  mc.config.ui.model_position.x = 1.35;
+		                  mc.config.ui.model_position.y = 0.8;
+		                  mc.setupInitialModelProperties(scale);
 		
 		            ipcRenderer.send('save-model-position', { x: 1.35, y: 0.8, scale });
 		            return { success: true};

--- a/live-2d/js/ui/ui-controller.js
+++ b/live-2d/js/ui/ui-controller.js
@@ -44,17 +44,34 @@ class UIController {
         const chatInput = document.getElementById('chat-input');
         const textChatContainer = document.getElementById('text-chat-container');
         const submitBtn = document.getElementById('chat-send-btn');
+        const dragHandle = document.getElementById('chat-drag-handle');
 
         if (!chatInput || !textChatContainer || !submitBtn) return;
+
+        // 设置拖动功能
+        this.setupChatBoxDrag(textChatContainer, dragHandle);
 
         // 强制固定对话框位置逻辑
         const screenExtend = this.config.ui?.screen_extend || { extend: false, left: false, right: true };
         
         // 无论是否扩展，都确保对话框样式正确
         textChatContainer.style.setProperty('position', 'fixed', 'important');
-        textChatContainer.style.setProperty('display', 'block', 'important');
-        textChatContainer.style.setProperty('visibility', 'visible', 'important');
-        textChatContainer.style.setProperty('opacity', '1', 'important');
+        
+        // 根据配置决定初始显示状态
+        const shouldShowChatBox = this.config.ui && this.config.ui.hasOwnProperty('show_chat_box')
+            ? this.config.ui.show_chat_box
+            : true;
+            
+        if (shouldShowChatBox) {
+            textChatContainer.style.setProperty('display', 'block', 'important');
+            textChatContainer.style.setProperty('visibility', 'visible', 'important');
+            textChatContainer.style.setProperty('opacity', '1', 'important');
+        } else {
+            textChatContainer.style.setProperty('display', 'none', 'important');
+            textChatContainer.style.setProperty('visibility', 'hidden', 'important');
+            textChatContainer.style.setProperty('opacity', '0', 'important');
+        }
+        
         textChatContainer.style.setProperty('z-index', '10000', 'important');
         textChatContainer.style.setProperty('width', '350px', 'important');
         textChatContainer.style.setProperty('height', 'auto', 'important');
@@ -109,6 +126,16 @@ class UIController {
             });
         }
 
+        // 防止拖动条点击时触发任何隐藏逻辑
+        if (dragHandle) {
+            dragHandle.addEventListener('click', (e) => {
+                e.stopPropagation();
+            });
+            dragHandle.addEventListener('mousedown', (e) => {
+                e.stopPropagation();
+            });
+        }
+
         textChatContainer.addEventListener('mouseenter', () => {
             ipcRenderer.send('set-ignore-mouse-events', {
                 ignore: false,
@@ -137,6 +164,63 @@ class UIController {
             });
         });
         
+    }
+
+    // 设置聊天框拖动功能
+    setupChatBoxDrag(container, dragHandle) {
+        if (!dragHandle) return;
+
+        let isDragging = false;
+        let startX = 0;
+        let startY = 0;
+        let startLeft = 0;
+        let startBottom = 0;
+
+        dragHandle.addEventListener('mousedown', (e) => {
+            // 防止文本选中
+            e.preventDefault();
+            isDragging = true;
+            startX = e.clientX;
+            startY = e.clientY;
+
+            // 获取当前位置
+            const rect = container.getBoundingClientRect();
+            startLeft = rect.left;
+            startBottom = window.innerHeight - rect.bottom;
+
+            // 添加拖动中的样式
+            dragHandle.style.background = 'rgba(100, 150, 200, 0.8)';
+            container.style.cursor = 'grabbing';
+        });
+
+        document.addEventListener('mousemove', (e) => {
+            if (!isDragging) return;
+
+            const deltaX = e.clientX - startX;
+            const deltaY = e.clientY - startY;
+
+            const newLeft = startLeft + deltaX;
+            const newBottom = startBottom - deltaY;
+
+            // 更新位置，使用 left 和 bottom 定位
+            container.style.setProperty('left', newLeft + 'px', 'important');
+            container.style.setProperty('right', 'auto', 'important');
+            container.style.setProperty('bottom', newBottom + 'px', 'important');
+        });
+
+        document.addEventListener('mouseup', () => {
+            if (!isDragging) return;
+            isDragging = false;
+
+            // 恢复样式
+            dragHandle.style.background = 'rgba(100, 150, 200, 0.4)';
+            container.style.cursor = 'default';
+        });
+
+        // 防止拖动时选中文本
+        dragHandle.addEventListener('selectstart', (e) => {
+            e.preventDefault();
+        });
     }
 
     // 显示字幕
@@ -435,18 +519,25 @@ class UIController {
         // 根据配置设置对话框显示状态
         const shouldShowChatBox = this.config.ui && this.config.ui.hasOwnProperty('show_chat_box')
             ? this.config.ui.show_chat_box
-            : true; // 默认强制显示
+            : true;
 
-        textChatContainer.style.setProperty('display', 'block', 'important');
-        textChatContainer.style.setProperty('visibility', 'visible', 'important');
-        textChatContainer.style.setProperty('opacity', '1', 'important');
-        textChatContainer.style.setProperty('z-index', '10000', 'important');
-        textChatContainer.style.setProperty('pointer-events', 'auto', 'important');
+        if (shouldShowChatBox) {
+            textChatContainer.style.setProperty('display', 'block', 'important');
+            textChatContainer.style.setProperty('visibility', 'visible', 'important');
+            textChatContainer.style.setProperty('opacity', '1', 'important');
+            textChatContainer.style.setProperty('z-index', '10000', 'important');
+            textChatContainer.style.setProperty('pointer-events', 'auto', 'important');
+            console.log('显示聊天框');
+        } else {
+            textChatContainer.style.setProperty('display', 'none', 'important');
+            textChatContainer.style.setProperty('visibility', 'hidden', 'important');
+            textChatContainer.style.setProperty('opacity', '0', 'important');
+            textChatContainer.style.setProperty('pointer-events', 'none', 'important');
+            console.log('隐藏聊天框');
+        }
         
         // 重新触发一次位置计算，确保可见性切换后位置正确
         this.setupChatBoxEvents();
-
-        console.log('强制显示聊天框');
 
         // 调试：确保对话框在可见范围内
         setTimeout(() => {
@@ -486,7 +577,18 @@ class UIController {
                 e.preventDefault();
                 const chatContainer = document.getElementById('text-chat-container');
                 if (chatContainer) {
-                    chatContainer.style.display = chatContainer.style.display === 'none' ? 'block' : 'none';
+                    const isHidden = window.getComputedStyle(chatContainer).display === 'none';
+                    if (isHidden) {
+                        chatContainer.style.setProperty('display', 'block', 'important');
+                        chatContainer.style.setProperty('visibility', 'visible', 'important');
+                        chatContainer.style.setProperty('opacity', '1', 'important');
+                        chatContainer.style.setProperty('pointer-events', 'auto', 'important');
+                    } else {
+                        chatContainer.style.setProperty('display', 'none', 'important');
+                        chatContainer.style.setProperty('visibility', 'hidden', 'important');
+                        chatContainer.style.setProperty('opacity', '0', 'important');
+                        chatContainer.style.setProperty('pointer-events', 'none', 'important');
+                    }
                 }
             }
 


### PR DESCRIPTION
# 更新简报

## 新增功能

1. 点击复位皮套位置按钮，皮套会回到主屏右侧中间部分，避免皮套飞出屏幕（需要要求复位必须是x=1.35，y=0.8，当前已实现）

2. 修复了文字对话框开关失效的问题

3. 更新了拖动对话框到副屏的功能

4. 移除了文字对话框左上角拖动的功能

---


## 实现细节

### 1. 皮套复位功能

- **屏幕几何感知**：通过 IPC 实时获取多屏环境下的主屏幕物理边界，解决了副屏位置变化导致的坐标偏移问题

- **智能锚点逻辑**：将 x=1.35, y=0.8 定义为特殊动态坐标。程序检测到该值时，会自动计算主屏幕的中心位置，而非使用简单的比例缩放

- **中心点对齐算法**：在定位时考虑了模型自身的宽高，通过 (目标坐标 - 模型半宽/高) 的公式，确保皮套中心点准确对齐目标位置，彻底解决了"复位后皮套飞走"的问题

### 2. 文字对话框开关修复

- **清理 CSS 强制样式**：移除了 css/styles.css 中 #text-chat-container 的 !important 声明（如 display: block !important）

- **修正初始化逻辑冲突**：修改了 js/ui/ui-controller.js 中的 setupChatBoxEvents 函数。该函数原本在处理跨屏定位时，会无条件地强制显示对话框，现在它会先读取配置再决定是否显示

- **强化 JS 控制优先级**：在 js/ui/ui-controller.js 的可见性设置中，改用 style.setProperty(..., 'important')。这确保了 JavaScript 的设置能够覆盖任何其他样式规则

- **完善隐藏状态**：隐藏时不仅设置 display: none，还同步处理了 visibility（可见性）、opacity（透明度）和 pointer-events（鼠标交互），确保对话框彻底消失且不干扰鼠标操作

- **同步快捷键行为**：更新了 Alt 键手动切换显示/隐藏的逻辑，使其与配置开关的隐藏行为保持一致

### 3. 拖动对话框到副屏

- **添加拖动条**：在对话框顶部添加拖动条，宽度为原对话框的 50%，高度 15px，居中显示

- **实现拖动逻辑**：鼠标按下记录起始位置，移动时计算偏移量更新对话框位置，松开时结束拖动

- **防止事件冲突**：防止拖动条点击时触发任何隐藏逻辑，通过事件阻止冒泡处理
