### PR TITLE
live2D 桌宠多屏硬切换功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 
 # 忽略特定文件夹
 # live-2d/2D/*
-live-2d/AI记录室/*
+AI记录室/*
 live-2d/build/
 live-2d/fake_neuro_audio/
 live-2d/node/

--- a/live-2d/js/services/http-server.js
+++ b/live-2d/js/services/http-server.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { BrowserWindow } = require('electron');
+const { BrowserWindow, screen } = require('electron');
 
 /**
  * HTTP API 服务器
@@ -294,6 +294,49 @@ class HttpServer {
             pm.syncEnabledPlugins()
                 .then(() => res.json({ success: true, message: '插件列表已同步' }))
                 .catch(e => res.json({ success: false, message: e.message }));
+        });
+
+        // ===== 显示器管理接口 =====
+
+        this.emotionApp.get('/get-displays', (req, res) => {
+            try {
+                const displays = screen.getAllDisplays();
+                res.json({
+                    success: true,
+                    displays: displays.map((d, i) => ({
+                        index: i,
+                        id: d.id,
+                        label: `显示器 ${i + 1} (${d.bounds.width}x${d.bounds.height})`,
+                        bounds: d.bounds,
+                        scaleFactor: d.scaleFactor
+                    }))
+                });
+            } catch (error) {
+                res.json({ success: false, message: error.toString(), displays: [] });
+            }
+        });
+
+        this.emotionApp.post('/switch-display', (req, res) => {
+            try {
+                const { display_index } = req.body;
+                const displays = screen.getAllDisplays();
+                const targetDisplay = displays[display_index];
+                const mainWindow = BrowserWindow.getAllWindows()[0];
+                
+                if (!mainWindow) {
+                    return res.json({ success: false, message: '应用窗口未找到' });
+                }
+                if (!targetDisplay) {
+                    return res.json({ success: false, message: '目标显示器未找到' });
+                }
+                
+                mainWindow.setPosition(targetDisplay.bounds.x, targetDisplay.bounds.y);
+                mainWindow.setSize(targetDisplay.bounds.width, targetDisplay.bounds.height);
+                
+                res.json({ success: true, message: `已切换到显示器 ${display_index + 1}` });
+            } catch (error) {
+                res.json({ success: false, message: error.toString() });
+            }
         });
 
         this.emotionApp.listen(3002, () => {

--- a/live-2d/webui/live2d_manager.py
+++ b/live-2d/webui/live2d_manager.py
@@ -493,3 +493,44 @@ def preview_expression():
     except Exception as e:
         logger.error(f'预览表情失败：{str(e)}')
         return jsonify({'success': False, 'error': str(e)}), 500
+
+
+# ============ 显示器管理 ============
+
+@live2d_bp.route('/api/live2d/display/list', methods=['GET'])
+def get_display_list():
+    """获取显示器列表（转发到 Electron）"""
+    try:
+        req = urllib.request.Request('http://localhost:3002/get-displays', method='GET')
+        req.add_header('Content-Type', 'application/json')
+        with urllib.request.urlopen(req, timeout=3) as response:
+            data = json.loads(response.read().decode('utf-8'))
+            return jsonify(data)
+    except urllib.error.URLError:
+        logger.warning('获取显示器列表失败：Electron 服务未启动')
+        return jsonify({'success': False, 'displays': [], 'error': 'Electron 服务未启动'})
+    except Exception as e:
+        logger.warning(f'获取显示器列表失败：{e}')
+        return jsonify({'success': False, 'displays': [], 'error': str(e)})
+
+
+@live2d_bp.route('/api/live2d/display/switch', methods=['POST'])
+def switch_display():
+    """切换显示器（转发到 Electron）"""
+    try:
+        data = request.get_json()
+        display_index = data.get('display_index', 0)
+        
+        json_data = json.dumps({'display_index': display_index}).encode('utf-8')
+        req = urllib.request.Request('http://localhost:3002/switch-display', data=json_data, method='POST')
+        req.add_header('Content-Type', 'application/json')
+        
+        with urllib.request.urlopen(req, timeout=3) as response:
+            result = json.loads(response.read().decode('utf-8'))
+            return jsonify(result)
+    except urllib.error.URLError:
+        logger.warning('切换显示器失败：Electron 服务未启动')
+        return jsonify({'success': False, 'error': 'Electron 服务未启动'})
+    except Exception as e:
+        logger.error(f'切换显示器失败：{e}')
+        return jsonify({'success': False, 'error': str(e)})

--- a/live-2d/webui/static/js/app.js
+++ b/live-2d/webui/static/js/app.js
@@ -808,6 +808,11 @@ async function startService(serviceName) {
         if (response.ok && result.success) {
             updateServiceStatus(serviceName, 'running');
             addLog(serviceName + ' ' + t('services.start_success'), 'success', 'system');
+            
+            // Live2D 启动后加载显示器列表
+            if (serviceName === 'live2d') {
+                setTimeout(loadDisplayList, 1500);
+            }
         } else {
             addLog(serviceName + ' ' + t('services.start_failed') + '：' + (result.error || t('common.unknown_error')), 'error', 'system');
         }
@@ -3960,5 +3965,70 @@ function toggleHeaderCollapse() {
         if (collapseBtn) {
             collapseBtn.querySelector('.collapse-text').textContent = t('common.collapse');
         }
+    }
+}
+
+// ============ 显示器切换功能 ============
+
+// 加载显示器列表
+async function loadDisplayList() {
+    const select = document.getElementById('display-select');
+    const statusDiv = document.getElementById('display-status');
+    const switchBtn = document.getElementById('switch-display-btn');
+    
+    if (!select) return;
+    
+    try {
+        const response = await fetch('/api/live2d/display/list');
+        const data = await response.json();
+        
+        if (data.success && data.displays && data.displays.length > 0) {
+            select.innerHTML = '';
+            
+            data.displays.forEach(display => {
+                const option = document.createElement('option');
+                option.value = display.index;
+                option.textContent = display.label;
+                select.appendChild(option);
+            });
+            
+            select.disabled = false;
+            switchBtn.disabled = false;
+            statusDiv.textContent = t('ui_settings.display_detected') || `检测到 ${data.displays.length} 个显示器`;
+        } else {
+            statusDiv.textContent = data.error || t('ui_settings.display_unavailable') || '无法获取显示器信息';
+        }
+    } catch (error) {
+        console.error('加载显示器列表失败:', error);
+        statusDiv.textContent = t('ui_settings.display_not_running') || 'Electron 未启动或连接失败';
+    }
+}
+
+// 切换显示器
+async function switchDisplay() {
+    const select = document.getElementById('display-select');
+    const displayIndex = parseInt(select.value);
+    
+    if (isNaN(displayIndex)) {
+        showToast(t('ui_settings.select_display_first') || '请选择目标显示器', 'warning');
+        return;
+    }
+    
+    try {
+        const response = await fetch('/api/live2d/display/switch', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ display_index: displayIndex })
+        });
+        
+        const result = await response.json();
+        
+        if (result.success) {
+            showToast(result.message, 'success');
+        } else {
+            showToast(t('ui_settings.switch_failed') + ': ' + (result.error || t('common.unknown_error')), 'error');
+        }
+    } catch (error) {
+        showToast(t('ui_settings.switch_error') + ': ' + error.message, 'error');
     }
 }

--- a/live-2d/webui/static/locales/en/translation.json
+++ b/live-2d/webui/static/locales/en/translation.json
@@ -225,7 +225,18 @@
     "model_switch_failed": "Failed to switch model",
     "ui_save_success": "UI settings saved",
     "ui_save_failed": "Failed to save UI settings",
-    "ui_save_error": "Error saving UI settings"
+    "ui_save_error": "Error saving UI settings",
+    "display_title": "Display Settings",
+    "select_display": "Select Display:",
+    "waiting_app": "Waiting for app to start...",
+    "switch_display": "Switch Display",
+    "display_hint": "Switch display after starting the app",
+    "display_detected": "Multiple displays detected",
+    "display_unavailable": "Unable to get display info",
+    "display_not_running": "Electron not running or connection failed",
+    "select_display_first": "Please select target display",
+    "switch_failed": "Switch failed",
+    "switch_error": "Switch request failed"
   },
   "dialog_config": {
     "max_messages": "Max Messages:",

--- a/live-2d/webui/static/locales/zh/translation.json
+++ b/live-2d/webui/static/locales/zh/translation.json
@@ -225,7 +225,18 @@
     "model_switch_failed": "切换模型失败",
     "ui_save_success": "UI 设置保存成功",
     "ui_save_failed": "UI 设置保存失败",
-    "ui_save_error": "UI 设置保存时出错"
+    "ui_save_error": "UI 设置保存时出错",
+    "display_title": "显示器设置",
+    "select_display": "选择显示器：",
+    "waiting_app": "等待应用启动...",
+    "switch_display": "切换显示器",
+    "display_hint": "启动应用后可切换显示器",
+    "display_detected": "检测到多个显示器",
+    "display_unavailable": "无法获取显示器信息",
+    "display_not_running": "Electron 未启动或连接失败",
+    "select_display_first": "请选择目标显示器",
+    "switch_failed": "切换失败",
+    "switch_error": "切换请求失败"
   },
   "dialog_config": {
     "max_messages": "最大消息数:",

--- a/live-2d/webui/templates/index.html
+++ b/live-2d/webui/templates/index.html
@@ -520,6 +520,18 @@
                         </div>
                     </div>
                 </div>
+                <!-- 显示器设置 -->
+                <div class="section" id="display-settings-section">
+                    <h4 data-i18n="ui_settings.display_title">显示器设置</h4>
+                    <div class="form-group">
+                        <label for="display-select" data-i18n="ui_settings.select_display">选择显示器：</label>
+                        <select id="display-select" disabled style="width: 100%; padding: 10px; border-radius: 8px; background: rgba(0,0,0,0.2); border: 1px solid rgba(255,255,255,0.3); color: white;">
+                            <option value="" data-i18n="ui_settings.waiting_app">等待应用启动...</option>
+                        </select>
+                    </div>
+                    <button onclick="switchDisplay()" id="switch-display-btn" disabled class="btn-start btn-apply mt-2.5" data-i18n="ui_settings.switch_display">切换显示器</button>
+                    <div id="display-status" class="status-hint" style="margin-top: 10px; font-size: 12px; color: rgba(255,255,255,0.6);" data-i18n="ui_settings.display_hint">启动应用后可切换显示器</div>
+                </div>
             </div>
             
             <!-- 动作管理面板 -->


### PR DESCRIPTION
（重发）多屏切换的兼容性选择，可实时切换
- Electron HTTP Server: 新增 /get-displays 和 /switch-display API
- Flask API: 新增 /api/live2d/display/list 和 /api/live2d/display/switch
- WebUI HTML: 在 UI 设置底部添加显示器选择 UI
- WebUI JS: Live2D 启动后自动加载显示器列表，点击切换实时生效
- 中英文翻译支持

（晚点做合并兼容）