### PR TITLE
修复 VRM 模式切回 Live2D 的状态同步问题

### DIFF
--- a/live-2d/js/app-initializer.js
+++ b/live-2d/js/app-initializer.js
@@ -270,10 +270,13 @@ class AppInitializer {
         // VRM模式：替换modelController并更新TTS唇形回调
         if (result.vrmController) {
             this.modelController = result.vrmController;
+            global.modelController = result.vrmController;
             if (this.ttsProcessor?.playbackEngine) {
                 this.ttsProcessor.playbackEngine.onAudioDataCallback =
                     (value) => result.vrmController.setMouthOpenY(value);
             }
+        } else {
+            global.modelController = this.modelController;
         }
 
         global.currentModel = this.model;

--- a/live-2d/js/model/vrm-model-adapter.js
+++ b/live-2d/js/model/vrm-model-adapter.js
@@ -503,6 +503,7 @@ class VRMModelAdapter extends EventEmitter {
     // 获取/设置VRM渲染状态
     setRenderingEnabled(enabled) {
         this._renderingEnabled = enabled;
+        this._visible = enabled;
         // 使用vrmGroup控制可见性（它包裹了vrm.scene）
         if (this.vrmGroup) {
             this.vrmGroup.visible = enabled;

--- a/live-2d/js/model/vrm-model-setup.js
+++ b/live-2d/js/model/vrm-model-setup.js
@@ -49,7 +49,7 @@ class VRMModelSetup {
         scene.add(directionalLight);
 
         // 加载VRM模型
-        const modelPath = config.ui?.vrm_model_path || '3D/Fioka1.vrm';
+        const modelPath = config.ui?.vrm_model_path || '3D/Sample_A.vrm';
         console.log(`正在加载VRM模型: ${modelPath}`);
 
         let vrm;
@@ -249,7 +249,7 @@ class VRMModelSetup {
 
     // 从模型路径提取角色名
     static _getCharacterName(modelPath) {
-        // 从 "3D/Fioka1.vrm" 提取 "Fioka1"
+        // 从 "3D/Sample_A.vrm" 提取 "Sample_A"
         const match = modelPath.match(/3D\/([^\/]+?)\.vrm$/i);
         if (match) return match[1];
         // 默认名称

--- a/live-2d/js/services/http-server.js
+++ b/live-2d/js/services/http-server.js
@@ -249,7 +249,7 @@ class HttpServer {
             if (model_type === 'vrm') {
                 // VRM模型切换：通过IPC触发
                 mainWindow.webContents.executeJavaScript(
-                    `require('electron').ipcRenderer.invoke('switch-vrm-model', '${model_name}')`
+                    `require('electron').ipcRenderer.invoke('switch-vrm-model', ${JSON.stringify(model_name)})`
                 ).then(() => {
                     res.json({ success: true, message: `VRM模型切换到 ${model_name}` });
                 }).catch(error => {
@@ -258,7 +258,7 @@ class HttpServer {
             } else {
                 // Live2D模型切换
                 mainWindow.webContents.executeJavaScript(
-                    `require('electron').ipcRenderer.invoke('switch-live2d-model', '${model_name}')`
+                    `require('electron').ipcRenderer.invoke('switch-live2d-model', ${JSON.stringify(model_name)})`
                 ).then(() => {
                     res.json({ success: true, message: `模型切换到 ${model_name}` });
                 }).catch(error => {

--- a/live-2d/js/services/http-server.js
+++ b/live-2d/js/services/http-server.js
@@ -212,13 +212,19 @@ class HttpServer {
 		            const isDualRight = window.innerWidth > window.screen.width * 1.2 && mc.config?.ui?.screen_extend?.right;
 		            const relX = isDualRight ? 0.825 : 0.65;
 		            const relY = 0.38;
-		            const defaultX = relX * window.innerWidth * scaleFactor;
-		            const defaultY = relY * window.innerHeight * scaleFactor;
 		            const scale = 0.65;
-		            model.x = defaultX;
-		            model.y = defaultY;
-		            model.scale.set(scale);
-		            mc.updateInteractionArea();
+
+		            if (model.modelType === 'vrm') {
+		                model.viewRect = mc._savedToViewRect(relX, relY, scale);
+		                if (mc._clampViewRect) mc._clampViewRect();
+		            } else {
+		                const defaultX = relX * window.innerWidth * scaleFactor;
+		                const defaultY = relY * window.innerHeight * scaleFactor;
+		                model.x = defaultX;
+		                model.y = defaultY;
+		                if (model.scale?.set) model.scale.set(scale);
+		                if (mc.updateInteractionArea) mc.updateInteractionArea();
+		            }
 		
 		            ipcRenderer.send('save-model-position', { x: relX, y: relY, scale, dual: isDualRight });
 

--- a/live-2d/main.js
+++ b/live-2d/main.js
@@ -9,6 +9,40 @@ const screenshot = require('screenshot-desktop');
 // 添加配置文件路径
 const configPath = path.join(app.getAppPath(), 'config.json');
 
+function loadConfigData() {
+    return JSON.parse(fs.readFileSync(configPath, 'utf8'));
+}
+
+function saveConfigData(configData) {
+    fs.writeFileSync(configPath, JSON.stringify(configData, null, 2), 'utf8');
+}
+
+function setLive2DConfig(modelName) {
+    const configData = loadConfigData();
+    if (!configData.ui) configData.ui = {};
+    configData.ui.model_type = 'live2d';
+    configData.ui.vrm_model = '';
+    configData.ui.vrm_model_path = '';
+    if (modelName) {
+        configData.ui.live2d_model = modelName;
+    }
+    saveConfigData(configData);
+}
+
+function setVRMConfig(vrmFileName) {
+    const configData = loadConfigData();
+    if (!configData.ui) configData.ui = {};
+    configData.ui.model_type = 'vrm';
+    configData.ui.vrm_model = vrmFileName;
+    configData.ui.vrm_model_path = `3D/${vrmFileName}`;
+    saveConfigData(configData);
+}
+
+function reloadSenderWindow(event) {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (win) win.reload();
+}
+
 // Live2D模型优先级配置（Python程序会修改这个列表来切换模型）
 const priorityFolders = ['肥牛', 'Hiyouri', 'Default', 'Main'];
 
@@ -377,6 +411,8 @@ ipcMain.handle('switch-live2d-model', async (event, modelName) => {
     try {
         console.log(`切换模型到: ${modelName}`);
 
+        setLive2DConfig(modelName);
+
         // 更新priorityFolders，将选中的模型放在第一位
         const index = priorityFolders.indexOf(modelName);
         if (index > 0) {
@@ -418,8 +454,7 @@ ipcMain.handle('switch-live2d-model', async (event, modelName) => {
         modelPathUpdater.update();
 
         // 通知渲染进程需要重新加载以应用新模型
-        const win = BrowserWindow.fromWebContents(event.sender)
-        win.reload()
+        reloadSenderWindow(event)
 
         return { success: true, message: `模型已切换到 ${modelName}，页面将重新加载` }
     } catch (error) {
@@ -495,16 +530,10 @@ ipcMain.handle('switch-vrm-model', async (event, vrmFileName) => {
         console.log(`切换VRM模型到: ${vrmFileName}`);
 
         // 更新config.json
-        const configData = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-        if (!configData.ui) configData.ui = {};
-        configData.ui.model_type = 'vrm';
-        configData.ui.vrm_model = vrmFileName;
-        configData.ui.vrm_model_path = `3D/${vrmFileName}`;
-        fs.writeFileSync(configPath, JSON.stringify(configData, null, 2), 'utf8');
+        setVRMConfig(vrmFileName);
 
         // 重新加载窗口
-        const win = BrowserWindow.fromWebContents(event.sender);
-        win.reload();
+        reloadSenderWindow(event);
 
         return { success: true, message: `VRM模型已切换到 ${vrmFileName}，页面将重新加载` };
     } catch (error) {

--- a/live-2d/main.js
+++ b/live-2d/main.js
@@ -43,6 +43,10 @@ function reloadSenderWindow(event) {
     if (win) win.reload();
 }
 
+function serializePriorityFolders(folders) {
+    return `[${folders.map(folder => JSON.stringify(folder)).join(', ')}]`;
+}
+
 // Live2D模型优先级配置（Python程序会修改这个列表来切换模型）
 const priorityFolders = ['肥牛', 'Hiyouri', 'Default', 'Main'];
 
@@ -433,7 +437,7 @@ ipcMain.handle('switch-live2d-model', async (event, modelName) => {
             let mainJsContent = fs.readFileSync(mainJsPath, 'utf8');
 
             // 构建新的priorityFolders数组字符串
-            const newPriorityString = `['${priorityFolders.join("', '")}']`;
+            const newPriorityString = serializePriorityFolders(priorityFolders);
 
             // 替换main.js中的priorityFolders定义
             mainJsContent = mainJsContent.replace(

--- a/live-2d/webui/config_manager.py
+++ b/live-2d/webui/config_manager.py
@@ -455,16 +455,25 @@ def handle_current_model():
         
         main_js_path = PROJECT_ROOT / 'main.js'
         
+        config = load_config()
+        ui_config = config.get('ui', {})
+
         # GET 请求：读取当前模型
         if request.method == 'GET':
+            if ui_config.get('model_type') == 'vrm':
+                return jsonify({
+                    'success': True,
+                    'model': ui_config.get('vrm_model', ''),
+                    'model_type': 'vrm'
+                })
             if main_js_path.exists():
                 with open(main_js_path, 'r', encoding='utf-8') as f:
                     content = f.read()
                 match = re.search(r"const priorityFolders = \['([^']+)'", content)
                 if match:
                     current_model = match.group(1)
-                    return jsonify({'success': True, 'model': current_model})
-            return jsonify({'success': True, 'model': '肥牛'})
+                    return jsonify({'success': True, 'model': current_model, 'model_type': 'live2d'})
+            return jsonify({'success': True, 'model': '肥牛', 'model_type': 'live2d'})
         
         # POST 请求：设置模型
         data = request.get_json()
@@ -472,6 +481,15 @@ def handle_current_model():
         
         if not model_name:
             return jsonify({'success': False, 'error': '未提供模型名称'})
+
+        if 'ui' not in config:
+            config['ui'] = {}
+        config['ui']['model_type'] = 'live2d'
+        config['ui']['vrm_model'] = ''
+        config['ui']['vrm_model_path'] = ''
+        config['ui']['live2d_model'] = model_name
+        if not save_config(config):
+            return jsonify({'success': False, 'error': '保存配置失败'}), 500
         
         # 更新 main.js 的 priorityFolders
         if main_js_path.exists():

--- a/live-2d/webui/live2d_manager.py
+++ b/live-2d/webui/live2d_manager.py
@@ -96,6 +96,17 @@ def save_live2d_model():
         if not model_name:
             return jsonify({'success': False, 'error': '未提供模型名称'})
 
+        from .config_manager import load_config, save_config
+        config = load_config()
+        if 'ui' not in config:
+            config['ui'] = {}
+        config['ui']['model_type'] = 'live2d'
+        config['ui']['vrm_model'] = ''
+        config['ui']['vrm_model_path'] = ''
+        config['ui']['live2d_model'] = model_name
+        if not save_config(config):
+            return jsonify({'success': False, 'error': '保存配置失败'}), 500
+
         main_js_path = PROJECT_ROOT / 'main.js'
         if main_js_path.exists():
             with open(main_js_path, 'r', encoding='utf-8') as f:


### PR DESCRIPTION
## 变更内容
- 修复从 VRM/3D 模型切回 Live2D/2D 模型时，`config.ui.model_type` 未恢复为 `live2d` 导致重载后仍进入 VRM 分支的问题。
- 统一主进程 VRM 与 Live2D 切换时的配置写入逻辑，切回 Live2D 时清空 `vrm_model` 和 `vrm_model_path`。
- 修复 WebUI 模型保存接口只修改 `main.js`、不更新 `config.json` 的问题，避免 WebUI 无法从 VRM 状态恢复到 Live2D。
- 在 VRM 初始化后同步 `global.modelController`，让复位位置等 HTTP 控制接口拿到正确的 VRM controller。
- 修复 VRM 渲染开关只隐藏场景但命中检测仍认为模型可见的问题。
- 将 VRM 默认回退模型改为仓库实际存在的 `3D/Sample_A.vrm`。
- 对 HTTP 模型切换入口的模型名进行安全转义，避免特殊字符导致执行脚本失败。

## 验证
- `node --check live-2d/main.js`
- `node --check live-2d/js/app-initializer.js`
- `node --check live-2d/js/model/vrm-model-adapter.js`
- `node --check live-2d/js/model/vrm-model-setup.js`
- `node --check live-2d/js/services/http-server.js`
- `python -m py_compile live-2d/webui/config_manager.py live-2d/webui/live2d_manager.py`
- `git diff --check`