### PR TITLE
模型多屏跨越改为单屏窗口 + 整窗重定位

### DIFF
--- a/live-2d/app.js
+++ b/live-2d/app.js
@@ -1,4 +1,6 @@
 // 导入所需模块
+// 跨屏桥接：注入 window.electronScreen（必须在任何模型交互逻辑之前加载）
+require('./js/services/electron-screen-bridge.js');
 const { ModelInteractionController } = require('./js/model/model-interaction.js');
 const { configLoader } = require('./js/core/config-loader.js');
 const { logToTerminal } = require('./js/api-utils.js');

--- a/live-2d/js/model/model-interaction.js
+++ b/live-2d/js/model/model-interaction.js
@@ -102,31 +102,26 @@ class ModelInteractionController {
         // 鼠标移动事件
         this.model.on('mousemove', (e) => {
             if (this.isDragging) {
-                let newX = e.data.global.x - this.dragOffset.x;
-                let newY = e.data.global.y - this.dragOffset.y;
-
-                // 限制模型移动范围
-                if (this.config && this.config.ui && this.config.ui.screen_extend) {
-                    const extend = this.config.ui.screen_extend;
-                    if (extend.extend && extend.left) {
-                        // 限制在主屏幕范围内 (假设主屏幕在右侧，左侧是扩展屏)
-                        // 这里需要根据实际屏幕布局调整，假设主屏幕宽度为 screen.getPrimaryDisplay().size.width
-                        // 简单处理：限制 x 不能小于 0
-                        if (newX < 0) newX = 0;
-                    }
-                }
-
+                // 拖动期间模型自由跟随光标，允许超出当前窗口边缘（会被窗口裁切）；
+                // 跨屏判定推迟到松手时的 checkAndSwitchDisplay，不在拖动中限制范围。
+                const newX = e.data.global.x - this.dragOffset.x;
+                const newY = e.data.global.y - this.dragOffset.y;
                 this.model.position.set(newX, newY);
                 this.updateInteractionArea();
             }
         });
 
         // 全局鼠标释放事件
-        window.addEventListener('mouseup', () => {
+        window.addEventListener('mouseup', async () => {
             if (this.isDragging) {
                 this.isDragging = false;
-                // 保存模型位置
-                this.saveModelPosition();
+                // 松手时先检测模型中心是否越出当前窗口，若是则整窗重定位到目标显示器。
+                const switched = await this.checkAndSwitchDisplay();
+                if (!switched) {
+                    // 未切屏：若模型中心越出当前窗口（目标屏不存在），吸回窗口内，避免模型“走丢”。
+                    this._clampModelToWindow();
+                    this.saveModelPosition();
+                }
                 setTimeout(() => {
                     if (!this.model.containsPoint(this.app.renderer.plugins.interaction.mouse.global)) {
                         ipcRenderer.send('set-ignore-mouse-events', {
@@ -254,13 +249,18 @@ class ModelInteractionController {
             }
         }, { passive: false });
 
-        // 窗口大小改变事件
+        // 窗口大小改变事件（跨屏重定位到不同尺寸的显示器时也会触发）
         window.addEventListener('resize', () => {
             if (this.app && this.app.renderer) {
                 const actualWidth = window.actualWidth || window.innerWidth;
                 const actualHeight = window.actualHeight || window.innerHeight;
                 const scaleFactor = window.canvasScaleFactor || 2;
                 this.app.renderer.resize(actualWidth * scaleFactor, actualHeight * scaleFactor);
+                // 同步 canvas 的 CSS 尺寸到当前窗口（2x 缓冲区需配对正确的 CSS 尺寸，否则跨屏后会被拉伸）
+                if (this.app.view && this.app.view.style) {
+                    this.app.view.style.width = actualWidth + 'px';
+                    this.app.view.style.height = actualHeight + 'px';
+                }
                 //多屏幕坐标系统，不设置pivot/position,舞台从0,0开始
                 this.updateInteractionArea();
             }
@@ -276,6 +276,102 @@ class ModelInteractionController {
         this.model.on('rightdown', (e) => {
             e.stopPropagation();
         });
+    }
+
+    // ===== 跨屏：松手时检测模型是否越出当前窗口，并整窗重定位到目标显示器 =====
+    // 把模型中心换算成屏幕绝对坐标来判断目标屏；
+    // 适配 myneuro 的坐标约定：canvas 坐标 = 窗口 CSS 坐标 × canvasScaleFactor(=2)。
+    async checkAndSwitchDisplay() {
+        // 仅在 Electron 桥接可用时执行
+        if (!window.electronScreen || !window.electronScreen.moveWindowToDisplay) return false;
+        if (!this.model) return false;
+
+        try {
+            const sf = window.canvasScaleFactor || 2;
+
+            // 模型中心（canvas 坐标）→ 当前窗口 CSS 坐标
+            const bounds = this.model.getBounds();
+            const modelCenterX = ((bounds.left + bounds.right) / 2) / sf;
+            const modelCenterY = ((bounds.top + bounds.bottom) / 2) / sf;
+
+            const displays = await window.electronScreen.getAllDisplays();
+            if (!displays || displays.length <= 1) return false;
+
+            const windowWidth = window.innerWidth;
+            const windowHeight = window.innerHeight;
+            // 模型中心仍在当前窗口内 → 不切屏
+            if (modelCenterX >= 0 && modelCenterX < windowWidth &&
+                modelCenterY >= 0 && modelCenterY < windowHeight) {
+                return false;
+            }
+
+            const currentDisplay = await window.electronScreen.getCurrentDisplay();
+            if (!currentDisplay) return false;
+
+            // 模型中心的屏幕绝对坐标
+            const modelScreenX = currentDisplay.screenX + modelCenterX;
+            const modelScreenY = currentDisplay.screenY + modelCenterY;
+
+            // 找到包含该点的目标显示器
+            let targetDisplay = null;
+            for (const d of displays) {
+                if (modelScreenX >= d.screenX && modelScreenX < d.screenX + d.width &&
+                    modelScreenY >= d.screenY && modelScreenY < d.screenY + d.height) {
+                    targetDisplay = d;
+                    break;
+                }
+            }
+            if (!targetDisplay) return false;
+
+            console.log('[Live2D] 检测到模型移出当前屏幕，准备切换到屏幕:', targetDisplay.id);
+
+            const result = await window.electronScreen.moveWindowToDisplay(modelScreenX, modelScreenY);
+            if (result && result.success && !result.sameDisplay) {
+                if (result.scaleRatio && result.scaleRatio !== 1) {
+                    // 不同屏缩放比变化时保持模型原大小，仅调整位置。
+                    console.log('[Live2D] 屏幕缩放比变化:', result.scaleRatio);
+                }
+
+                // 把模型放到新窗口内对应位置：模型视觉中心 = 屏幕坐标 − 新窗口屏幕原点，再换算回 canvas 坐标。
+                // 该坐标只依赖目标显示器 DIP 原点和 canvasScaleFactor，与窗口/缓冲区是否已 resize 无关；
+                // 命中目标屏说明中心点必落在 [0,target.width)×[0,target.height) 内，故无需再 clamp。
+                const targetCenterX = (modelScreenX - targetDisplay.screenX) * sf;
+                const targetCenterY = (modelScreenY - targetDisplay.screenY) * sf;
+                const b2 = this.model.getBounds();
+                const curCenterX = (b2.left + b2.right) / 2;
+                const curCenterY = (b2.top + b2.bottom) / 2;
+                this.model.x += targetCenterX - curCenterX;
+                this.model.y += targetCenterY - curCenterY;
+                this.updateInteractionArea();
+
+                // 保存：用“目标显示器的 DIP 尺寸”算相对位置，避免依赖跨屏后仍在重申/尚未稳定的 innerWidth。
+                this.saveModelPosition(targetDisplay.width, targetDisplay.height);
+                console.log('[Live2D] 跨屏切换完成，模型新位置:', this.model.x, this.model.y);
+                return true;
+            }
+            return false;
+        } catch (error) {
+            console.error('[Live2D] 跨屏检测/切换出错:', error);
+            return false;
+        }
+    }
+
+    // 若模型中心越出当前窗口，吸回窗口内（保持中心位于 [0,innerWidth]×[0,innerHeight]，canvas 坐标）。
+    _clampModelToWindow() {
+        if (!this.model) return;
+        const sf = window.canvasScaleFactor || 2;
+        const maxX = window.innerWidth * sf;
+        const maxY = window.innerHeight * sf;
+        const b = this.model.getBounds();
+        const cx = (b.left + b.right) / 2;
+        const cy = (b.top + b.bottom) / 2;
+        const clampedX = Math.min(Math.max(cx, 0), maxX);
+        const clampedY = Math.min(Math.max(cy, 0), maxY);
+        if (clampedX !== cx || clampedY !== cy) {
+            this.model.x += clampedX - cx;
+            this.model.y += clampedY - cy;
+            this.updateInteractionArea();
+        }
     }
 
 
@@ -318,23 +414,25 @@ class ModelInteractionController {
         const actualHeight = window.actualHeight || window.innerHeight;
         const scaleFactor = window.canvasScaleFactor || 2;
 
-        const scaleX = (actualWidth * scaleMultiplier) / this.model.width;
-        const scaleY = (actualHeight * scaleMultiplier) / this.model.height;
         this.model.scale.set(scaleMultiplier);
 
-        const isDualRight = window.innerWidth > window.screen.width * 1.2 && this.config?.ui?.screen_extend?.right;
+        // 窗口已由主进程落在“上次所在的显示器”，这里只按当前显示器内的相对位置摆放，
+        // 不再依据 isDualRight 切换 x_dual/y_dual。
         const pos = this.config?.ui?.model_position;
-        const defaultRelX = isDualRight ? (pos?.x_dual ?? 0.825) : (pos?.x ?? 0.65);
-        const defaultRelY = isDualRight ? (pos?.y_dual ?? 0.38) : (pos?.y ?? 0.38);
+        const defaultRelX = pos?.x ?? 0.65;
+        const defaultRelY = pos?.y ?? 0.38;
 
         this.model.x = defaultRelX * actualWidth * scaleFactor;
         this.model.y = defaultRelY * actualHeight * scaleFactor;
 
         this.updateInteractionArea();
+        // 防御：若配置里存了越界的相对位置（例如旧版跨屏 bug 导致的负值），启动时吸回当前窗口内。
+        this._clampModelToWindow();
     }
 
     // 保存模型位置到配置文件
-    saveModelPosition() {
+    // 只保存“当前显示器内的相对位置（0~1）”；所在显示器的屏幕原点由主进程附加（save-model-position）。
+    saveModelPosition(overrideWidth, overrideHeight) {
         if (!this.model || !this.config) return;
 
         // 检查是否启用位置记忆
@@ -342,12 +440,12 @@ class ModelInteractionController {
             return;
         }
 
-        // 使用实际窗口尺寸计算相对位置
-        const actualWidth = window.actualWidth || window.innerWidth;
-        const actualHeight = window.actualHeight || window.innerHeight;
+        // 计算相对位置的基准宽高：跨屏切换时传入“目标显示器的 DIP 尺寸”，避免依赖尚未稳定的 innerWidth。
+        const actualWidth = overrideWidth || window.actualWidth || window.innerWidth;
+        const actualHeight = overrideHeight || window.actualHeight || window.innerHeight;
         const scaleFactor = window.canvasScaleFactor || 2;
 
-        //将canvas坐标转换为相对于窗口的坐标，在计算相对位置
+        //将canvas坐标转换为相对于窗口的坐标，再计算相对位置
         const windowX = this.model.x / scaleFactor;
         const windowY = this.model.y / scaleFactor;
 
@@ -355,26 +453,18 @@ class ModelInteractionController {
         const relativeX = windowX / actualWidth;
         const relativeY = windowY / actualHeight;
 
-        const isDualRight = window.innerWidth > window.screen.width * 1.2 && this.config?.ui?.screen_extend?.right;
-
         // 更新配置对象
-        if (isDualRight) {
-            this.config.ui.model_position.x_dual = relativeX;
-            this.config.ui.model_position.y_dual = relativeY;
-        } else {
-            this.config.ui.model_position.x = relativeX;
-            this.config.ui.model_position.y = relativeY;
-        }
+        this.config.ui.model_position.x = relativeX;
+        this.config.ui.model_position.y = relativeY;
 
-        // 发送IPC消息保存位置
+        // 发送IPC消息保存位置（dual 字段已废弃；显示器原点由主进程根据窗口位置写入）
         ipcRenderer.send('save-model-position', {
             x: relativeX,
             y: relativeY,
-            scale: this.model.scale.x,
-            dual: isDualRight
+            scale: this.model.scale.x
         });
 
-        console.log('保存模型位置:', { 
+        console.log('保存模型位置:', {
             canvasPos: { x: this.model.x, y: this.model.y },
             windowPos: { x: windowX, y: windowY },
             relativePos: { x: relativeX, y: relativeY },

--- a/live-2d/js/model/model-interaction.js
+++ b/live-2d/js/model/model-interaction.js
@@ -112,11 +112,11 @@ class ModelInteractionController {
         });
 
         // 全局鼠标释放事件
-        window.addEventListener('mouseup', async () => {
+        window.addEventListener('mouseup', async (e) => {
             if (this.isDragging) {
                 this.isDragging = false;
-                // 松手时先检测模型中心是否越出当前窗口，若是则整窗重定位到目标显示器。
-                const switched = await this.checkAndSwitchDisplay();
+                // 松手时若“光标拖到了窗口边缘 + 模型越过该边”，则整窗重定位到那一侧的显示器。
+                const switched = await this.checkAndSwitchDisplay(e.clientX, e.clientY);
                 if (!switched) {
                     // 未切屏：若模型中心越出当前窗口（目标屏不存在），吸回窗口内，避免模型“走丢”。
                     this._clampModelToWindow();
@@ -278,65 +278,72 @@ class ModelInteractionController {
         });
     }
 
-    // ===== 跨屏：松手时检测模型是否越出当前窗口，并整窗重定位到目标显示器 =====
-    // 把模型中心换算成屏幕绝对坐标来判断目标屏；
-    // 适配 myneuro 的坐标约定：canvas 坐标 = 窗口 CSS 坐标 × canvasScaleFactor(=2)。
-    async checkAndSwitchDisplay() {
+    // ===== 跨屏：松手时若“光标拖到窗口边缘 + 模型越过该边”，整窗重定位到那一侧的显示器 =====
+    // 触发用“光标贴边(EDGE 内) 且 模型可见区也越过该边”双重确认：光标到边缘=明确要往那侧推出去，
+    // 松手在屏幕中间不会误触；光标永远能拖到边缘，故四向、任意抓取点都对称。
+    // 坐标约定：canvas 坐标 = 窗口 CSS 坐标 × canvasScaleFactor(=2)，getBounds 返回 canvas 坐标。
+    // cursorX/cursorY：松手时光标在当前窗口的 CSS 像素坐标。
+    async checkAndSwitchDisplay(cursorX, cursorY) {
         // 仅在 Electron 桥接可用时执行
         if (!window.electronScreen || !window.electronScreen.moveWindowToDisplay) return false;
         if (!this.model) return false;
+        if (!Number.isFinite(cursorX) || !Number.isFinite(cursorY)) return false;
 
         try {
-            const sf = window.canvasScaleFactor || 2;
-
-            // 模型中心（canvas 坐标）→ 当前窗口 CSS 坐标
-            const bounds = this.model.getBounds();
-            const modelCenterX = ((bounds.left + bounds.right) / 2) / sf;
-            const modelCenterY = ((bounds.top + bounds.bottom) / 2) / sf;
-
             const displays = await window.electronScreen.getAllDisplays();
             if (!displays || displays.length <= 1) return false;
-
-            const windowWidth = window.innerWidth;
-            const windowHeight = window.innerHeight;
-            // 模型中心仍在当前窗口内 → 不切屏
-            if (modelCenterX >= 0 && modelCenterX < windowWidth &&
-                modelCenterY >= 0 && modelCenterY < windowHeight) {
-                return false;
-            }
-
             const currentDisplay = await window.electronScreen.getCurrentDisplay();
             if (!currentDisplay) return false;
 
-            // 模型中心的屏幕绝对坐标
-            const modelScreenX = currentDisplay.screenX + modelCenterX;
-            const modelScreenY = currentDisplay.screenY + modelCenterY;
+            const sf = window.canvasScaleFactor || 2;
+            const W = window.innerWidth, H = window.innerHeight;
+            // 模型可见区域在当前窗口 client 像素下的边界（getBounds 是 canvas 坐标，÷sf 回到 client）
+            const b = this.model.getBounds();
+            const vLeft = b.left / sf, vRight = b.right / sf, vTop = b.top / sf, vBottom = b.bottom / sf;
 
-            // 找到包含该点的目标显示器
-            let targetDisplay = null;
-            for (const d of displays) {
-                if (modelScreenX >= d.screenX && modelScreenX < d.screenX + d.width &&
-                    modelScreenY >= d.screenY && modelScreenY < d.screenY + d.height) {
-                    targetDisplay = d;
-                    break;
+            // 光标贴到哪条边(EDGE 内) 且 模型也越过该边，就在那侧“边外一点”探测目标显示器；另一轴用光标位置。
+            const EDGE = 10;
+            const sX = currentDisplay.screenX, sY = currentDisplay.screenY;
+            const probes = [];
+            if (cursorX <= EDGE && vLeft < 0)       probes.push({ x: sX - 1,      y: sY + cursorY });
+            if (cursorX >= W - EDGE && vRight > W)   probes.push({ x: sX + W + 1,  y: sY + cursorY });
+            if (cursorY <= EDGE && vTop < 0)        probes.push({ x: sX + cursorX, y: sY - 1 });
+            if (cursorY >= H - EDGE && vBottom > H)  probes.push({ x: sX + cursorX, y: sY + H + 1 });
+
+            let targetDisplay = null, probe = null;
+            for (const p of probes) {
+                for (const d of displays) {
+                    if (d.id === currentDisplay.id) continue;
+                    if (p.x >= d.screenX && p.x < d.screenX + d.width &&
+                        p.y >= d.screenY && p.y < d.screenY + d.height) {
+                        targetDisplay = d; probe = p; break;
+                    }
                 }
+                if (targetDisplay) break;
             }
             if (!targetDisplay) return false;
 
-            console.log('[Live2D] 检测到模型移出当前屏幕，准备切换到屏幕:', targetDisplay.id);
+            console.log('[Live2D] 光标拖到屏幕边缘，准备切换到屏幕:', targetDisplay.id);
 
-            const result = await window.electronScreen.moveWindowToDisplay(modelScreenX, modelScreenY);
+            const result = await window.electronScreen.moveWindowToDisplay(probe.x, probe.y);
             if (result && result.success && !result.sameDisplay) {
                 if (result.scaleRatio && result.scaleRatio !== 1) {
-                    // 不同屏缩放比变化时保持模型原大小，仅调整位置。
                     console.log('[Live2D] 屏幕缩放比变化:', result.scaleRatio);
                 }
 
-                // 把模型放到新窗口内对应位置：模型视觉中心 = 屏幕坐标 − 新窗口屏幕原点，再换算回 canvas 坐标。
-                // 该坐标只依赖目标显示器 DIP 原点和 canvasScaleFactor，与窗口/缓冲区是否已 resize 无关；
-                // 命中目标屏说明中心点必落在 [0,target.width)×[0,target.height) 内，故无需再 clamp。
-                const targetCenterX = (modelScreenX - targetDisplay.screenX) * sf;
-                const targetCenterY = (modelScreenY - targetDisplay.screenY) * sf;
+                // 以探测点为视觉中心，夹住可见模型完整落入目标屏（目标屏 DIP 尺寸），换算到 canvas 后用 delta 落位。
+                const tw = targetDisplay.width, th = targetDisplay.height;
+                const halfVisW = (vRight - vLeft) / 2;
+                const halfVisH = (vBottom - vTop) / 2;
+                const margin = 16;
+                let cx = probe.x - targetDisplay.screenX;
+                let cy = probe.y - targetDisplay.screenY;
+                const loX = margin + halfVisW, hiX = tw - margin - halfVisW;
+                const loY = margin + halfVisH, hiY = th - margin - halfVisH;
+                cx = hiX >= loX ? Math.min(Math.max(cx, loX), hiX) : tw / 2;
+                cy = hiY >= loY ? Math.min(Math.max(cy, loY), hiY) : th / 2;
+
+                const targetCenterX = cx * sf, targetCenterY = cy * sf; // canvas 坐标
                 const b2 = this.model.getBounds();
                 const curCenterX = (b2.left + b2.right) / 2;
                 const curCenterY = (b2.top + b2.bottom) / 2;
@@ -345,7 +352,7 @@ class ModelInteractionController {
                 this.updateInteractionArea();
 
                 // 保存：用“目标显示器的 DIP 尺寸”算相对位置，避免依赖跨屏后仍在重申/尚未稳定的 innerWidth。
-                this.saveModelPosition(targetDisplay.width, targetDisplay.height);
+                this.saveModelPosition(tw, th);
                 console.log('[Live2D] 跨屏切换完成，模型新位置:', this.model.x, this.model.y);
                 return true;
             }

--- a/live-2d/js/model/vrm-model-interaction.js
+++ b/live-2d/js/model/vrm-model-interaction.js
@@ -6,6 +6,8 @@ const VRM_VIEWPORT_ASPECT = 1.5;   // 视口高宽比（height / width）
 const VRM_SCALE_FACTOR = 0.896;    // saved_scale * factor = viewport_width / innerWidth
 const VRM_PADDING_X = 0.104;       // 模型左边缘在视口中的水平偏移（占视口宽度比例）
 const VRM_PADDING_Y = 0.282;       // 模型顶部在视口中的垂直偏移（占视口高度比例）
+// 模型可见区域的垂直中心占视口高度的比例（上 VRM_PADDING_Y、下 0.96 之间的中点），用于跨屏中心判定
+const VRM_CENTER_Y_FRAC = (VRM_PADDING_Y + 0.96) / 2;
 
 // VRM模型交互控制器
 class VRMInteractionController {
@@ -282,7 +284,7 @@ class VRMInteractionController {
             }
         });
 
-        window.addEventListener('mouseup', (e) => {
+        window.addEventListener('mouseup', async (e) => {
             if (e.button === 0 && this.isDragging) {
                 this.isDragging = false;
 
@@ -298,8 +300,12 @@ class VRMInteractionController {
                     }
                 }
 
-                this._clampViewRect();
-                this.saveModelPosition();
+                // 松手时检测模型是否越出当前窗口并整窗重定位到目标显示器。
+                const switched = await this.checkAndSwitchDisplay();
+                if (!switched) {
+                    this._clampViewRect();
+                    this.saveModelPosition();
+                }
 
                 setTimeout(() => {
                     if (!model.containsPoint({ x: e.clientX, y: e.clientY })) {
@@ -387,6 +393,72 @@ class VRMInteractionController {
         });
     }
 
+    // ===== 跨屏：松手时检测模型是否越出当前窗口，并整窗重定位到目标显示器 =====
+    // VRM 在 client/CSS 像素下工作（渲染器 1:1，无 ×2）。
+    async checkAndSwitchDisplay() {
+        if (!window.electronScreen || !window.electronScreen.moveWindowToDisplay) return false;
+        if (!this.model || !this.model.viewRect) return false;
+
+        try {
+            const vr = this.model.viewRect;
+            // 模型“可见区域”的视觉中心（client 像素）
+            const modelCenterX = vr.x + 0.5 * vr.width;
+            const modelCenterY = vr.y + VRM_CENTER_Y_FRAC * vr.height;
+
+            const displays = await window.electronScreen.getAllDisplays();
+            if (!displays || displays.length <= 1) return false;
+
+            const windowWidth = window.innerWidth;
+            const windowHeight = window.innerHeight;
+            // 模型中心仍在当前窗口内 → 不切屏
+            if (modelCenterX >= 0 && modelCenterX < windowWidth &&
+                modelCenterY >= 0 && modelCenterY < windowHeight) {
+                return false;
+            }
+
+            const currentDisplay = await window.electronScreen.getCurrentDisplay();
+            if (!currentDisplay) return false;
+
+            const modelScreenX = currentDisplay.screenX + modelCenterX;
+            const modelScreenY = currentDisplay.screenY + modelCenterY;
+
+            let targetDisplay = null;
+            for (const d of displays) {
+                if (modelScreenX >= d.screenX && modelScreenX < d.screenX + d.width &&
+                    modelScreenY >= d.screenY && modelScreenY < d.screenY + d.height) {
+                    targetDisplay = d;
+                    break;
+                }
+            }
+            if (!targetDisplay) return false;
+
+            console.log('[VRM] 检测到模型移出当前屏幕，准备切换到屏幕:', targetDisplay.id);
+            const result = await window.electronScreen.moveWindowToDisplay(modelScreenX, modelScreenY);
+            if (result && result.success && !result.sameDisplay) {
+                if (result.scaleRatio && result.scaleRatio !== 1) {
+                    // 保持模型原大小，仅调整位置。
+                    console.log('[VRM] 屏幕缩放比变化:', result.scaleRatio);
+                }
+
+                // 模型视觉中心放到新窗口内对应位置（client 像素，无 ×2）。只依赖目标屏 DIP 原点，与 resize 无关；
+                // 命中目标屏说明中心点必在目标屏范围内，无需再 clamp。
+                const newCenterX = modelScreenX - targetDisplay.screenX;
+                const newCenterY = modelScreenY - targetDisplay.screenY;
+                this.model.viewRect.x = newCenterX - 0.5 * this.model.viewRect.width;
+                this.model.viewRect.y = newCenterY - VRM_CENTER_Y_FRAC * this.model.viewRect.height;
+
+                // 保存：用目标显示器 DIP 尺寸作基准，避免依赖跨屏后尚未稳定的 innerWidth。
+                this.saveModelPosition(targetDisplay.width, targetDisplay.height);
+                console.log('[VRM] 跨屏切换完成，viewRect:', this.model.viewRect);
+                return true;
+            }
+            return false;
+        } catch (error) {
+            console.error('[VRM] 跨屏检测/切换出错:', error);
+            return false;
+        }
+    }
+
 
    // 设置嘴部动画
     setMouthOpenY(v) {
@@ -438,12 +510,12 @@ class VRMInteractionController {
     }
 
     // 保存VRM视口位置（Live2D兼容格式）
-    saveModelPosition() {
+    saveModelPosition(overrideWidth, overrideHeight) {
         if (!this.model || !this.config) return;
         const vr = this.model.viewRect;
         if (!vr || !this.config.ui?.model_position?.remember_position) return;
 
-        const saved = this._viewRectToSaved();
+        const saved = this._viewRectToSaved(overrideWidth, overrideHeight);
         this.config.ui.model_position.x = saved.x;
         this.config.ui.model_position.y = saved.y;
         this.config.ui.model_scale = saved.scale;
@@ -469,10 +541,11 @@ class VRMInteractionController {
     }
 
     // 将VRM视口矩形转换为Live2D兼容保存值
-    _viewRectToSaved() {
+    // overrideWidth/Height：跨屏切换时传入“目标显示器的 DIP 尺寸”，避免依赖尚未稳定的 innerWidth。
+    _viewRectToSaved(overrideWidth, overrideHeight) {
         const vr = this.model.viewRect;
-        const iW = window.innerWidth;
-        const iH = window.innerHeight;
+        const iW = overrideWidth || window.innerWidth;
+        const iH = overrideHeight || window.innerHeight;
         return {
             x: (vr.x + VRM_PADDING_X * vr.width) * 2 / iW,
             y: (vr.y + VRM_PADDING_Y * vr.height) * 2 / iH,

--- a/live-2d/js/model/vrm-model-interaction.js
+++ b/live-2d/js/model/vrm-model-interaction.js
@@ -300,8 +300,8 @@ class VRMInteractionController {
                     }
                 }
 
-                // 松手时检测模型是否越出当前窗口并整窗重定位到目标显示器。
-                const switched = await this.checkAndSwitchDisplay();
+                // 松手时若“光标拖到了窗口边缘 + 模型越过该边”，整窗重定位到那一侧的显示器。
+                const switched = await this.checkAndSwitchDisplay(e.clientX, e.clientY);
                 if (!switched) {
                     this._clampViewRect();
                     this.saveModelPosition();
@@ -393,62 +393,75 @@ class VRMInteractionController {
         });
     }
 
-    // ===== 跨屏：松手时检测模型是否越出当前窗口，并整窗重定位到目标显示器 =====
-    // VRM 在 client/CSS 像素下工作（渲染器 1:1，无 ×2）。
-    async checkAndSwitchDisplay() {
+    // ===== 跨屏：松手时若“光标拖到窗口边缘 + 模型越过该边”，整窗重定位到那一侧的显示器 =====
+    // 触发用“光标贴边(EDGE 内) 且 模型可见区也越过该边”双重确认：光标到边缘=明确要往那侧推出去，
+    // 松手在屏幕中间不会误触；光标永远能拖到边缘，故四向、任意抓取点都对称。
+    // VRM 在 client/CSS 像素下工作（渲染器 1:1，无 ×2）。cursorX/cursorY：松手时光标的窗口 CSS 坐标。
+    async checkAndSwitchDisplay(cursorX, cursorY) {
         if (!window.electronScreen || !window.electronScreen.moveWindowToDisplay) return false;
         if (!this.model || !this.model.viewRect) return false;
+        if (!Number.isFinite(cursorX) || !Number.isFinite(cursorY)) return false;
 
         try {
-            const vr = this.model.viewRect;
-            // 模型“可见区域”的视觉中心（client 像素）
-            const modelCenterX = vr.x + 0.5 * vr.width;
-            const modelCenterY = vr.y + VRM_CENTER_Y_FRAC * vr.height;
-
             const displays = await window.electronScreen.getAllDisplays();
             if (!displays || displays.length <= 1) return false;
-
-            const windowWidth = window.innerWidth;
-            const windowHeight = window.innerHeight;
-            // 模型中心仍在当前窗口内 → 不切屏
-            if (modelCenterX >= 0 && modelCenterX < windowWidth &&
-                modelCenterY >= 0 && modelCenterY < windowHeight) {
-                return false;
-            }
-
             const currentDisplay = await window.electronScreen.getCurrentDisplay();
             if (!currentDisplay) return false;
 
-            const modelScreenX = currentDisplay.screenX + modelCenterX;
-            const modelScreenY = currentDisplay.screenY + modelCenterY;
+            const vr = this.model.viewRect;
+            const W = window.innerWidth, H = window.innerHeight;
+            // 模型可见区域在当前窗口 client 像素下的边界
+            const vLeft = vr.x + VRM_PADDING_X * vr.width;
+            const vRight = vr.x + (1 - VRM_PADDING_X) * vr.width;
+            const vTop = vr.y + VRM_PADDING_Y * vr.height;
+            const vBottom = vr.y + 0.96 * vr.height;
 
-            let targetDisplay = null;
-            for (const d of displays) {
-                if (modelScreenX >= d.screenX && modelScreenX < d.screenX + d.width &&
-                    modelScreenY >= d.screenY && modelScreenY < d.screenY + d.height) {
-                    targetDisplay = d;
-                    break;
+            // 光标贴到哪条边(EDGE 内) 且 模型也越过该边，就在那侧“边外一点”探测目标显示器；另一轴用光标位置。
+            const EDGE = 10;
+            const sX = currentDisplay.screenX, sY = currentDisplay.screenY;
+            const probes = [];
+            if (cursorX <= EDGE && vLeft < 0)       probes.push({ x: sX - 1,      y: sY + cursorY });
+            if (cursorX >= W - EDGE && vRight > W)   probes.push({ x: sX + W + 1,  y: sY + cursorY });
+            if (cursorY <= EDGE && vTop < 0)        probes.push({ x: sX + cursorX, y: sY - 1 });
+            if (cursorY >= H - EDGE && vBottom > H)  probes.push({ x: sX + cursorX, y: sY + H + 1 });
+
+            let targetDisplay = null, probe = null;
+            for (const p of probes) {
+                for (const d of displays) {
+                    if (d.id === currentDisplay.id) continue;
+                    if (p.x >= d.screenX && p.x < d.screenX + d.width &&
+                        p.y >= d.screenY && p.y < d.screenY + d.height) {
+                        targetDisplay = d; probe = p; break;
+                    }
                 }
+                if (targetDisplay) break;
             }
             if (!targetDisplay) return false;
 
-            console.log('[VRM] 检测到模型移出当前屏幕，准备切换到屏幕:', targetDisplay.id);
-            const result = await window.electronScreen.moveWindowToDisplay(modelScreenX, modelScreenY);
+            console.log('[VRM] 光标拖到屏幕边缘，准备切换到屏幕:', targetDisplay.id);
+            const result = await window.electronScreen.moveWindowToDisplay(probe.x, probe.y);
             if (result && result.success && !result.sameDisplay) {
                 if (result.scaleRatio && result.scaleRatio !== 1) {
-                    // 保持模型原大小，仅调整位置。
                     console.log('[VRM] 屏幕缩放比变化:', result.scaleRatio);
                 }
 
-                // 模型视觉中心放到新窗口内对应位置（client 像素，无 ×2）。只依赖目标屏 DIP 原点，与 resize 无关；
-                // 命中目标屏说明中心点必在目标屏范围内，无需再 clamp。
-                const newCenterX = modelScreenX - targetDisplay.screenX;
-                const newCenterY = modelScreenY - targetDisplay.screenY;
-                this.model.viewRect.x = newCenterX - 0.5 * this.model.viewRect.width;
-                this.model.viewRect.y = newCenterY - VRM_CENTER_Y_FRAC * this.model.viewRect.height;
+                // 以探测点为视觉中心放到新窗口，再夹住可见模型完整落入目标屏（用目标屏 DIP 尺寸，免受 innerWidth 未稳定影响）。
+                const tw = targetDisplay.width, th = targetDisplay.height;
+                const halfVisW = (vRight - vLeft) / 2;
+                const halfVisH = (vBottom - vTop) / 2; // VRM_CENTER_Y_FRAC 取可见区上下中点，故上下对称
+                const margin = 16;
+                let cx = probe.x - targetDisplay.screenX;
+                let cy = probe.y - targetDisplay.screenY;
+                const loX = margin + halfVisW, hiX = tw - margin - halfVisW;
+                const loY = margin + halfVisH, hiY = th - margin - halfVisH;
+                cx = hiX >= loX ? Math.min(Math.max(cx, loX), hiX) : tw / 2;
+                cy = hiY >= loY ? Math.min(Math.max(cy, loY), hiY) : th / 2;
+
+                this.model.viewRect.x = cx - 0.5 * vr.width;
+                this.model.viewRect.y = cy - VRM_CENTER_Y_FRAC * vr.height;
 
                 // 保存：用目标显示器 DIP 尺寸作基准，避免依赖跨屏后尚未稳定的 innerWidth。
-                this.saveModelPosition(targetDisplay.width, targetDisplay.height);
+                this.saveModelPosition(tw, th);
                 console.log('[VRM] 跨屏切换完成，viewRect:', this.model.viewRect);
                 return true;
             }

--- a/live-2d/js/services/electron-screen-bridge.js
+++ b/live-2d/js/services/electron-screen-bridge.js
@@ -1,0 +1,58 @@
+// electron-screen-bridge.js
+// 为渲染端提供 window.electronScreen 桥接，供跨屏逻辑查询显示器 / 重定位窗口。
+//
+// 本应用使用 nodeIntegration:true / contextIsolation:false，没有 preload，所以这里直接把对象挂到
+// window 上即可，渲染端的跨屏逻辑（model-interaction.js / vrm-model-interaction.js）通过它调用主进程。
+const { ipcRenderer } = require('electron');
+
+window.electronScreen = {
+    getAllDisplays: () => ipcRenderer.invoke('get-all-displays'),
+    getCurrentDisplay: () => ipcRenderer.invoke('get-current-display'),
+    moveWindowToDisplay: (screenX, screenY) => ipcRenderer.invoke('move-window-to-display', screenX, screenY),
+    getPrimaryDisplayInfo: () => ipcRenderer.invoke('get-primary-display-info'),
+};
+
+// 缓存当前显示器信息（供需要同步读取的逻辑使用）
+window.__petCurrentDisplay = null;
+function refreshCurrentDisplay() {
+    return window.electronScreen.getCurrentDisplay()
+        .then((d) => { window.__petCurrentDisplay = d; return d; })
+        .catch(() => null);
+}
+refreshCurrentDisplay();
+
+// 跨屏重定位后：主进程 setBounds 把窗口移到新屏并广播 'display-changed'。
+// 窗口尺寸变化会触发原生 resize 事件（各模型的 resize 处理器据此重建渲染缓冲区）；
+// 这里额外把 canvas 的 CSS 尺寸 / 全局尺寸刷新到新屏，避免 2x canvas 的 CSS 尺寸停留在旧屏导致拉伸。
+ipcRenderer.on('display-changed', (event, info) => {
+    console.log('[electron-screen-bridge] display-changed:', info);
+    if (info && info.bounds) {
+        window.__petCurrentDisplay = {
+            id: info.displayId,
+            screenX: info.bounds.x,
+            screenY: info.bounds.y,
+            width: info.bounds.width,
+            height: info.bounds.height,
+            scaleFactor: info.scaleFactor,
+        };
+    }
+    // 等窗口实际 resize 落地后再刷新 CSS / 全局尺寸（两帧：一帧给 setBounds，一帧给 resize 事件）
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            const w = window.innerWidth;
+            const h = window.innerHeight;
+            window.actualWindowWidth = w;
+            window.actualWindowHeight = h;
+            const canvas = document.getElementById('canvas');
+            if (canvas) {
+                canvas.style.width = w + 'px';
+                canvas.style.height = h + 'px';
+            }
+            // 再触发一次 resize，确保各模型 resize 处理器以新屏尺寸重建缓冲区
+            window.dispatchEvent(new Event('resize'));
+            refreshCurrentDisplay();
+        });
+    });
+});
+
+module.exports = {};

--- a/live-2d/js/services/http-server.js
+++ b/live-2d/js/services/http-server.js
@@ -209,8 +209,8 @@ class HttpServer {
 		            const { ipcRenderer } = require('electron');
 		            const model = mc.model;
 		            const scaleFactor = window.canvasScaleFactor || 2;
-		            const isDualRight = window.innerWidth > window.screen.width * 1.2 && mc.config?.ui?.screen_extend?.right;
-		            const relX = isDualRight ? 0.825 : 0.65;
+		            // 窗口只覆盖当前显示器，重置到当前窗口内的默认相对位置即可（不再区分单/双屏）。
+		            const relX = 0.65;
 		            const relY = 0.38;
 		            const scale = 0.65;
 
@@ -226,7 +226,7 @@ class HttpServer {
 		                if (mc.updateInteractionArea) mc.updateInteractionArea();
 		            }
 		
-		            ipcRenderer.send('save-model-position', { x: relX, y: relY, scale, dual: isDualRight });
+		            ipcRenderer.send('save-model-position', { x: relX, y: relY, scale });
 
 		            // 同步复位字幕位置
 		            const uic = global.uiController;

--- a/live-2d/js/ui/ui-controller.js
+++ b/live-2d/js/ui/ui-controller.js
@@ -31,15 +31,27 @@ class UIController {
 
     // 设置鼠标穿透
     setupMouseIgnore() {
-        const updateMouseIgnore = () => {
+        // 这些可交互 UI 容器悬停时必须“不穿透”，否则点击会穿过去。
+        // 快捷面板(#quick-settings)原本没被纳入判定，只靠模型命中盒蹭——单屏布局下齿轮落在
+        // 命中盒外就点不动了。这里统一把它们纳入：鼠标在这些元素上时保持窗口可交互。
+        const INTERACTIVE_UI = '#quick-settings, #text-chat-container, #model-controls';
+        const updateMouseIgnore = (e) => {
             if (!global.currentModel) return;
             if (this.isAdjustingSubtitle) return;
 
-            const shouldIgnore = !global.currentModel.containsPoint(
+            // 鼠标悬在可交互 UI 元素上 → 不穿透
+            let overUI = false;
+            if (e) {
+                const el = document.elementFromPoint(e.clientX, e.clientY);
+                if (el && el.closest && el.closest(INTERACTIVE_UI)) overUI = true;
+            }
+
+            const overModel = global.currentModel.containsPoint(
                 global.pixiApp.renderer.plugins.interaction.mouse.global
             );
+
             ipcRenderer.send('set-ignore-mouse-events', {
-                ignore: shouldIgnore,
+                ignore: !overModel && !overUI,
                 options: { forward: true }
             });
         };
@@ -55,9 +67,6 @@ class UIController {
 
         if (!chatInput || !textChatContainer || !submitBtn) return;
 
-        // 强制固定对话框位置逻辑
-        const screenExtend = this.config.ui?.screen_extend || { extend: false, left: false, right: true };
-        
         // 基础定位样式
         textChatContainer.style.setProperty('position', 'fixed', 'important');
         textChatContainer.style.setProperty('z-index', '10000', 'important');
@@ -78,54 +87,22 @@ class UIController {
             textChatContainer.style.setProperty('opacity', '0', 'important');
         }
 
-        // 统一使用屏幕信息进行定位，确保无论是否扩展，对话框都显示在主屏右下角
-        const screenInfo = ipcRenderer.sendSync('get-screen-info-sync');
-        if (screenInfo) {
-            const { primaryDisplay, windowBounds } = screenInfo;
-            
-            // 使用主进程返回的实际窗口边界，确保坐标系完全匹配
-            const winX = windowBounds ? windowBounds.x : 0;
-            const winY = windowBounds ? windowBounds.y : 0;
-            const winH = windowBounds ? windowBounds.height : window.innerHeight;
-            
-            // 计算主屏相对于窗口左侧和底部的偏移
-            // 窗口坐标 (0,0) 对应屏幕坐标 (winX, winY)
-            const primaryLeftOffset = primaryDisplay.bounds.x - winX;
-            const primaryTopOffset = primaryDisplay.bounds.y - winY;
-            const primaryBottomOffset = winH - (primaryTopOffset + primaryDisplay.bounds.height);
+        // 窗口只覆盖“当前显示器”，聊天框/字幕直接锚定到本窗口的右下角即可，
+        // 不再需要 get-screen-info-sync 把坐标换算到主屏（那是旧巨型跨屏窗口才需要的）。
+        textChatContainer.style.setProperty('left', 'auto', 'important');
+        textChatContainer.style.setProperty('right', '20px', 'important');
+        textChatContainer.style.setProperty('bottom', '50px', 'important');
 
-            // 始终定位到主屏右下角 (相对于窗口左侧)
-            // 350是对话框宽度，20是右边距
-            const rightPos = primaryLeftOffset + primaryDisplay.bounds.width - 350 - 20;
-            
-            textChatContainer.style.setProperty('left', rightPos + 'px', 'important');
-            textChatContainer.style.setProperty('right', 'auto', 'important');
-            textChatContainer.style.setProperty('bottom', (primaryBottomOffset + 50) + 'px', 'important');
-
-            // 同时确保字幕容器在主屏显示
-            const subtitleContainer = document.getElementById('subtitle-container');
-            if (subtitleContainer) {
-                subtitleContainer.style.setProperty('position', 'fixed', 'important');
-                subtitleContainer.style.setProperty('bottom', (primaryBottomOffset + 20) + 'px', 'important');
-                // 字幕在主屏右下角距离屏幕右侧800px处开始显示，显示范围不超过400px/行
-                const subtitleLeft = primaryLeftOffset + primaryDisplay.bounds.width - 800;
-                subtitleContainer.style.setProperty('left', subtitleLeft + 'px', 'important');
-                subtitleContainer.style.setProperty('width', '400px', 'important');
-                subtitleContainer.style.setProperty('max-width', '400px', 'important');
-                subtitleContainer.style.setProperty('transform', 'none', 'important');
-                subtitleContainer.style.setProperty('display', 'block', 'important');
-            }
-
-            console.log('跨屏定位调试:', {
-                winX, winY, winH,
-                primaryX: primaryDisplay.bounds.x,
-                primaryY: primaryDisplay.bounds.y,
-                primaryW: primaryDisplay.bounds.width,
-                primaryH: primaryDisplay.bounds.height,
-                primaryLeftOffset,
-                primaryBottomOffset,
-                rightPos
-            });
+        const subtitleContainer = document.getElementById('subtitle-container');
+        if (subtitleContainer) {
+            subtitleContainer.style.setProperty('position', 'fixed', 'important');
+            subtitleContainer.style.setProperty('left', 'auto', 'important');
+            subtitleContainer.style.setProperty('right', '20px', 'important');
+            subtitleContainer.style.setProperty('bottom', '20px', 'important');
+            subtitleContainer.style.setProperty('width', '400px', 'important');
+            subtitleContainer.style.setProperty('max-width', '400px', 'important');
+            subtitleContainer.style.setProperty('transform', 'none', 'important');
+            subtitleContainer.style.setProperty('display', 'block', 'important');
         }
 
         textChatContainer.addEventListener('mouseenter', () => {

--- a/live-2d/main.js
+++ b/live-2d/main.js
@@ -57,6 +57,107 @@ function ensureTopMost(win) {
     }
 }
 
+// ===== 跨屏方案辅助函数 =====
+// 单显示器全屏边界：左/上各内缩 1px，破坏“起点贴齐 + size 等于 display”的完美全屏判定，
+// 规避 DWM/Chromium borderless-fullscreen / 遮挡优化带来的副作用（后台视频暂停、播放器卡顿等）。
+// 用于把窗口尺寸定为单个显示器的全屏填充范围。
+function getFullscreenDisplayBounds(display) {
+    const b = display && display.bounds ? display.bounds : { x: 0, y: 0, width: 1280, height: 720 };
+    return {
+        x: b.x + 1,
+        y: b.y + 1,
+        width: Math.max(1, b.width - 1),
+        height: Math.max(1, b.height - 1),
+    };
+}
+
+// 启动时选择窗口所在显示器：优先上次保存的显示器（config.ui.model_position.display），否则主屏。
+function findStartupDisplay(config) {
+    const displays = screen.getAllDisplays();
+    const saved = config && config.ui && config.ui.model_position && config.ui.model_position.display;
+    if (saved && Number.isFinite(saved.screenX) && Number.isFinite(saved.screenY)) {
+        const px = saved.screenX + 10;
+        const py = saved.screenY + 10;
+        const found = displays.find(d =>
+            px >= d.bounds.x && px < d.bounds.x + d.bounds.width &&
+            py >= d.bounds.y && py < d.bounds.y + d.bounds.height
+        );
+        if (found) return found;
+        try {
+            const near = screen.getDisplayNearestPoint({ x: saved.screenX, y: saved.screenY });
+            if (near) return near;
+        } catch (e) { /* ignore */ }
+    }
+    return screen.getPrimaryDisplay();
+}
+
+// 创建/跨屏后多次重申窗口边界：抵消创建期被夹到 workArea，以及跨不同 DPI 屏时 Electron 单次
+// setBounds 把尺寸算错。
+//
+// 关键：每次调用先取消该窗口上一轮“尚未触发”的重申计时器。否则快速来回切屏时，上一次切到 A 屏
+// 排的 500/1500ms 延迟重申，会在已经切到 B 屏后触发、把窗口拽回 A 屏的尺寸/位置，两边互相打架
+// 导致窗口尺寸错乱、模型与光标错位。
+function schedulePetBoundsRepair(win, targetBounds) {
+    if (!win || !targetBounds) return;
+    if (win._petBoundsRepairTimers) {
+        for (const t of win._petBoundsRepairTimers) clearTimeout(t);
+    }
+    win._petBoundsRepairTimers = [];
+    // 容差 2px：off-by-one + DPI 取整会让 getBounds 比目标大 1~2px，足够接近就不再重申，避免无谓抖动。
+    const near = (a, b) => Math.abs(a - b) <= 2;
+    [0, 50, 300, 800].forEach((delay) => {
+        const id = setTimeout(() => {
+            if (!win || win.isDestroyed()) return;
+            const b = win.getBounds();
+            if (near(b.x, targetBounds.x) && near(b.y, targetBounds.y) &&
+                near(b.width, targetBounds.width) && near(b.height, targetBounds.height)) return;
+            try {
+                win.setBounds(targetBounds);
+            } catch (e) {
+                console.error('[PetBoundsRepair] setBounds 失败:', e.message);
+            }
+        }, delay);
+        win._petBoundsRepairTimers.push(id);
+    });
+}
+
+// 跨屏切换时，Electron 首次 setBounds 会用错误缩放因子把尺寸算错（副屏→主屏常“过冲”到比目标更大），
+// 随后由 schedulePetBoundsRepair 修正，中间一两帧会“闪跳”。切屏期间把窗口透明度降到 0
+// 遮住过渡，待 getBounds 收敛到目标尺寸后再恢复原透明度。
+function hidePetForMove(win) {
+    if (!win || win.isDestroyed()) return;
+    if (win._petHidden) return; // 已在切屏过渡中，不重复记录原透明度
+    try {
+        win._petPrevOpacity = win.getOpacity();
+        win._petHidden = true;
+        win.setOpacity(0);
+    } catch (e) { /* ignore */ }
+}
+
+function revealPetAfterMove(win, targetBounds) {
+    if (!win || win.isDestroyed()) return;
+    if (win._petRevealPoll) { clearInterval(win._petRevealPoll); win._petRevealPoll = null; }
+    const near = (a, b) => Math.abs(a - b) <= 2;
+    const start = Date.now();
+    let settledAt = null;
+    win._petRevealPoll = setInterval(() => {
+        if (!win || win.isDestroyed()) { clearInterval(win._petRevealPoll); win._petRevealPoll = null; return; }
+        const b = win.getBounds();
+        const settled = near(b.x, targetBounds.x) && near(b.y, targetBounds.y) &&
+            near(b.width, targetBounds.width) && near(b.height, targetBounds.height);
+        if (settled && settledAt === null) settledAt = Date.now();
+        // 关键：尺寸“稳定”仅代表窗口边界到位，渲染端此时可能还没以新屏尺寸重排/重绘完成。
+        // 再多等 ~120ms 宽限期让渲染端画好，再恢复显示，避免恢复瞬间露出未重绘的过渡帧（闪一下）。
+        // 800ms 硬兜底，任何情况下都不会永久隐藏。
+        if ((settledAt !== null && Date.now() - settledAt >= 120) || Date.now() - start > 800) {
+            try { win.setOpacity(win._petPrevOpacity != null ? win._petPrevOpacity : 1); } catch (e) { /* ignore */ }
+            win._petHidden = false;
+            clearInterval(win._petRevealPoll);
+            win._petRevealPoll = null;
+        }
+    }, 16);
+}
+
 function createWindow () {
     // 读取配置
     let config = {};
@@ -66,58 +167,18 @@ function createWindow () {
         console.error('读取配置失败:', e);
     }
 
-    const screenExtend = config.ui?.screen_extend || { extend: false, left: false, right: true };
-    
-    // 获取所有显示器信息
-    const displays = screen.getAllDisplays()
-    const primaryDisplay = screen.getPrimaryDisplay();
-    
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    // ===== 跨屏方案：窗口只覆盖“单个”显示器，跨屏靠整窗重定位（move-window-to-display）实现 =====
+    // 不再把所有显示器并集成一块巨型窗口；启动时落在上次所在的显示器（否则主屏）。
+    const startupDisplay = findStartupDisplay(config);
+    const startupBounds = getFullscreenDisplayBounds(startupDisplay);
+    const minX = startupBounds.x;
+    const minY = startupBounds.y;
+    const totalWidth = startupBounds.width;
+    const totalHeight = startupBounds.height;
 
-    if (screenExtend.extend) {
-        if (screenExtend.right && !screenExtend.left) {
-            // 保持当前不变 (包含所有屏幕)
-            displays.forEach((display, index) => {
-                const { x, y, width, height } = display.bounds
-                console.log(`显示器 ${index}: x=${x}, y=${y}, width=${width}, height=${height}`)
-                minX = Math.min(minX, x)
-                minY = Math.min(minY, y)
-                maxX = Math.max(maxX, x + width)
-                maxY = Math.max(maxY, y + height)
-            })
-        } else if (screenExtend.left) {
-            // 包含主屏和主屏左侧的屏幕
-            displays.forEach((display, index) => {
-                const { x, y, width, height } = display.bounds;
-                if (x <= primaryDisplay.bounds.x) {
-                    console.log(`显示器 ${index} (左侧/主屏): x=${x}, y=${y}, width=${width}, height=${height}`);
-                    minX = Math.min(minX, x);
-                    minY = Math.min(minY, y);
-                    maxX = Math.max(maxX, x + width);
-                    maxY = Math.max(maxY, y + height);
-                }
-            });
-        } else {
-            // 默认仅主屏
-            minX = primaryDisplay.bounds.x;
-            minY = primaryDisplay.bounds.y;
-            maxX = primaryDisplay.bounds.x + primaryDisplay.bounds.width;
-            maxY = primaryDisplay.bounds.y + primaryDisplay.bounds.height;
-        }
-    } else {
-        // 非扩展模式：仅使用主屏
-        minX = primaryDisplay.bounds.x;
-        minY = primaryDisplay.bounds.y;
-        maxX = primaryDisplay.bounds.x + primaryDisplay.bounds.width;
-        maxY = primaryDisplay.bounds.y + primaryDisplay.bounds.height;
-    }
-    
-    const totalWidth = maxX - minX
-    const totalHeight = maxY - minY
-    
-    console.log(`=== 窗口创建信息 ===`)
-    console.log(`总边界: minX=${minX}, minY=${minY}, maxX=${maxX}, maxY=${maxY}`)
-    console.log(`计算的窗口尺寸: ${totalWidth}x${totalHeight}`)
+    console.log(`=== 窗口创建信息（单屏方案）===`)
+    console.log(`目标显示器: id=${startupDisplay.id}, 缩放=${startupDisplay.scaleFactor}, bounds=${JSON.stringify(startupDisplay.bounds)}`)
+    console.log(`窗口尺寸: ${totalWidth}x${totalHeight}`)
     console.log(`窗口位置: (${minX}, ${minY})`)
     
     const win = new BrowserWindow({
@@ -153,29 +214,8 @@ function createWindow () {
     console.log(`窗口创建后立即尺寸: ${immediateBounds.width}x${immediateBounds.height}`)
     console.log(`窗口创建后立即位置: (${immediateBounds.x}, ${immediateBounds.y})`)
     
-    // 延迟验证窗口实际尺寸
-    setTimeout(() => {
-        const actualBounds = win.getBounds()
-        console.log(`窗口实际尺寸: ${actualBounds.width}x${actualBounds.height}`)
-        console.log(`窗口实际位置: (${actualBounds.x}, ${actualBounds.y})`)
-        
-        // 如果尺寸不匹配，尝试强制设置
-        if (actualBounds.width !== totalWidth || actualBounds.height !== totalHeight) {
-            console.log(`⚠️ 窗口尺寸不匹配！尝试强制设置为 ${totalWidth}x${totalHeight}`)
-            win.setBounds({
-                x: minX,
-                y: minY,
-                width: totalWidth,
-                height: totalHeight
-            })
-            
-            setTimeout(() => {
-                const finalBounds = win.getBounds()
-                console.log(`强制设置后尺寸: ${finalBounds.width}x${finalBounds.height}`)
-            }, 100)
-        }
-        console.log(`======================`)
-    }, 100)
+    // 创建后多次重申单屏边界（替代旧的一次性 100ms 自检），抵消创建期被夹到 workArea。
+    schedulePetBoundsRepair(win, { x: minX, y: minY, width: totalWidth, height: totalHeight })
     
     win.loadFile('index.html')
     win.on('minimize', (event) => {
@@ -240,51 +280,8 @@ app.on('activate', () => {
     }
 })
 
-ipcMain.on('window-move', (event, { mouseX, mouseY }) => {
-    const win = BrowserWindow.fromWebContents(event.sender)
-    const [currentX, currentY] = win.getPosition()
-    // 不限制窗口移动范围,允许自由移动到任何位置(包括副屏)
-    let newX = currentX + mouseX
-    let newY = currentY + mouseY
-
-    win.setPosition(newX, newY)
-
-    // 动态调整窗口大小以覆盖当前位置所在的所有屏幕
-    const displays = screen.getAllDisplays()
-    const winBounds = win.getBounds()
-    
-    // 找出窗口覆盖的所有显示器
-    let minX = winBounds.x
-    let minY = winBounds.y
-    let maxX = winBounds.x + winBounds.width
-    let maxY = winBounds.y + winBounds.height
-    
-    displays.forEach(display => {
-        const { x, y, width, height } = display.bounds
-        // 检查窗口是否与这个显示器有交集
-        if (!(winBounds.x + winBounds.width < x || winBounds.x > x + width ||
-              winBounds.y + winBounds.height < y || winBounds.y > y + height)) {
-            minX = Math.min(minX, x)
-            minY = Math.min(minY, y)
-            maxX = Math.max(maxX, x + width)
-            maxY = Math.max(maxY, y + height)
-        }
-    })
-    
-    const newWidth = maxX - minX
-    const newHeight = maxY - minY
-    
-    // 如果需要调整窗口大小
-    if (newWidth !== winBounds.width || newHeight !== winBounds.height || minX !== winBounds.x || minY !== winBounds.y) {
-        win.setBounds({
-            x: minX,
-            y: minY,
-            width: newWidth,
-            height: newHeight
-        })
-        console.log(`窗口调整: ${newWidth}x${newHeight} at (${minX}, ${minY})`)
-    }
-})
+// 旧的 'window-move'（巨窗跟随 + 动态并集 setBounds）方案已废弃。
+// 跨屏改由 'move-window-to-display' 实现（见下方），渲染端拖动只移动模型精灵。
 
 ipcMain.on('set-ignore-mouse-events', (event, { ignore, options }) => {
     BrowserWindow.fromWebContents(event.sender).setIgnoreMouseEvents(ignore, options)
@@ -293,20 +290,6 @@ ipcMain.on('set-ignore-mouse-events', (event, { ignore, options }) => {
 ipcMain.on('set-window-opacity', (event, opacity) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     if (win) win.setOpacity(Math.max(0, Math.min(1, opacity)));
-})
-
-ipcMain.on('get-screen-info-sync', (event) => {
-    try {
-        const win = BrowserWindow.fromWebContents(event.sender);
-        event.returnValue = {
-            primaryDisplay: screen.getPrimaryDisplay(),
-            allDisplays: screen.getAllDisplays(),
-            windowBounds: win ? win.getBounds() : null
-        };
-    } catch (e) {
-        console.error('获取屏幕信息失败:', e);
-        event.returnValue = null;
-    }
 })
 
 ipcMain.on('request-top-most', (event) => {
@@ -481,15 +464,125 @@ ipcMain.handle('get-window-bounds', (event) => {
 });
 
 // 添加获取所有显示器信息的IPC处理器
+// 返回跨屏所需的字段（screenX/screenY 为屏幕绝对坐标，x/y 为相对当前窗口左上角的坐标），
+// 同时保留 bounds/workArea/rotation 以兼容旧调用（如 model-setup.js）。
 ipcMain.handle('get-all-displays', (event) => {
     const displays = screen.getAllDisplays();
+    const win = BrowserWindow.fromWebContents(event.sender);
+    const windowBounds = win && !win.isDestroyed() ? win.getBounds() : { x: 0, y: 0 };
     return displays.map(display => ({
         id: display.id,
+        x: display.bounds.x - windowBounds.x,
+        y: display.bounds.y - windowBounds.y,
+        width: display.bounds.width,
+        height: display.bounds.height,
+        screenX: display.bounds.x,
+        screenY: display.bounds.y,
+        scaleFactor: display.scaleFactor,
+        // 兼容旧调用
         bounds: display.bounds,
         workArea: display.workArea,
-        scaleFactor: display.scaleFactor,
         rotation: display.rotation
     }));
+});
+
+// 获取“当前窗口所在”的显示器信息（渲染端用 screenX/screenY 做窗口<->屏幕坐标换算）
+ipcMain.handle('get-current-display', (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win || win.isDestroyed()) return null;
+    const windowBounds = win.getBounds();
+    const currentDisplay = screen.getDisplayMatching(windowBounds);
+    return {
+        id: currentDisplay.id,
+        x: 0,
+        y: 0,
+        width: currentDisplay.bounds.width,
+        height: currentDisplay.bounds.height,
+        screenX: currentDisplay.bounds.x,
+        screenY: currentDisplay.bounds.y,
+        scaleFactor: currentDisplay.scaleFactor,
+        workArea: currentDisplay.workArea
+    };
+});
+
+// 获取主显示器信息
+ipcMain.handle('get-primary-display-info', () => {
+    const primary = screen.getPrimaryDisplay();
+    return {
+        id: primary.id,
+        bounds: { ...primary.bounds },
+        workArea: primary.workArea,
+        scaleFactor: primary.scaleFactor
+    };
+});
+
+// ===== 跨屏核心：把整个窗口重定位到“包含指定屏幕点”的显示器并填满它 =====
+// 渲染端在松手时检测到模型中心越出当前窗口，换算成屏幕绝对坐标后调用本接口。
+ipcMain.handle('move-window-to-display', async (event, screenX, screenY) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win || win.isDestroyed()) return { success: false, error: 'Window not found' };
+    try {
+        const displays = screen.getAllDisplays();
+        const currentBounds = win.getBounds();
+
+        // 找到包含该屏幕点的目标显示器
+        let targetDisplay = null;
+        for (const display of displays) {
+            const b = display.bounds;
+            if (screenX >= b.x && screenX < b.x + b.width &&
+                screenY >= b.y && screenY < b.y + b.height) {
+                targetDisplay = display;
+                break;
+            }
+        }
+        if (!targetDisplay) {
+            console.log('move-window-to-display: 未找到包含点的屏幕, screenX=', screenX, 'screenY=', screenY);
+            return { success: false, error: 'No display found at the given point' };
+        }
+
+        const currentDisplay = screen.getDisplayMatching(currentBounds);
+        if (currentDisplay.id === targetDisplay.id) {
+            return { success: true, sameDisplay: true };
+        }
+
+        console.log('move-window-to-display: 从屏幕', currentDisplay.id, '切换到屏幕', targetDisplay.id);
+
+        // 不同屏幕可能有不同缩放：广播 scaleRatio（渲染端目前保持模型原大小，仅调位置）
+        const scaleRatio = targetDisplay.scaleFactor / currentDisplay.scaleFactor;
+        const newBounds = getFullscreenDisplayBounds(targetDisplay);
+
+        // 切屏期间隐藏窗口，遮住“尺寸过冲/修正”那一两帧的闪跳；尺寸稳定后由 revealPetAfterMove 恢复。
+        hidePetForMove(win);
+        win.setBounds(newBounds);
+
+        // 关键修复：跨“不同缩放因子(DPI)”的显示器时，Electron 单次 setBounds 会用错误的缩放因子
+        // 计算物理尺寸，使窗口尺寸不匹配目标屏。等窗口落到目标屏后多次重申边界，按目标屏缩放因子重算尺寸。
+        schedulePetBoundsRepair(win, newBounds);
+        revealPetAfterMove(win, newBounds);
+
+        setTimeout(() => {
+            if (!win.isDestroyed()) {
+                win.webContents.send('display-changed', {
+                    displayId: targetDisplay.id,
+                    bounds: targetDisplay.bounds,
+                    scaleFactor: targetDisplay.scaleFactor,
+                    scaleRatio: scaleRatio,
+                    previousScaleFactor: currentDisplay.scaleFactor
+                });
+            }
+        }, 32);
+
+        return {
+            success: true,
+            displayId: targetDisplay.id,
+            bounds: targetDisplay.bounds,
+            scaleFactor: targetDisplay.scaleFactor,
+            scaleRatio: scaleRatio
+        };
+    } catch (err) {
+        console.error('move-window-to-display 错误:', err.message);
+        return { success: false, error: err.message };
+    }
 });
 
 
@@ -511,14 +604,19 @@ ipcMain.on('save-model-position', (event, position) => {
             };
         }
 
-        if (position.dual) {
-            configData.ui.model_position.x_dual = position.x;
-            configData.ui.model_position.y_dual = position.y;
-        } else {
-            configData.ui.model_position.x = position.x;
-            configData.ui.model_position.y = position.y;
-        }
+        // 跨屏方案：位置按“当前显示器内的相对位置（0~1）”保存，不再区分单/双屏 x_dual/y_dual。
+        configData.ui.model_position.x = position.x;
+        configData.ui.model_position.y = position.y;
         configData.ui.model_scale = position.scale;
+
+        // 记录当前窗口所在显示器的屏幕原点，供下次启动把窗口落回同一块屏（findStartupDisplay 使用）。
+        const win = BrowserWindow.fromWebContents(event.sender);
+        if (win && !win.isDestroyed()) {
+            try {
+                const d = screen.getDisplayMatching(win.getBounds());
+                configData.ui.model_position.display = { screenX: d.bounds.x, screenY: d.bounds.y };
+            } catch (e) { /* ignore */ }
+        }
 
         // 保存到文件
         fs.writeFileSync(configPath, JSON.stringify(configData, null, 2), 'utf8');


### PR DESCRIPTION
## 背景

原本桌宠的多屏跨越用一块横跨所有显示器的巨型透明窗口承载模型，跨屏靠在大画布里移动精灵。这块巨窗在 Windows 上对 DWM/GPU 较重、需要创建期强制 setBounds 自检，且不处理混合 DPI，跨屏布局靠 `screen_extend` 的脆弱启发式。

本 PR 改为「单屏窗口 + 整窗重定位」：窗口只覆盖单个显示器，拖动模型越界时把整个窗口重定位到目标显示器。

## 改动

**主进程 (main.js)**
- 单屏窗口创建（单屏全屏填充 + 启动落回上次所在显示器）
- 新增 IPC：`move-window-to-display` / `get-current-display` / `get-primary-display-info`；`get-all-displays` 增加 `screenX/screenY/width/height` 等字段
- 跨不同缩放比(DPI)显示器时 Electron 单次 `setBounds` 会用错误缩放因子算尺寸 → 落屏后多次重申边界修正，并在每次切屏取消上一次的过期重申计时器（修复快速来回切屏时的尺寸错乱/模型错位）
- 切屏期间隐藏窗口、尺寸稳定且重绘完成后再显示，消除切屏「闪跳」
- 移除已废弃的 `window-move` 处理器

**渲染端**
- 新增 `electron-screen-bridge.js`：注入 `window.electronScreen`
- Live2D / VRM 松手时检测模型中心越界并整窗切屏；位置按目标显示器 DIP 尺寸保存
- 聊天框 / 字幕改为锚定当前窗口右下角
- 快捷设置面板补上鼠标穿透处理（修复悬停其上点击会穿透）

## 测试

在两块不同 DPI 的显示器（主屏 2560×1600 @150%、副屏 1920×1080 @125%）上实测：模型拖到屏幕边缘松手会整窗切到目标屏；快速来回、跨 DPI 尺寸、切屏闪跳均已修复；位置记忆正常。

注：未改动 `config.json`（个人配置）。
