### PR TITLE
修复游戏焦点下 PTT 按住说话失效

### DIFF
--- a/live-2d/js/ai/conversation/ASRController.js
+++ b/live-2d/js/ai/conversation/ASRController.js
@@ -218,7 +218,7 @@ class ASRController {
      * PTT：按下，开始录音
      */
     pttStartRecording() {
-        if (this.asrEnabled && this.asrProcessor) {
+        if (this.asrEnabled && this.asrProcessor?.pttStartRecording) {
             this.asrProcessor.pttStartRecording();
         }
     }
@@ -227,7 +227,7 @@ class ASRController {
      * PTT：松开，结束录音并触发识别
      */
     pttStopRecording() {
-        if (this.asrEnabled && this.asrProcessor) {
+        if (this.asrEnabled && this.asrProcessor?.pttStopRecording) {
             this.asrProcessor.pttStopRecording();
         }
     }

--- a/live-2d/js/ai/conversation/ASRController.js
+++ b/live-2d/js/ai/conversation/ASRController.js
@@ -232,6 +232,12 @@ class ASRController {
         }
     }
 
+    pttCancelRecording(reason) {
+        if (this.asrEnabled && this.asrProcessor?.pttCancelRecording) {
+            this.asrProcessor.pttCancelRecording(reason);
+        }
+    }
+
     /**
      * 检查ASR是否可用
      */

--- a/live-2d/js/ai/conversation/VoiceChatFacade.js
+++ b/live-2d/js/ai/conversation/VoiceChatFacade.js
@@ -223,6 +223,10 @@ class VoiceChatFacade {
         return this.asrController.pttStopRecording();
     }
 
+    pttCancelRecording(reason) {
+        return this.asrController.pttCancelRecording(reason);
+    }
+
     getVoiceBargeInStatus() {
         return this.asrController.getVoiceBargeInStatus();
     }

--- a/live-2d/js/shortcut-manager.js
+++ b/live-2d/js/shortcut-manager.js
@@ -1,158 +1,252 @@
 const { globalShortcut, BrowserWindow, app } = require('electron');
 
-/**
- * 全局快捷键管理器
- * 统一管理应用的所有全局快捷键
- */
+let uiohookApi = null;
+try {
+    uiohookApi = require('uiohook-napi');
+} catch (error) {
+    console.warn('[PTT] uiohook-napi is unavailable; PTT will use window focus fallback only.', error.message);
+}
+
 class ShortcutManager {
-    constructor() {
+    constructor(config = {}) {
+        this.config = config || {};
         this.shortcuts = [];
+        this.pttKey = this._normalizeKey(this.config.asr?.ptt_key || 'v') || 'v';
+        this.pttKeyCode = null;
+        this.pttKeyDown = false;
+        this.pttHookStarted = false;
+        this.pttHandlers = null;
     }
 
-    /**
-     * 注册所有快捷键
-     */
     registerAll() {
-        // 应用控制类快捷键
         this._registerAppControls();
-
-        // TTS 打断快捷键
         this._registerTTSInterrupt();
-
-        // 窗口置顶快捷键
         this._registerWindowTopMost();
-
-        // 动作和音乐控制快捷键
         this._registerMotionAndMusicControls();
-
-        // 气泡框显示快捷键
         this._registerBubbleToggle();
+        this._registerGlobalPTT();
 
-        console.log(`已注册 ${this.shortcuts.length} 个全局快捷键！！！`);
+        console.log(`Registered ${this.shortcuts.length} global shortcuts.`);
     }
 
-    /**
-     * 注册应用控制快捷键
-     */
     _registerAppControls() {
         this._register('CommandOrControl+Q', () => {
             app.quit();
-        }, '退出应用');
+        }, 'Quit app');
     }
 
-    /**
-     * 注册 TTS 打断快捷键
-     */
     _registerTTSInterrupt() {
         this._register('CommandOrControl+G', () => {
-            const mainWindow = BrowserWindow.getAllWindows()[0];
-            if (mainWindow) {
-                mainWindow.webContents.send('interrupt-tts');
-            }
-        }, '打断 TTS 语音');
+            this._sendToMainWindow('interrupt-tts');
+        }, 'Interrupt TTS');
     }
 
-    /**
-     * 注册窗口置顶快捷键
-     */
     _registerWindowTopMost() {
         this._register('CommandOrControl+T', () => {
             const windows = BrowserWindow.getAllWindows();
             windows.forEach(win => {
                 win.setAlwaysOnTop(true, 'screen-saver');
             });
-        }, '强制窗口置顶');
+        }, 'Force window topmost');
     }
 
-    /**
-     * 注册动作和音乐控制快捷键
-     */
     _registerMotionAndMusicControls() {
-        // Ctrl+Shift+1 到 Ctrl+Shift+9
         for (let i = 1; i <= 9; i++) {
             if (i === 6) {
-                // Ctrl+Shift+6: 播放音乐
                 this._register(`CommandOrControl+Shift+${i}`, () => {
-                    const mainWindow = BrowserWindow.getAllWindows()[0];
-                    if (mainWindow) {
-                        mainWindow.webContents.send('trigger-music-play');
-                    }
-                }, '播放随机音乐');
+                    this._sendToMainWindow('trigger-music-play');
+                }, 'Play random music');
             } else if (i === 8) {
-                // Ctrl+Shift+8: 停止音乐 + 赌气动作
                 this._register(`CommandOrControl+Shift+${i}`, () => {
-                    const mainWindow = BrowserWindow.getAllWindows()[0];
-                    if (mainWindow) {
-                        mainWindow.webContents.send('trigger-music-stop-with-motion');
-                    }
-                }, '停止音乐并播放赌气动作');
+                    this._sendToMainWindow('trigger-music-stop-with-motion');
+                }, 'Stop music with motion');
             } else {
-                // 其他: 触发对应索引的动作
                 this._register(`CommandOrControl+Shift+${i}`, () => {
-                    const motionIndex = i - 1;
-                    const mainWindow = BrowserWindow.getAllWindows()[0];
-                    if (mainWindow) {
-                        mainWindow.webContents.send('trigger-motion-hotkey', motionIndex);
-                    }
-                }, `触发动作 ${i}`);
+                    this._sendToMainWindow('trigger-motion-hotkey', i - 1);
+                }, `Trigger motion ${i}`);
             }
         }
 
-        // Ctrl+Shift+0: 停止所有动作
         this._register('CommandOrControl+Shift+0', () => {
-            const mainWindow = BrowserWindow.getAllWindows()[0];
-            if (mainWindow) {
-                mainWindow.webContents.send('stop-all-motions');
-            }
-        }, '停止所有动作');
+            this._sendToMainWindow('stop-all-motions');
+        }, 'Stop all motions');
     }
 
-    /**
-     * 注册气泡框切换快捷键
-     */
     _registerBubbleToggle() {
         this._register('CommandOrControl+M', () => {
-            const mainWindow = BrowserWindow.getAllWindows()[0];
-            if (mainWindow) {
-                mainWindow.webContents.send('toggle-bubble');
-            }
-        }, '切换气泡框显示/隐藏');
+            this._sendToMainWindow('toggle-bubble');
+        }, 'Toggle bubble');
     }
 
-    /**
-     * 注册单个快捷键
-     * @param {string} accelerator 快捷键组合
-     * @param {Function} callback 回调函数
-     * @param {string} description 描述
-     */
+    _registerGlobalPTT() {
+        if (!uiohookApi) return;
+
+        const { uIOhook } = uiohookApi;
+        this.pttKeyCode = this._resolveUiohookKeyCode(this.pttKey);
+        if (this.pttKeyCode == null) {
+            console.warn(`[PTT] Unsupported ptt_key "${this.pttKey}". Global PTT is disabled.`);
+            return;
+        }
+
+        const isPTTEvent = (event) => event && event.keycode === this.pttKeyCode;
+        const onKeyDown = (event) => {
+            if (!isPTTEvent(event) || this.pttKeyDown) return;
+            this.pttKeyDown = true;
+            this._sendPTT('down');
+        };
+        const onKeyUp = (event) => {
+            if (!isPTTEvent(event)) return;
+            if (!this.pttKeyDown) {
+                this._sendPTT('up');
+                return;
+            }
+            this.pttKeyDown = false;
+            this._sendPTT('up');
+        };
+
+        try {
+            uIOhook.on('keydown', onKeyDown);
+            uIOhook.on('keyup', onKeyUp);
+            uIOhook.start();
+            this.pttHandlers = { onKeyDown, onKeyUp };
+            this.pttHookStarted = true;
+            console.log(`[PTT] Global hold-to-talk registered on ${this.pttKey.toUpperCase()}.`);
+        } catch (error) {
+            try {
+                uIOhook.off('keydown', onKeyDown);
+                uIOhook.off('keyup', onKeyUp);
+            } catch (_) {
+                // Ignore cleanup errors from a partially started hook.
+            }
+            console.warn('[PTT] Failed to start global PTT hook; window focus fallback remains available.', error);
+        }
+    }
+
+    _unregisterGlobalPTT() {
+        if (!uiohookApi) return;
+
+        const { uIOhook } = uiohookApi;
+        if (this.pttHandlers) {
+            try {
+                uIOhook.off('keydown', this.pttHandlers.onKeyDown);
+                uIOhook.off('keyup', this.pttHandlers.onKeyUp);
+            } catch (error) {
+                console.warn('[PTT] Failed to remove global PTT handlers.', error);
+            }
+            this.pttHandlers = null;
+        }
+
+        if (this.pttHookStarted) {
+            try {
+                uIOhook.stop();
+            } catch (error) {
+                console.warn('[PTT] Failed to stop global PTT hook.', error);
+            }
+        }
+
+        this.pttHookStarted = false;
+        this.pttKeyDown = false;
+    }
+
     _register(accelerator, callback, description = '') {
         try {
             const success = globalShortcut.register(accelerator, callback);
             if (success) {
                 this.shortcuts.push({ accelerator, description });
-                console.log(`✓ 已注册快捷键: ${accelerator}${description ? ` (${description})` : ''}`);
+                console.log(`Registered shortcut: ${accelerator}${description ? ` (${description})` : ''}`);
             } else {
-                console.warn(`✗ 快捷键注册失败: ${accelerator}`);
+                console.warn(`Failed to register shortcut: ${accelerator}`);
             }
         } catch (error) {
-            console.error(`注册快捷键 ${accelerator} 时出错:`, error);
+            console.error(`Error registering shortcut ${accelerator}:`, error);
         }
     }
 
-    /**
-     * 取消所有快捷键
-     */
     unregisterAll() {
+        this._unregisterGlobalPTT();
         globalShortcut.unregisterAll();
-        console.log('已取消所有全局快捷键');
         this.shortcuts = [];
+        console.log('Unregistered all global shortcuts.');
     }
 
-    /**
-     * 获取已注册的快捷键列表
-     */
     getRegisteredShortcuts() {
         return this.shortcuts;
+    }
+
+    _sendPTT(action) {
+        this._sendToMainWindow('ptt-global-key', {
+            action,
+            key: this.pttKey,
+            source: 'uiohook'
+        });
+    }
+
+    _sendToMainWindow(channel, ...args) {
+        const mainWindow = BrowserWindow.getAllWindows().find(win => !win.isDestroyed());
+        if (!mainWindow || mainWindow.webContents.isDestroyed()) return;
+        mainWindow.webContents.send(channel, ...args);
+    }
+
+    _normalizeKey(value) {
+        const raw = String(value || '').trim().toLowerCase();
+        const aliases = {
+            ' ': 'space',
+            spacebar: 'space',
+            return: 'enter',
+            esc: 'escape',
+            control: 'ctrl',
+            command: 'meta',
+            cmd: 'meta',
+            win: 'meta',
+            windows: 'meta',
+            option: 'alt',
+            left: 'arrowleft',
+            up: 'arrowup',
+            right: 'arrowright',
+            down: 'arrowdown'
+        };
+        return aliases[raw] || raw;
+    }
+
+    _resolveUiohookKeyCode(key) {
+        if (!uiohookApi) return null;
+
+        const { UiohookKey } = uiohookApi;
+        if (/^[a-z]$/.test(key)) return UiohookKey[key.toUpperCase()];
+        if (/^[0-9]$/.test(key)) return UiohookKey[key];
+        if (/^f([1-9]|1[0-9]|2[0-4])$/.test(key)) return UiohookKey[key.toUpperCase()];
+
+        const names = {
+            backspace: 'Backspace',
+            tab: 'Tab',
+            enter: 'Enter',
+            escape: 'Escape',
+            space: 'Space',
+            pageup: 'PageUp',
+            pagedown: 'PageDown',
+            end: 'End',
+            home: 'Home',
+            arrowleft: 'ArrowLeft',
+            arrowup: 'ArrowUp',
+            arrowright: 'ArrowRight',
+            arrowdown: 'ArrowDown',
+            insert: 'Insert',
+            delete: 'Delete',
+            ctrl: 'Ctrl',
+            alt: 'Alt',
+            altright: 'AltRight',
+            shift: 'Shift',
+            shiftright: 'ShiftRight',
+            meta: 'Meta'
+        };
+
+        if (/^numpad[0-9]$/.test(key)) {
+            const digit = key.slice('numpad'.length);
+            return UiohookKey[`Numpad${digit}`];
+        }
+
+        const name = names[key];
+        return name ? UiohookKey[name] : null;
     }
 }
 

--- a/live-2d/js/ui/ui-controller.js
+++ b/live-2d/js/ui/ui-controller.js
@@ -594,13 +594,8 @@ class UIController {
             const proc = voiceChat.asrController?.asrProcessor;
             if (!proc) return;
             const nextPTTMode = !proc.pttModeEnabled;
-            const cancelledPTT = typeof this._cancelActivePTT === 'function'
-                ? this._cancelActivePTT('mode-toggle')
-                : false;
-            if (!cancelledPTT && typeof voiceChat.pttCancelRecording === 'function') {
-                voiceChat.pttCancelRecording('mode-toggle');
-            } else if (!cancelledPTT && typeof proc.pttCancelRecording === 'function') {
-                proc.pttCancelRecording('mode-toggle');
+            if (typeof this._cancelActivePTT === 'function') {
+                this._cancelActivePTT('mode-toggle');
             }
             proc.pttModeEnabled = nextPTTMode;
             config.asr = config.asr || {};

--- a/live-2d/js/ui/ui-controller.js
+++ b/live-2d/js/ui/ui-controller.js
@@ -21,6 +21,8 @@ class UIController {
         this.subtitleScale = 1.0;
         this._subtitleCenterX = null;
         this._subtitleCenterY = null;
+        this._pttCleanup = null;
+        this._cancelActivePTT = null;
     }
 
     // 初始化UI控制
@@ -591,44 +593,201 @@ class UIController {
         toggleModeBtn.addEventListener('click', () => {
             const proc = voiceChat.asrController?.asrProcessor;
             if (!proc) return;
-            proc.pttModeEnabled = !proc.pttModeEnabled;
+            const nextPTTMode = !proc.pttModeEnabled;
+            const cancelledPTT = typeof this._cancelActivePTT === 'function'
+                ? this._cancelActivePTT('mode-toggle')
+                : false;
+            if (!cancelledPTT && typeof voiceChat.pttCancelRecording === 'function') {
+                voiceChat.pttCancelRecording('mode-toggle');
+            } else if (!cancelledPTT && typeof proc.pttCancelRecording === 'function') {
+                proc.pttCancelRecording('mode-toggle');
+            }
+            proc.pttModeEnabled = nextPTTMode;
+            config.asr = config.asr || {};
             config.asr.ptt_enabled = proc.pttModeEnabled;
             toggleModeBtn.classList.toggle('active', proc.pttModeEnabled);
         });
     }
 
-    // PTT（按住说话）模式按键监听
+    // PTT global/local hold-to-talk listener
     setupPTT(voiceChat, config) {
-        const pttKey = (config.asr?.ptt_key || 'v').toLowerCase();
+        if (typeof this._pttCleanup === 'function') {
+            this._pttCleanup();
+        }
+
+        const normalizeKey = (value) => {
+            const raw = String(value || '').trim().toLowerCase();
+            const aliases = {
+                ' ': 'space',
+                spacebar: 'space',
+                return: 'enter',
+                esc: 'escape',
+                control: 'ctrl',
+                command: 'meta',
+                cmd: 'meta',
+                win: 'meta',
+                windows: 'meta',
+                option: 'alt',
+                left: 'arrowleft',
+                up: 'arrowup',
+                right: 'arrowright',
+                down: 'arrowdown'
+            };
+            return aliases[raw] || raw;
+        };
+
+        const pttKey = normalizeKey(config.asr?.ptt_key || 'v') || 'v';
+        const recordingText = '\u5f55\u97f3\u4e2d...';
         let pttActive = false;
+        let pttSource = null;
 
-        const isPTTEnabled = () => voiceChat.asrController?.asrProcessor?.pttModeEnabled || false;
-
+        const getProcessor = () => voiceChat.asrController?.asrProcessor;
+        const isPTTEnabled = () => getProcessor()?.pttModeEnabled || false;
+        const matchesPTTKey = (key) => normalizeKey(key) === pttKey;
         const isInputFocused = () => {
             const el = document.activeElement;
             if (!el) return false;
             const tag = el.tagName;
-            return tag === 'INPUT' || tag === 'TEXTAREA' || el.isContentEditable;
+            return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable;
+        };
+        const shouldSkipForInput = (source) => {
+            if (!isInputFocused()) return false;
+            return source === 'local' || document.hasFocus();
         };
 
-        document.addEventListener('keydown', (e) => {
-            if (e.key.toLowerCase() !== pttKey) return;
-            if (!isPTTEnabled()) return;
-            if (e.repeat || pttActive || isInputFocused()) return;
-            pttActive = true;
-            voiceChat.pttStartRecording();
-            this.showSubtitle('录音中...', 0);
-        });
+        const cancelProcessor = (reason) => {
+            const proc = getProcessor();
+            if (typeof voiceChat.pttCancelRecording === 'function') {
+                voiceChat.pttCancelRecording(reason);
+                return;
+            }
+            if (typeof proc?.pttCancelRecording === 'function') {
+                proc.pttCancelRecording(reason);
+                return;
+            }
+            if (!proc) return;
+            proc.isRecording = false;
+            proc.asrLocked = false;
+            proc.hasInterruptedThisSession = false;
+            if (proc.silenceTimeout) {
+                clearTimeout(proc.silenceTimeout);
+                proc.silenceTimeout = null;
+            }
+        };
 
-        document.addEventListener('keyup', (e) => {
-            if (e.key.toLowerCase() !== pttKey || !pttActive) return;
+        const cancelPTT = (reason = 'cancelled') => {
+            const wasActive = pttActive;
             pttActive = false;
-            if (!isPTTEnabled()) return;
-            voiceChat.pttStopRecording();
-            this.hideSubtitle();
-        });
+            pttSource = null;
+            if (wasActive) {
+                cancelProcessor(reason);
+                this.hideSubtitle();
+                logToTerminal('info', `[PTT] cancelled: ${reason}`);
+            }
+            return wasActive;
+        };
 
-        console.log(`PTT按键监听已注册，按键: ${pttKey.toUpperCase()}`);
+        const startPTT = (source) => {
+            if (!isPTTEnabled()) return false;
+            if (pttActive) {
+                if (source === 'global') pttSource = 'global';
+                return true;
+            }
+            if (shouldSkipForInput(source)) {
+                logToTerminal('info', `[PTT] ${source} keydown ignored because input is focused`);
+                return false;
+            }
+
+            pttActive = true;
+            pttSource = source;
+            logToTerminal('info', `[PTT] ${source} keydown, start recording`);
+            if (typeof voiceChat.pttStartRecording === 'function') {
+                voiceChat.pttStartRecording();
+            }
+            this.showSubtitle(recordingText, 0);
+            return true;
+        };
+
+        const stopPTT = (source, reason = 'keyup') => {
+            if (!pttActive) return false;
+            const activeSource = pttSource;
+            pttActive = false;
+            pttSource = null;
+
+            if (!isPTTEnabled()) {
+                cancelProcessor(reason);
+                this.hideSubtitle();
+                logToTerminal('info', `[PTT] ${source} ${reason}, mode disabled so recording was cancelled`);
+                return true;
+            }
+
+            logToTerminal('info', `[PTT] ${source} ${reason}, stop recording from ${activeSource || 'unknown'}`);
+            if (typeof voiceChat.pttStopRecording === 'function') {
+                voiceChat.pttStopRecording();
+            }
+            this.hideSubtitle();
+            return true;
+        };
+
+        const onLocalKeyDown = (e) => {
+            if (!matchesPTTKey(e.key) || e.repeat) return;
+            startPTT('local');
+        };
+
+        const onLocalKeyUp = (e) => {
+            if (!matchesPTTKey(e.key)) return;
+            stopPTT('local');
+        };
+
+        const onGlobalPTT = (_event, payload = {}) => {
+            if (!payload || !matchesPTTKey(payload.key)) return;
+            if (payload.action === 'down') {
+                startPTT('global');
+            } else if (payload.action === 'up') {
+                stopPTT('global');
+            }
+        };
+
+        const onWindowBlur = () => {
+            setTimeout(() => {
+                if (pttActive && pttSource !== 'global') {
+                    stopPTT('window-blur', 'blur');
+                }
+            }, 50);
+        };
+
+        const onVisibilityChange = () => {
+            if (document.hidden) {
+                cancelPTT('visibility-hidden');
+            }
+        };
+
+        const onBeforeUnload = () => {
+            cancelPTT('beforeunload');
+        };
+
+        document.addEventListener('keydown', onLocalKeyDown);
+        document.addEventListener('keyup', onLocalKeyUp);
+        ipcRenderer.on('ptt-global-key', onGlobalPTT);
+        window.addEventListener('blur', onWindowBlur);
+        document.addEventListener('visibilitychange', onVisibilityChange);
+        window.addEventListener('beforeunload', onBeforeUnload);
+
+        this._cancelActivePTT = cancelPTT;
+        this._pttCleanup = () => {
+            document.removeEventListener('keydown', onLocalKeyDown);
+            document.removeEventListener('keyup', onLocalKeyUp);
+            ipcRenderer.removeListener('ptt-global-key', onGlobalPTT);
+            window.removeEventListener('blur', onWindowBlur);
+            document.removeEventListener('visibilitychange', onVisibilityChange);
+            window.removeEventListener('beforeunload', onBeforeUnload);
+            if (this._cancelActivePTT === cancelPTT) {
+                this._cancelActivePTT = null;
+            }
+            this._pttCleanup = null;
+        };
+
+        console.log(`PTT listener registered, key: ${pttKey.toUpperCase()} (global + local fallback)`);
     }
 
     // 显示歌词气泡

--- a/live-2d/js/voice/asr-processor.js
+++ b/live-2d/js/voice/asr-processor.js
@@ -511,6 +511,8 @@ class ASRProcessor {
 
     // PTT: cancel current recording without submitting it to ASR
     pttCancelRecording(reason = 'cancelled') {
+        if (!this.isRecording) return;
+
         if (this.silenceTimeout) {
             clearTimeout(this.silenceTimeout);
             this.silenceTimeout = null;

--- a/live-2d/js/voice/asr-processor.js
+++ b/live-2d/js/voice/asr-processor.js
@@ -274,6 +274,7 @@ class ASRProcessor {
         }
         if (this.silenceTimeout) {
             clearTimeout(this.silenceTimeout);
+            this.silenceTimeout = null;
         }
     }
 
@@ -506,6 +507,22 @@ class ASRProcessor {
         this.isRecording = true;
         this.recordingStartIndex = this.continuousBuffer.length;
         console.log('PTT: 开始录音');
+    }
+
+    // PTT: cancel current recording without submitting it to ASR
+    pttCancelRecording(reason = 'cancelled') {
+        if (this.silenceTimeout) {
+            clearTimeout(this.silenceTimeout);
+            this.silenceTimeout = null;
+        }
+
+        this.isRecording = false;
+        this.asrLocked = false;
+        this.hasInterruptedThisSession = false;
+        this.recordingStartIndex = this.continuousBuffer.length;
+        this.continuousBuffer = this.continuousBuffer.slice(-this.PRE_RECORD_SAMPLES);
+
+        console.log(`PTT: recording cancelled (${reason})`);
     }
 
     // PTT：松开触发，强制结束录音并送 ASR

--- a/live-2d/main.js
+++ b/live-2d/main.js
@@ -8,6 +8,7 @@ const screenshot = require('screenshot-desktop');
 
 // 添加配置文件路径
 const configPath = path.join(app.getAppPath(), 'config.json');
+let shortcutManager = null;
 
 function loadConfigData() {
     return JSON.parse(fs.readFileSync(configPath, 'utf8'));
@@ -238,8 +239,9 @@ function createWindow () {
 app.whenReady().then(() => {
     // 读取配置判断模型类型
     let modelType = 'live2d';
+    let configData = {};
     try {
-        const configData = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+        configData = JSON.parse(fs.readFileSync(configPath, 'utf8'));
         modelType = configData.ui?.model_type || 'live2d';
     } catch (e) {
         console.log('读取配置失败，使用默认Live2D模式');
@@ -260,7 +262,7 @@ app.whenReady().then(() => {
     httpServer.start();
 
     // 注册全局快捷键
-    const shortcutManager = new ShortcutManager();
+    shortcutManager = new ShortcutManager(configData);
     shortcutManager.registerAll();
 });
 
@@ -271,6 +273,13 @@ app.on('window-all-closed', () => {
     }
     if (process.platform !== 'darwin') {
         app.quit()
+    }
+})
+
+app.on('will-quit', () => {
+    if (shortcutManager) {
+        shortcutManager.unregisterAll();
+        shortcutManager = null;
     }
 })
 

--- a/live-2d/package-lock.json
+++ b/live-2d/package-lock.json
@@ -21,7 +21,8 @@
         "play-sound": "^1.1.6",
         "screenshot-desktop": "^1.15.3",
         "socket.io-client": "^4.8.1",
-        "three": "^0.183.2"
+        "three": "^0.183.2",
+        "uiohook-napi": "^1.5.5"
       }
     },
     "node_modules/@electron/get": {
@@ -72,14 +73,14 @@
       "version": "6.5.10",
       "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.5.10.tgz",
       "integrity": "sha512-PUF2Y9YISRu5eVrVVHhHCWpc/KmxQTg3UH8rIUs8UI9dCK41/wsPd3pEahzf7H47v7x1HCohVZcFO3XQc1bUDw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@pixi/core": {
       "version": "5.3.12",
       "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.12.tgz",
       "integrity": "sha512-SKZPU2mP4UE4trWOTcubGekKwopnotbyR2X8nb68wffBd1GzMoaxyakltfJF2oCV/ivrru/biP4CkW9K6MJ56g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pixi/constants": "5.3.12",
         "@pixi/math": "5.3.12",
@@ -97,19 +98,22 @@
       "version": "5.3.12",
       "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.12.tgz",
       "integrity": "sha512-UcuvZZ8cQu+ZC7ufLpKi8NfZX0FncPuxKd0Rf6u6pzO2SmHPq4C1moXYGDnkZjPFAjNYFFHC7chU+zolMtkL/g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pixi/core/node_modules/@pixi/runner": {
       "version": "5.3.12",
       "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.12.tgz",
       "integrity": "sha512-I5mXx4BiP8Bx5CFIXy3XV3ABYFXbIWaY6FxWsNFkySn0KUhizN7SarPdhFGs//hJuC54EH2FsKKNa98Lfc2nCQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pixi/core/node_modules/@pixi/settings": {
       "version": "5.3.12",
       "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.12.tgz",
       "integrity": "sha512-tLAa8tpDGllgj88NMUQn2Obn9MFJfHNF/CKs8aBhfeZGU4yL4PZDtlI+tqaB1ITGl3xxyHmJK+qfmv5lJn+zyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ismobilejs": "^1.1.0"
       }
@@ -119,6 +123,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.12.tgz",
       "integrity": "sha512-YNYUj94XgogipYhPOjbdFBIsy7+U6KmolvK+Av1G88GDac5SDoALb1Nt6s23fd8HIz6b4YnabHOdXGz3zPir1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pixi/settings": "5.3.12"
       }
@@ -128,6 +133,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.12.tgz",
       "integrity": "sha512-/fsH/GAxc62rvwTnmrnV8oGCkk4LwJ9pt2Jv3UIorNsjXyL0V5fGw7uZnilF2eSdu6LgQKBMWPOtBF0TNML3lg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pixi/math": "5.3.12",
         "@pixi/settings": "5.3.12",
@@ -139,6 +145,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.12.tgz",
       "integrity": "sha512-tLAa8tpDGllgj88NMUQn2Obn9MFJfHNF/CKs8aBhfeZGU4yL4PZDtlI+tqaB1ITGl3xxyHmJK+qfmv5lJn+zyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ismobilejs": "^1.1.0"
       }
@@ -147,8 +154,7 @@
       "version": "6.5.10",
       "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-6.5.10.tgz",
       "integrity": "sha512-EIUGza+E+sCy3dupuIjvRK/WyVyfSzHb5XsxRaxNrPwvG1iIUIqNqZ3owLYCo4h17fJWrj/yXVufNNtUKQccWQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@pixi/loaders": {
       "version": "5.3.12",
@@ -183,15 +189,13 @@
       "version": "6.5.10",
       "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.5.10.tgz",
       "integrity": "sha512-4HiHp6diCmigJT/DSbnqQP62OfWKmZB7zPWMdV1AEdr4YT1QxzXAW1wHg7dkoEfyTHqZKl0tm/zcqKq/iH7tMA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@pixi/settings": {
       "version": "6.5.10",
       "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.5.10.tgz",
       "integrity": "sha512-ypAS5L7pQ2Qb88yQK72bXtc7sD8OrtLWNXdZ/gnw5kwSWCFaOSoqhKqJCXrR5DQtN98+RQefwbEAmMvqobhFyw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@pixi/constants": "6.5.10"
       }
@@ -201,6 +205,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.12.tgz",
       "integrity": "sha512-vticet92RFZ3nDZ6/VDwZ7RANO0jzyXOF/5RuJf0yNVJgBoH4cNix520FfsBWE2ormD+z5t1KEmFeW4e35z2kw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pixi/constants": "5.3.12",
         "@pixi/core": "5.3.12",
@@ -214,13 +219,15 @@
       "version": "5.3.12",
       "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.12.tgz",
       "integrity": "sha512-UcuvZZ8cQu+ZC7ufLpKi8NfZX0FncPuxKd0Rf6u6pzO2SmHPq4C1moXYGDnkZjPFAjNYFFHC7chU+zolMtkL/g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pixi/sprite/node_modules/@pixi/settings": {
       "version": "5.3.12",
       "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.12.tgz",
       "integrity": "sha512-tLAa8tpDGllgj88NMUQn2Obn9MFJfHNF/CKs8aBhfeZGU4yL4PZDtlI+tqaB1ITGl3xxyHmJK+qfmv5lJn+zyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ismobilejs": "^1.1.0"
       }
@@ -230,7 +237,6 @@
       "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.5.10.tgz",
       "integrity": "sha512-UqX1XYtzqFSirmTOy8QAK4Ccg4KkIZztrBdRPKwFSOEiKAJoGDCSBmyQBo/9aYQKGObbNnrJ7Hxv3/ucg3/1GA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@pixi/extensions": "6.5.10",
         "@pixi/settings": "6.5.10"
@@ -241,6 +247,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.12.tgz",
       "integrity": "sha512-PU/L852YjVbTy/6fDKQtYji6Vqcwi5FZNIjK6JXKuDPF411QfJK3QBaEqJTrexzHlc9Odr0tYECjwtXkCUR02g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pixi/constants": "5.3.12",
         "@pixi/settings": "5.3.12",
@@ -253,13 +260,15 @@
       "version": "5.3.12",
       "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.12.tgz",
       "integrity": "sha512-UcuvZZ8cQu+ZC7ufLpKi8NfZX0FncPuxKd0Rf6u6pzO2SmHPq4C1moXYGDnkZjPFAjNYFFHC7chU+zolMtkL/g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pixi/utils/node_modules/@pixi/settings": {
       "version": "5.3.12",
       "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.12.tgz",
       "integrity": "sha512-tLAa8tpDGllgj88NMUQn2Obn9MFJfHNF/CKs8aBhfeZGU4yL4PZDtlI+tqaB1ITGl3xxyHmJK+qfmv5lJn+zyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ismobilejs": "^1.1.0"
       }
@@ -1100,7 +1109,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -1663,7 +1671,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
       "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -1794,7 +1803,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mini-signals/-/mini-signals-1.2.0.tgz",
       "integrity": "sha512-alffqMkGCjjTSwvYMVLx+7QeJ6sTuxbXqBkP21my4iWU5+QpTQAJt3h7htA1OKm9F3BpMM0vnu72QIoiJakrLA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -1882,6 +1892,17 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/normalize-url": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
@@ -1960,6 +1981,7 @@
       "resolved": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.11.tgz",
       "integrity": "sha512-nQQNb6GJinexGecJEbfKJdoQ9mbwAHDbYUIDTB0y+DTQaxdZwERtx7LJ631QEBFDXkcxD5+ixBYmt0n2LkWcwQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -2110,7 +2132,6 @@
       "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.5.10.tgz",
       "integrity": "sha512-Gdzp5ENypyglvsh5Gv3teUZnZnmizo4xOsL+QqmWALdFlJXJwLJMVhKVThV/q/095XR6i4Ou54oshn+m4EkuFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/offscreencanvas": "^2019.6.4"
       },
@@ -2133,7 +2154,6 @@
       "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.5.10.tgz",
       "integrity": "sha512-NxFdDDxlbH5fQkzGHraLGoTMucW9pVgXqQm13TSmkA3NWIi/SItHL4qT2SI8nmclT9Vid1VDEBCJFAbdeuQw1Q==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@pixi/constants": "6.5.10",
         "@pixi/math": "6.5.10",
@@ -2215,7 +2235,6 @@
       "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.5.10.tgz",
       "integrity": "sha512-KPHGJ910fi8bRQQ+VcTIgrK+bKIm8yAQaZKPqMtm14HzHPGcES6HkgeNY1sd7m8J4aS9btm5wOSyFu0p5IzTpA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@pixi/constants": "6.5.10",
         "@pixi/core": "6.5.10",
@@ -2243,7 +2262,6 @@
       "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.5.10.tgz",
       "integrity": "sha512-AuK7mXBmyVsDFL9DDFPB8sqP8fwQ2NOktvu98bQuJl0/p/UeK/0OAQnF3wcf3FeBv5YGXfNHL21c2DCisjKfTg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@pixi/constants": "6.5.10",
         "@pixi/core": "6.5.10",
@@ -2254,15 +2272,13 @@
       "version": "6.5.10",
       "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.5.10.tgz",
       "integrity": "sha512-fxeu7ykVbMGxGV2S3qRTupHToeo1hdWBm8ihyURn3BMqJZe2SkZEECPd5RyvIuuNUtjRnmhkZRnF3Jsz2S+L0g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pixi.js/node_modules/@pixi/mesh": {
       "version": "6.5.10",
       "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.5.10.tgz",
       "integrity": "sha512-tUNPsdp5/t/yRsCmfxIcufIfbQVzgAlMNgQ1igWOkSxzhB7vlEbZ8ZLLW5tQcNyM/r7Nhjz+RoB+RD+/BCtvlA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@pixi/constants": "6.5.10",
         "@pixi/core": "6.5.10",
@@ -2353,7 +2369,6 @@
       "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.5.10.tgz",
       "integrity": "sha512-UiK+8LgM9XQ/SBDKjRgZ8WggdOSlFRXqiWjEZVmNkiyU8HvXeFzWPRhpc8RR1zDwAUhZWKtMhF8X/ba9m+z2lg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@pixi/constants": "6.5.10",
         "@pixi/core": "6.5.10",
@@ -2405,7 +2420,6 @@
       "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.5.10.tgz",
       "integrity": "sha512-ikwkonLJ+6QmEVW8Ji9fS5CjrKNbU4mHzYuwRQas/VJQuSWgd0myCcaw6ZbF1oSfQe70HgbNOR0sH8Q3Com0qg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@pixi/core": "6.5.10",
         "@pixi/math": "6.5.10",
@@ -2436,7 +2450,6 @@
       "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.5.10.tgz",
       "integrity": "sha512-4f4qDMmAz9IoSAe08G2LAxUcEtG9jSdudfsMQT2MG+OpfToirboE6cNoO0KnLCvLzDVE/mfisiQ9uJbVA9Ssdw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/earcut": "^2.1.0",
         "earcut": "^2.2.4",
@@ -2578,6 +2591,7 @@
       "resolved": "https://registry.npmjs.org/resource-loader/-/resource-loader-3.0.1.tgz",
       "integrity": "sha512-fBuCRbEHdLCI1eglzQhUv9Rrdcmqkydr1r6uHE2cYHvRBrcLXeSmbE/qI/urFt8rPr/IGxir3BUwM5kUK8XoyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mini-signals": "^1.2.0",
         "parse-uri": "^1.0.0"
@@ -2970,8 +2984,7 @@
       "version": "0.183.2",
       "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
       "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -3007,6 +3020,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uiohook-napi": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/uiohook-napi/-/uiohook-napi-1.5.5.tgz",
+      "integrity": "sha512-oSlTdnECw2GBfsJPTbBQBeE4v/EXP0EZmX6BJq5nzH/JgFaBE8JpFwEA/kLhiEP7HxQw28FViWiYgdIZzWuuJQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/undici-types": {
@@ -3147,7 +3173,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/live-2d/package.json
+++ b/live-2d/package.json
@@ -20,7 +20,8 @@
     "play-sound": "^1.1.6",
     "screenshot-desktop": "^1.15.3",
     "socket.io-client": "^4.8.1",
-    "three": "^0.183.2"
+    "three": "^0.183.2",
+    "uiohook-napi": "^1.5.5"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## 背景

当前 PTT（按住说话）逻辑只在渲染进程里监听 `document` 的 `keydown` / `keyup`。当游戏或其它窗口拿到焦点后，Electron 窗口收不到 V 键事件，PTT 模式下就会表现为 ASR 无法开始或无法正确结束录音。

## 修改内容

- 在主进程 `ShortcutManager` 中引入 `uiohook-napi`，监听全局键盘 `keydown` / `keyup`，并通过 `ptt-global-key` IPC 通知渲染进程。
- 渲染层 PTT 改为同时支持全局事件和窗口内事件兜底，并统一处理重复按键、输入框焦点、窗口失焦、页面隐藏和卸载清理。
- 增加 `pttCancelRecording()`，用于切换模式或异常收尾时丢弃当前录音，避免 `isRecording`、`asrLocked`、`silenceTimeout` 残留导致后续 PTT 卡住。
- 应用退出时释放全局 hook 和 Electron 全局快捷键。
- 新增 `uiohook-napi` 依赖。

## 行为说明

- 只有 PTT 模式开启时，全局 V 键才会触发录音。
- PTT 模式关闭时，全局 hook 只观察按键，不拦截按键，微信、游戏、办公软件仍可正常输入 V。
- 如果 `uiohook-napi` 加载或启动失败，会自动降级为原来的窗口内监听兜底，不影响应用启动。

## 验证

- `node -c live-2d/js/shortcut-manager.js`
- `node -c live-2d/main.js`
- `node -c live-2d/js/ui/ui-controller.js`
- `node -c live-2d/js/voice/asr-processor.js`
- `node -c live-2d/js/ai/conversation/ASRController.js`
- `node -c live-2d/js/ai/conversation/VoiceChatFacade.js`
- `npm ls uiohook-napi`
- `git diff --check`

备注：实际游戏焦点下的全局按键行为需要在 Windows 桌面环境中手动确认；如果游戏以管理员权限运行，应用也可能需要同等权限才能收到全局键盘事件。