### PR TITLE
fix: 限制字幕调整模式的拖动热区

### DIFF
--- a/live-2d/css/styles.css
+++ b/live-2d/css/styles.css
@@ -843,7 +843,8 @@ body.screen-left #text-chat-container {
     z-index: 9999 !important;
     background: rgba(0, 0, 0, 0.5) !important;
     box-sizing: border-box;
-    pointer-events: none;
+    cursor: grab;
+    pointer-events: auto;
 }
 
 /* 字幕调整操作按钮 */

--- a/live-2d/js/ui/ui-controller.js
+++ b/live-2d/js/ui/ui-controller.js
@@ -859,7 +859,7 @@ class UIController {
         if (!overlay) {
             overlay = document.createElement('div');
             overlay.id = 'subtitle-adjust-overlay';
-            overlay.style.cssText = 'position:fixed;top:0;left:0;right:0;bottom:0;z-index:9998;background:transparent;cursor:grab;';
+            overlay.style.cssText = 'position:fixed;top:0;left:0;right:0;bottom:0;z-index:9998;background:transparent;cursor:default;';
             document.body.appendChild(overlay);
         }
 
@@ -877,7 +877,7 @@ class UIController {
         const onDragStart = (e) => {
             if (e.target.id === 'subtitle-confirm-btn') return;
             e.preventDefault(); e.stopPropagation();
-            this.isDraggingSubtitle = true; overlay.style.cursor = 'grabbing';
+            this.isDraggingSubtitle = true; c.style.cursor = 'grabbing';
             const sx = e.clientX, sy = e.clientY, scx = this._subtitleCenterX, scy = this._subtitleCenterY;
             const onMove = (ev) => {
                 if (!this.isDraggingSubtitle) return;
@@ -886,15 +886,15 @@ class UIController {
                 c.style.top = `${this._subtitleCenterY = scy + ev.clientY - sy}px`;
             };
             const onUp = () => {
-                this.isDraggingSubtitle = false; overlay.style.cursor = 'grab';
+                this.isDraggingSubtitle = false; c.style.cursor = '';
                 document.removeEventListener('mousemove', onMove);
                 document.removeEventListener('mouseup', onUp);
             };
             document.addEventListener('mousemove', onMove);
             document.addEventListener('mouseup', onUp);
         };
-        overlay.addEventListener('mousedown', onDragStart);
-        this._adjustCleanup.push(() => overlay.removeEventListener('mousedown', onDragStart));
+        c.addEventListener('mousedown', onDragStart);
+        this._adjustCleanup.push(() => c.removeEventListener('mousedown', onDragStart));
 
         // 滚轮缩放
         const onWheel = (e) => {
@@ -902,8 +902,8 @@ class UIController {
             this.subtitleScale = Math.max(0.3, Math.min(3.0, this.subtitleScale + (e.deltaY > 0 ? -0.05 : 0.05)));
             c.style.transform = `translate(-50%, -50%) scale(${this.subtitleScale})`;
         };
-        overlay.addEventListener('wheel', onWheel, { passive: false });
-        this._adjustCleanup.push(() => overlay.removeEventListener('wheel', onWheel));
+        c.addEventListener('wheel', onWheel, { passive: false });
+        this._adjustCleanup.push(() => c.removeEventListener('wheel', onWheel));
 
         // 确认按钮
         const confirmBtn = document.getElementById('subtitle-confirm-btn');
@@ -929,6 +929,7 @@ class UIController {
         }
 
         c.classList.remove('subtitle-adjusting');
+        c.style.cursor = '';
         const t = document.getElementById('subtitle-text');
         if (t) t.textContent = this._savedText || '';
         if (!this._savedText) c.style.display = this._savedDisplay || 'none';


### PR DESCRIPTION
## 变更说明

- 将字幕调整模式的拖拽起点从全屏透明遮罩改为字幕框本身，避免在全屏任意位置都能拖动字幕。
- 调整模式下恢复字幕框的鼠标事件，并为字幕框显示 grab/grabbing 光标反馈。
- 将滚轮缩放响应范围同步限制在字幕框区域内。
- 退出调整模式时清理字幕框的临时光标样式，避免影响正常字幕显示。

## 验证

- 已执行 
ode --check live-2d/js/ui/ui-controller.js，语法检查通过。
- 已执行 git diff --check，未发现空白错误。
- 已确认本次提交只包含：
  - live-2d/css/styles.css
  - live-2d/js/ui/ui-controller.js

## 隐私与敏感信息

- 本次操作使用线上仓库的干净临时克隆完成，没有带入本地工作区文件。
- 已检查本次 diff，未新增 key、token、secret、prompt、system_prompt 等敏感或提示词相关内容。