### PR TITLE
修复配置修改后缺少未保存提醒

### DIFF
--- a/live-2d/test.py
+++ b/live-2d/test.py
@@ -550,6 +550,10 @@ class set_pyqt(QWidget):
         self.selected_audio_path = None  # 选择的音频文件路径
         self.config_path = 'config.json'
         self.config = self.load_config()
+        self.config_dirty = False
+        self._loading_config_ui = False
+        self._config_dirty_widgets = []
+        self._save_button_default_style = ''
 
         # 日志读取相关
         self.log_readers = {}
@@ -690,6 +694,7 @@ class set_pyqt(QWidget):
         # 保持原来的功能
         self.set_btu()
         self.set_config()
+        self._init_config_dirty_tracking()
 
         # 云端版本隐藏本地专属功能入口
         if IS_CLOUD_VERSION:
@@ -735,6 +740,10 @@ class set_pyqt(QWidget):
 
     def closeEvent(self, event):
         """处理窗口关闭事件"""
+        if not self._confirm_discard_unsaved_config("关闭前保存配置"):
+            event.ignore()
+            return
+
         try:
             # 重新加载配置，确保使用最新的设置
             try:
@@ -2780,6 +2789,136 @@ class set_pyqt(QWidget):
             # 静默失败，不显示错误
             pass
 
+    def _mark_config_dirty(self):
+        if self._loading_config_ui:
+            return
+        self.config_dirty = True
+        self._update_config_dirty_indicator()
+
+    def _clear_config_dirty(self):
+        self.config_dirty = False
+        self._update_config_dirty_indicator()
+
+    def _update_config_dirty_indicator(self):
+        if not hasattr(self, 'ui') or not hasattr(self.ui, 'saveConfigButton'):
+            return
+
+        if self.config_dirty:
+            self.ui.saveConfigButton.setStyleSheet("""
+                QPushButton {
+                    background-color: #eab308;
+                    color: #111111;
+                    border-radius: 8px;
+                    border: 1px solid #ca8a04;
+                    padding: 6px 12px;
+                    font-weight: bold;
+                }
+                QPushButton:hover {
+                    background-color: #f59e0b;
+                }
+            """)
+            self.ui.saveConfigButton.setToolTip("当前配置有未保存的修改，请先保存配置")
+        else:
+            self.ui.saveConfigButton.setStyleSheet(self._save_button_default_style)
+            self.ui.saveConfigButton.setToolTip("")
+
+    def _init_config_dirty_tracking(self):
+        self._save_button_default_style = self.ui.saveConfigButton.styleSheet()
+        self._config_dirty_widgets = [
+            self.ui.lineEdit,
+            self.ui.lineEdit_2,
+            self.ui.lineEdit_3,
+            self.ui.textEdit_3,
+            self.ui.doubleSpinBox_temperature,
+            self.ui.checkBox_temperature_enabled,
+            self.ui.lineEdit_4,
+            self.ui.lineEdit_5,
+            self.ui.checkBox_mcp_enable,
+            self.ui.checkBox_5,
+            self.ui.checkBox_3,
+            self.ui.checkBox_4,
+            self.ui.checkBox_asr,
+            self.ui.checkBox_tts,
+            self.ui.checkBox_persistent_history,
+            self.ui.checkBox_voice_barge_in,
+            self.ui.checkBox_ptt_enabled,
+            self.ui.comboBox_tts_language,
+            self.ui.checkBox_subtitle_enabled,
+            self.ui.lineEdit_user_name,
+            self.ui.lineEdit_ai_name,
+            self.ui.checkBox_hide_model,
+            self.ui.checkBox_auto_close_services,
+            self.ui.lineEdit_cloud_provider,
+            self.ui.lineEdit_cloud_api_key,
+            self.ui.checkBox_cloud_tts_enabled,
+            self.ui.lineEdit_cloud_tts_url,
+            self.ui.lineEdit_cloud_tts_model,
+            self.ui.lineEdit_cloud_tts_voice,
+            self.ui.comboBox_cloud_tts_format,
+            self.ui.doubleSpinBox_cloud_tts_speed,
+            self.ui.checkBox_aliyun_tts_enabled,
+            self.ui.lineEdit_aliyun_tts_api_key,
+            self.ui.lineEdit_aliyun_tts_model,
+            self.ui.lineEdit_aliyun_tts_voice,
+            self.ui.checkBox_volcengine_tts_enabled,
+            self.ui.lineEdit_volcengine_tts_appid,
+            self.ui.lineEdit_volcengine_tts_access_token,
+            self.ui.lineEdit_volcengine_tts_voice_type,
+            self.ui.checkBox_cloud_asr_enabled,
+            self.ui.lineEdit_cloud_asr_url,
+            self.ui.lineEdit_cloud_asr_appid,
+            self.ui.lineEdit_cloud_asr_appkey,
+            self.ui.lineEdit_cloud_asr_dev_pid,
+            self.ui.checkBox_gateway_enabled,
+            self.ui.lineEdit_gateway_base_url,
+            self.ui.lineEdit_gateway_api_key,
+            self.ui.checkBox_use_vision_model,
+            self.ui.lineEdit_vision_api_key,
+            self.ui.lineEdit_vision_api_url,
+            self.ui.lineEdit_vision_model,
+        ]
+
+        if hasattr(self, 'checkBox_vmc_enabled'):
+            self._config_dirty_widgets.extend([
+                self.checkBox_vmc_enabled,
+                self.lineEdit_vmc_host,
+                self.lineEdit_vmc_port,
+            ])
+
+        for widget in self._config_dirty_widgets:
+            try:
+                if isinstance(widget, QLineEdit):
+                    widget.textChanged.connect(self._mark_config_dirty)
+                elif isinstance(widget, QTextEdit):
+                    widget.textChanged.connect(self._mark_config_dirty)
+                elif isinstance(widget, QCheckBox):
+                    widget.stateChanged.connect(lambda *_: self._mark_config_dirty())
+                elif isinstance(widget, QComboBox):
+                    widget.currentIndexChanged.connect(lambda *_: self._mark_config_dirty())
+                elif isinstance(widget, (QSpinBox, QDoubleSpinBox)):
+                    widget.valueChanged.connect(lambda *_: self._mark_config_dirty())
+            except RuntimeError:
+                pass
+
+        self._clear_config_dirty()
+
+    def _confirm_discard_unsaved_config(self, title="未保存配置"):
+        if not self.config_dirty:
+            return True
+        reply = QMessageBox.warning(
+            self,
+            title,
+            "当前配置有未保存的修改，继续操作可能导致配置未生效。\n\n是否仍要继续？",
+            QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel,
+            QMessageBox.Save
+        )
+        if reply == QMessageBox.Save:
+            self.save_config()
+            return not self.config_dirty
+        if reply == QMessageBox.Discard:
+            return True
+        return False
+
     def set_btu(self):
         self.ui.pushButton.clicked.connect(lambda: self.ui.stackedWidget.setCurrentIndex(1))
         self.ui.pushButton_3.clicked.connect(lambda: self.ui.stackedWidget.setCurrentIndex(0))
@@ -3331,6 +3470,7 @@ class set_pyqt(QWidget):
 
 
     def set_config(self):
+        self._loading_config_ui = True
         self.ui.lineEdit.setText(self.config['llm']['api_key'])
         self.ui.lineEdit_2.setText(self.config['llm']['api_url'])
         self.ui.lineEdit_3.setText(self.config['llm']['model'])
@@ -3434,6 +3574,7 @@ class set_pyqt(QWidget):
             self.checkBox_vmc_enabled.setChecked(vmc_config.get('enabled', False))
             self.lineEdit_vmc_host.setText(vmc_config.get('host', '127.0.0.1'))
             self.lineEdit_vmc_port.setText(str(vmc_config.get('port', 39539)))
+        self._loading_config_ui = False
 
 
     # ===== 插件配置文件读写 =====
@@ -4080,6 +4221,7 @@ class set_pyqt(QWidget):
             with open(cfg_path, 'w', encoding='utf-8') as f:
                 import json
                 json.dump(cfg, f, ensure_ascii=False, indent=2)
+            self._clear_config_dirty()
             self.toast.show_message("配置已保存", 1500)
         except Exception as e:
             self.toast.show_message(f"保存失败: {e}", 3000)
@@ -4379,6 +4521,8 @@ class set_pyqt(QWidget):
             self.update_toggle_button_style(False)
         else:
             # 当前未运行，执行启动操作
+            if not self._confirm_discard_unsaved_config("启动前保存配置"):
+                return
             self.start_live_2d()
             self.live2d_running = True
             self.update_toggle_button_style(True)
@@ -4770,6 +4914,7 @@ class set_pyqt(QWidget):
 
         # 重新加载配置到内存，确保立即生效
         self.config = current_config
+        self._clear_config_dirty()
 
         # 使用Toast提示替代QMessageBox
         self.toast.show_message("配置已保存，模型选择已应用", 1500)

--- a/live-2d/webui/config_manager.py
+++ b/live-2d/webui/config_manager.py
@@ -221,6 +221,7 @@ def handle_ui_settings():
         subtitle_config = config.get('subtitle_labels', {})
         return jsonify({
             'show_chat_box': ui_config.get('show_chat_box', True),
+            'intro_text': ui_config.get('intro_text', '你好啊'),
             'show_model': ui_config.get('show_model', True),
             'model_scale': ui_config.get('model_scale', 2.3),
             'subtitle_user': subtitle_config.get('user', '用户'),
@@ -235,6 +236,7 @@ def handle_ui_settings():
             if 'subtitle_labels' not in config:
                 config['subtitle_labels'] = {}
             config['ui']['show_chat_box'] = data.get('show_chat_box', True)
+            config['ui']['intro_text'] = data.get('intro_text', config['ui'].get('intro_text', '你好啊'))
             config['ui']['show_model'] = data.get('show_model', True)
             config['ui']['model_scale'] = data.get('model_scale', 2.3)
             config['subtitle_labels']['user'] = data.get('subtitle_user', '用户')

--- a/live-2d/webui/static/css/style.css
+++ b/live-2d/webui/static/css/style.css
@@ -153,6 +153,10 @@ h1 {
     background: #3b82f6;
     border-color: rgba(59, 130, 246, 0.5);
 }
+.tab-button.has-unsaved-config {
+    border-color: rgba(234, 179, 8, 0.8);
+    box-shadow: inset 3px 0 0 var(--yellow);
+}
 .tab-content {
     display: none; background: rgba(255, 255, 255, 0.05);
     border-radius: 0 12px 12px 12px; padding: 25px; backdrop-filter: blur(10px);
@@ -211,6 +215,17 @@ h1 {
     background: #1d4ed8;
     transform: none;
     box-shadow: none;
+}
+.config-save-button.config-unsaved,
+.btn-primary.config-unsaved {
+    background: #eab308;
+    color: #111111;
+    box-shadow: 0 0 0 2px rgba(234, 179, 8, 0.25);
+}
+
+.config-save-button.config-unsaved:hover,
+.btn-primary.config-unsaved:hover {
+    background: #f59e0b;
 }
 .dashboard { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; margin-bottom: 30px; }
 @media (max-width: 1200px) {

--- a/live-2d/webui/static/js/app.js
+++ b/live-2d/webui/static/js/app.js
@@ -794,12 +794,16 @@ function updateServiceStatus(serviceName, status) {
     }
 }
 
+function confirmStartLive2dWithCurrentConfig() {
+    return !hasUnsavedConfig() || confirm(START_WITH_UNSAVED_MESSAGE);
+}
+
 // Live2D 启动/关闭切换
 async function toggleLive2dService() {
     if (serviceStates['live2d'] === 'running') {
         await stopService('live2d');
     } else {
-        if (hasUnsavedConfig() && !confirm(START_WITH_UNSAVED_MESSAGE)) {
+        if (!confirmStartLive2dWithCurrentConfig()) {
             return;
         }
         await startService('live2d');
@@ -845,6 +849,9 @@ async function stopService(serviceName) {
 // 重启服务（仅 Live2D）
 async function restartService(serviceName) {
     try {
+        if (serviceName === 'live2d' && !confirmStartLive2dWithCurrentConfig()) {
+            return;
+        }
         addLog(t('services.restarting') + ' ' + serviceName + ' ' + t('services.service_suffix'), 'info', 'system');
         await stopService(serviceName);
         setTimeout(function() { startService(serviceName); }, 1500);
@@ -855,6 +862,10 @@ async function restartService(serviceName) {
 
 // 一键启动全部服务
 async function startAllServices() {
+    if (serviceStates['live2d'] !== 'running' && !confirmStartLive2dWithCurrentConfig()) {
+        return;
+    }
+
     addLog(t('services.start_all_begin'), 'info', 'system');
     const services = ['live2d', 'asr', 'tts', 'memos', 'rag', 'bert'];
     let successCount = 0;

--- a/live-2d/webui/static/js/app.js
+++ b/live-2d/webui/static/js/app.js
@@ -1,6 +1,11 @@
 // My Neuro WebUI - 前端 JavaScript v3.3
 
 const serviceStates = {};
+const UNSAVED_CONFIG_MESSAGE = '当前配置有未保存的修改，请先保存配置。';
+const START_WITH_UNSAVED_MESSAGE = '当前配置有未保存的修改，启动桌宠前建议先保存配置。仍要继续启动吗？';
+const CONFIG_DIRTY_PANELS = new Set(['llm-config', 'voice-settings', 'ui-settings', 'dialog-config']);
+const configDirtyItems = new Set();
+let isConfigDirtyTrackingReady = false;
 let currentLogTab = 'system-log';
 let logPollingInterval = null;
 let lastPetLogCount = 0;  // 记录上次桌宠日志数量
@@ -794,6 +799,9 @@ async function toggleLive2dService() {
     if (serviceStates['live2d'] === 'running') {
         await stopService('live2d');
     } else {
+        if (hasUnsavedConfig() && !confirm(START_WITH_UNSAVED_MESSAGE)) {
+            return;
+        }
         await startService('live2d');
     }
 }
@@ -912,7 +920,98 @@ async function stopAllServices() {
 }
 
 // 切换标签页
+function getDirtyKeyForConfigElement(element) {
+    if (!element || !element.closest) return null;
+    if (element.id === 'live2d-model-select') return null;
+
+    const pluginModal = element.closest('#pluginConfigModal');
+    if (pluginModal && pluginModal.style.display !== 'none') {
+        return 'plugin-config';
+    }
+
+    const panel = element.closest('.tab-content');
+    if (!panel || !CONFIG_DIRTY_PANELS.has(panel.id)) return null;
+    return panel.id;
+}
+
+function getConfigSaveButton(dirtyKey) {
+    if (dirtyKey === 'plugin-config') {
+        return document.getElementById('saveConfigBtn');
+    }
+    const panel = document.getElementById(dirtyKey);
+    return panel ? panel.querySelector('.config-save-button') : null;
+}
+
+function updateConfigDirtyIndicators() {
+    CONFIG_DIRTY_PANELS.forEach(panelId => {
+        const button = getConfigSaveButton(panelId);
+        const tabButton = document.querySelector(`.tab-button[onclick="switchTab('${panelId}')"]`);
+        const isDirty = configDirtyItems.has(panelId);
+
+        if (button) {
+            button.classList.toggle('config-unsaved', isDirty);
+            button.title = isDirty ? UNSAVED_CONFIG_MESSAGE : '';
+        }
+        if (tabButton) {
+            tabButton.classList.toggle('has-unsaved-config', isDirty);
+        }
+    });
+
+    const pluginButton = getConfigSaveButton('plugin-config');
+    if (pluginButton) {
+        const isPluginDirty = configDirtyItems.has('plugin-config');
+        pluginButton.classList.toggle('config-unsaved', isPluginDirty);
+        pluginButton.title = isPluginDirty ? UNSAVED_CONFIG_MESSAGE : '';
+    }
+}
+
+function markConfigDirty(dirtyKey) {
+    if (!dirtyKey) return;
+    configDirtyItems.add(dirtyKey);
+    updateConfigDirtyIndicators();
+}
+
+function clearConfigDirty(dirtyKey) {
+    configDirtyItems.delete(dirtyKey);
+    updateConfigDirtyIndicators();
+}
+
+function clearAllConfigDirty() {
+    configDirtyItems.clear();
+    updateConfigDirtyIndicators();
+}
+
+function hasUnsavedConfig() {
+    return configDirtyItems.size > 0;
+}
+
+function initConfigDirtyTracking() {
+    if (isConfigDirtyTrackingReady) return;
+    const markFromEvent = (event) => {
+        const element = event.target;
+        const tagName = element && element.tagName ? element.tagName.toLowerCase() : '';
+        if (!['input', 'textarea', 'select'].includes(tagName)) return;
+        if (element.type && ['button', 'submit', 'reset', 'file', 'hidden'].includes(element.type)) return;
+
+        markConfigDirty(getDirtyKeyForConfigElement(element));
+    };
+
+    document.addEventListener('input', markFromEvent, true);
+    document.addEventListener('change', markFromEvent, true);
+    isConfigDirtyTrackingReady = true;
+}
+
+function confirmLeaveDirtyConfig(dirtyKey) {
+    if (!configDirtyItems.has(dirtyKey)) return true;
+    return confirm(UNSAVED_CONFIG_MESSAGE);
+}
+
 function switchTab(tabName) {
+    const currentPanel = document.querySelector('.tab-content.active');
+    if (currentPanel && currentPanel.id !== tabName && !confirmLeaveDirtyConfig(currentPanel.id)) {
+        return;
+    }
+
     document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
     document.querySelectorAll('.tab-button').forEach(b => b.classList.remove('active'));
     document.getElementById(tabName).classList.add('active');
@@ -929,7 +1028,7 @@ function switchTab(tabName) {
 // ============ 配置保存 ============
 
 // 保存配置的通用函数
-async function saveConfig(url, data, successMsg) {
+async function saveConfig(url, data, successMsg, dirtyKey = null) {
     try {
         const response = await fetch(url, {
             method: 'POST',
@@ -939,6 +1038,9 @@ async function saveConfig(url, data, successMsg) {
         const result = await response.json();
         if (response.ok && result.success) {
             addLog(successMsg, 'success', 'system');
+            if (dirtyKey) {
+                clearConfigDirty(dirtyKey);
+            }
         } else {
             addLog(t('common.save') + t('common.error') + '：' + (result.error || t('common.unknown_error')), 'error', 'system');
         }
@@ -966,6 +1068,7 @@ async function saveLLMConfig() {
         if (response.ok && result.success) {
             addLog(t('llm_config.save_success'), 'success', 'system');
             showSuccess(t('llm_config.save_success'));
+            clearConfigDirty('llm-config');
         } else {
             addLog(t('llm_config.save_failed') + '：' + (result.error || t('common.unknown_error')), 'error', 'system');
             showError(t('llm_config.save_failed') + '：' + (result.error || t('common.unknown_error')));
@@ -1052,6 +1155,7 @@ async function saveCloudSettings() {
         if (response.ok && result.success) {
             addLog(t('cloud_config.save_success'), 'success', 'system');
             showSuccess(t('cloud_config.save_success'));
+            clearConfigDirty('voice-settings');
         } else {
             addLog(t('cloud_config.save_failed') + '：' + (result.error || t('common.unknown_error')), 'error', 'system');
             showError(t('cloud_config.save_failed') + '：' + (result.error || t('common.unknown_error')));
@@ -1321,6 +1425,7 @@ document.addEventListener('DOMContentLoaded', async function() {
         try { await window.i18nReady; } catch (e) { console.error('i18n init failed:', e); }
     }
     // 初始化保存按钮状态（防止页面跳动）
+    initConfigDirtyTracking();
     switchTab('dashboard');
 
     // 检查服务状态
@@ -1369,7 +1474,12 @@ document.addEventListener('DOMContentLoaded', async function() {
     console.log(t('logs.init_complete'));
 
     // 页面卸载时停止所有轮询
-    window.addEventListener('beforeunload', () => {
+    window.addEventListener('beforeunload', (event) => {
+        if (hasUnsavedConfig()) {
+            event.preventDefault();
+            event.returnValue = '';
+            return;
+        }
         stopLogPolling();
         stopChatHistoryPolling();
     });
@@ -1448,8 +1558,12 @@ async function saveCurrentModel() {
 // 保存 UI 设置
 async function saveUISettings() {
     const settings = {
+        intro_text: document.getElementById('intro-text').value,
         show_chat_box: document.getElementById('show-chat-box').checked,
         show_model: !document.getElementById('hide-model').checked,  // 勾选表示隐藏，所以取反
+        subtitle_enabled: document.getElementById('subtitle-enabled').checked,
+        subtitle_user: document.getElementById('subtitle-user').value,
+        subtitle_ai: document.getElementById('subtitle-ai').value,
         subtitle_labels: {
             enabled: document.getElementById('subtitle-enabled').checked,
             user: document.getElementById('subtitle-user').value,
@@ -1466,6 +1580,7 @@ async function saveUISettings() {
         if (response.ok && result.success) {
             addLog(t('ui_settings.ui_save_success'), 'success', 'system');
             showSuccess(t('ui_settings.ui_save_success'));
+            clearConfigDirty('ui-settings');
         } else {
             addLog(t('ui_settings.ui_save_failed') + '：' + (result.error || t('common.unknown_error')), 'error', 'system');
             showError(t('ui_settings.ui_save_failed') + '：' + (result.error || t('common.unknown_error')));
@@ -2092,7 +2207,10 @@ function openPluginConfigModal(pluginPath, displayName) {
 }
 
 // 关闭插件配置模态框
-function closePluginConfigModal() {
+function closePluginConfigModal(force = false) {
+    if (!force && !confirmLeaveDirtyConfig('plugin-config')) {
+        return;
+    }
     // 恢复背景滚动
     document.body.style.overflow = '';
     document.documentElement.style.overflow = '';
@@ -2180,6 +2298,7 @@ async function loadPluginConfig(displayName) {
             
             // 渲染配置表单（使用键顺序）
             renderPluginConfigForm(result.config);
+            clearConfigDirty('plugin-config');
             
             // 检查 README 是否存在
             checkReadmeExists(displayName);
@@ -2300,6 +2419,7 @@ function resetPluginConfig() {
         resetFieldToDefault(key, field);
     }
     
+    markConfigDirty('plugin-config');
     addLog(t('plugins.reset_default'), 'info', 'system');
 }
 
@@ -2345,7 +2465,8 @@ async function savePluginConfig() {
         if (response.ok && result.success) {
             addLog(t('plugins.save_success'), 'success', 'system');
             showSuccess(t('plugins.save_success'));
-            closePluginConfigModal();
+            clearConfigDirty('plugin-config');
+            closePluginConfigModal(true);
             // 重新加载插件列表以更新状态
             loadPlugins();
         } else {
@@ -2593,6 +2714,8 @@ async function saveDialogSettings() {
         if (response1.ok && result1.success && response2.ok && result2.success) {
             addLog(t('dialog_config.save_success'), 'success', 'system');
             showSuccess(t('dialog_config.save_success'));
+            clearConfigDirty('dialog-config');
+            clearConfigDirty('ui-settings');
         } else {
             const errorMsg = (result1.error || result2.error || t('common.unknown_error'));
             addLog(t('dialog_config.save_failed') + '：' + errorMsg, 'error', 'system');


### PR DESCRIPTION
## 背景

用户修改配置后，如果忘记点击保存，启动桌宠或离开配置页时没有明显提醒，容易出现“配置看起来改了但实际未生效”的困惑。

## 修改

- WebUI 增加未保存配置状态追踪：配置项被修改后，高亮对应保存按钮，并在侧边栏配置入口显示黄色提示。
- WebUI 在切换配置页、关闭/刷新页面、启动桌宠前检测未保存修改，并给出确认提醒。
- 插件配置弹窗支持未保存状态提示，重置默认值后会标记为未保存，保存成功后清除提示。
- Qt 主窗口增加配置脏状态：编辑配置后高亮“保存配置”按钮，关闭窗口或启动桌宠前提示保存/继续/取消。
- WebUI 的 UI 设置保存补充 `intro_text`，避免“开场白”在 Live2D 设置页修改后无法通过该页保存。

## 验证

- `python -m py_compile live-2d/test.py live-2d/webui/config_manager.py`
- `node --check live-2d/webui/static/js/app.js`
- `git diff --check`

## 影响

改动只涉及配置保存提醒和 UI 保存字段补全，不改变桌宠启动、服务管理、模型切换等核心流程。未保存提示只在用户修改配置后触发，保存成功后自动清除。