### PR TITLE
feat: add GitHub releases check and update modal to WebUI

### DIFF
--- a/live-2d/webui/main_app.py
+++ b/live-2d/webui/main_app.py
@@ -31,6 +31,7 @@ def create_app():
     from .marketplace import market_bp
     from .log_monitor import log_bp
     from .live2d_manager import live2d_bp
+    from .updater import updater_bp
 
     app.register_blueprint(service_bp)
     app.register_blueprint(config_bp)
@@ -39,6 +40,7 @@ def create_app():
     app.register_blueprint(market_bp)
     app.register_blueprint(log_bp)
     app.register_blueprint(live2d_bp)
+    app.register_blueprint(updater_bp)
     
     # 注册首页路由（必须在蓝图之后，确保根路径被正确处理）
     @app.route('/')

--- a/live-2d/webui/static/css/style.css
+++ b/live-2d/webui/static/css/style.css
@@ -2104,6 +2104,14 @@ body.header-collapsed .collapse-icon {
     border: 1px solid rgba(255, 255, 255, 0.1);
     transition: all 0.3s ease;
     flex-shrink: 0;
+    /* 重置 <button> 默认样式，保持与 <a> 对齐一致 */
+    cursor: pointer;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    line-height: 0;
+    appearance: none;
+    -webkit-appearance: none;
 }
 
 .header-icon svg {

--- a/live-2d/webui/static/js/releases.js
+++ b/live-2d/webui/static/js/releases.js
@@ -1,0 +1,488 @@
+/**
+ * releases.js - 版本更新检查模块
+ * 自动检查 GitHub releases，高亮更新按钮，弹窗展示版本列表
+ */
+(function () {
+    'use strict';
+
+    // ============ 状态 ============
+    let currentVersion = '';
+    let releases = [];
+    let hasNewVersion = false;
+
+    // ============ 注入样式 ============
+    function injectStyles() {
+        if (document.getElementById('releases-styles')) return;
+        const style = document.createElement('style');
+        style.id = 'releases-styles';
+        style.textContent = `
+/* 更新按钮高亮 */
+#checkUpdateBtn.has-update {
+    color: #60a5fa !important;
+    animation: releases-pulse 2s ease-in-out infinite;
+}
+@keyframes releases-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.6; }
+}
+
+/* Releases 模态框特殊样式 */
+#releasesModal .modal-content {
+    max-width: 720px;
+}
+#releasesModal .releases-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+#releasesModal .releases-version-badge {
+    font-size: 12px;
+    padding: 2px 10px;
+    border-radius: 12px;
+    background: rgba(99, 102, 241, 0.2);
+    color: #a5b4fc;
+}
+#releasesModal .releases-list {
+    max-height: 60vh;
+    overflow-y: auto;
+}
+#releasesModal .release-item {
+    padding: 16px 20px;
+    border-bottom: 1px solid rgba(255,255,255,0.08);
+}
+#releasesModal .release-item:last-child {
+    border-bottom: none;
+}
+#releasesModal .release-item:hover {
+    background: rgba(255,255,255,0.03);
+}
+#releasesModal .release-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    margin-bottom: 6px;
+}
+#releasesModal .release-name {
+    font-weight: 600;
+    font-size: 15px;
+    color: #e5e7eb;
+}
+#releasesModal .release-badges {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    margin-top: 4px;
+}
+#releasesModal .badge {
+    font-size: 11px;
+    padding: 1px 8px;
+    border-radius: 4px;
+    font-weight: 500;
+}
+.badge-latest {
+    background: rgba(34,197,94,0.2);
+    color: #4ade80;
+}
+.badge-new {
+    background: rgba(251,191,36,0.2);
+    color: #fbbf24;
+}
+.badge-pre {
+    background: rgba(168,85,247,0.2);
+    color: #c084fc;
+}
+#releasesModal .release-date {
+    font-size: 12px;
+    color: #6b7280;
+    margin-top: 2px;
+}
+#releasesModal .release-body {
+    font-size: 13px;
+    color: #9ca3af;
+    margin: 8px 0;
+    line-height: 1.6;
+    max-height: 200px;
+    overflow-y: auto;
+}
+#releasesModal .release-body h1,
+#releasesModal .release-body h2,
+#releasesModal .release-body h3 {
+    font-weight: 600;
+    margin: 0.5em 0 0.25em;
+    color: #d1d5db;
+}
+#releasesModal .release-body h1 { font-size: 1.1em; }
+#releasesModal .release-body h2 { font-size: 1em; }
+#releasesModal .release-body h3 { font-size: 0.95em; }
+#releasesModal .release-body ul,
+#releasesModal .release-body ol {
+    padding-left: 1.25em;
+    margin: 0.25em 0;
+}
+#releasesModal .release-body ul { list-style-type: disc; }
+#releasesModal .release-body ol { list-style-type: decimal; }
+#releasesModal .release-body li { margin: 0.15em 0; }
+#releasesModal .release-body a {
+    color: #60a5fa;
+    text-decoration: underline;
+}
+#releasesModal .release-body code {
+    background: rgba(255,255,255,0.08);
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+    font-size: 0.9em;
+}
+#releasesModal .release-body pre {
+    background: rgba(255,255,255,0.06);
+    padding: 0.5em;
+    border-radius: 4px;
+    overflow-x: auto;
+    margin: 0.5em 0;
+}
+#releasesModal .release-body pre code {
+    background: none;
+    padding: 0;
+}
+#releasesModal .release-body p { margin: 0.25em 0; }
+#releasesModal .release-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: #60a5fa;
+    text-decoration: none;
+}
+#releasesModal .release-link:hover {
+    text-decoration: underline;
+}
+
+/* 骨架屏加载 */
+#releasesModal .releases-skeleton {
+    padding: 20px;
+}
+#releasesModal .skeleton-item {
+    margin-bottom: 16px;
+}
+#releasesModal .skeleton-bar {
+    height: 14px;
+    border-radius: 4px;
+    background: linear-gradient(90deg, rgba(255,255,255,0.06) 25%, rgba(255,255,255,0.12) 50%, rgba(255,255,255,0.06) 75%);
+    background-size: 200% 100%;
+    animation: skeleton-shimmer 1.5s infinite;
+    margin-bottom: 8px;
+}
+@keyframes skeleton-shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+}
+
+/* 错误状态 */
+#releasesModal .releases-error {
+    text-align: center;
+    padding: 30px 20px;
+    color: #9ca3af;
+}
+#releasesModal .releases-error button {
+    margin-top: 12px;
+    padding: 6px 20px;
+    border-radius: 8px;
+    border: none;
+    background: #6366f1;
+    color: white;
+    cursor: pointer;
+    font-size: 13px;
+}
+#releasesModal .releases-error button:hover {
+    background: #4f46e5;
+}
+
+/* 空状态 */
+#releasesModal .releases-empty {
+    text-align: center;
+    padding: 40px 20px;
+    color: #6b7280;
+}
+`;
+        document.head.appendChild(style);
+    }
+
+    // ============ 创建模态框 DOM ============
+    function createModal() {
+        if (document.getElementById('releasesModal')) return;
+
+        const modal = document.createElement('div');
+        modal.id = 'releasesModal';
+        modal.className = 'modal';
+        modal.style.display = 'none';
+        modal.innerHTML = `
+            <div class="modal-content">
+                <div class="modal-header">
+                    <div class="releases-header">
+                        <h3 data-i18n="releases.title">${t('releases.title')}</h3>
+                        <span class="releases-version-badge" id="releasesCurrentBadge"></span>
+                    </div>
+                    <button class="btn-close" id="releasesCloseBtn">&times;</button>
+                </div>
+                <div class="modal-body" style="padding: 0;">
+                    <div id="releasesContent"></div>
+                </div>
+            </div>
+        `;
+        document.body.appendChild(modal);
+
+        // 关闭按钮
+        document.getElementById('releasesCloseBtn').addEventListener('click', closeModal);
+
+        // 点击背景关闭
+        modal.addEventListener('click', function (e) {
+            if (e.target === modal) closeModal();
+        });
+
+        // ESC 关闭
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape' && modal.style.display !== 'none') {
+                closeModal();
+            }
+        });
+    }
+
+    // ============ 打开/关闭模态框 ============
+    function openModal() {
+        const modal = document.getElementById('releasesModal');
+        if (!modal) return;
+        modal.style.setProperty('display', 'block', 'important');
+        document.body.style.overflow = 'hidden';
+    }
+
+    function closeModal() {
+        const modal = document.getElementById('releasesModal');
+        if (!modal) return;
+        modal.style.display = 'none';
+        document.body.style.overflow = '';
+    }
+
+    // ============ 版本比较 ============
+    function isNewer(tagName) {
+        const currentRelease = releases.find(r => r.tag_name === currentVersion);
+        if (!currentRelease || !currentRelease.published_at) return false;
+        const targetRelease = releases.find(r => r.tag_name === tagName);
+        if (!targetRelease || !targetRelease.published_at) return false;
+        return new Date(targetRelease.published_at).getTime() > new Date(currentRelease.published_at).getTime();
+    }
+
+    function checkHasNewVersion() {
+        const currentRelease = releases.find(r => r.tag_name === currentVersion);
+        if (!currentRelease || !currentRelease.published_at) return false;
+        return releases.some(r =>
+            !r.prerelease && r.published_at &&
+            new Date(r.published_at).getTime() > new Date(currentRelease.published_at).getTime()
+        );
+    }
+
+    // ============ Markdown 渲染 ============
+    function renderMarkdown(text) {
+        if (!text) return '';
+        try {
+            if (typeof marked !== 'undefined' && typeof DOMPurify !== 'undefined') {
+                return DOMPurify.sanitize(marked.parse(text, { async: false }));
+            }
+        } catch (e) {
+            console.warn('Markdown rendering failed, using plain text:', e);
+        }
+        // 降级：简单转义 HTML
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    // ============ 日期格式化 ============
+    function formatDate(dateStr) {
+        if (!dateStr) return '';
+        try {
+            return new Date(dateStr).toLocaleDateString();
+        } catch {
+            return dateStr;
+        }
+    }
+
+    // ============ 渲染加载骨架屏 ============
+    function renderLoading() {
+        let html = '<div class="releases-skeleton">';
+        for (let i = 0; i < 3; i++) {
+            html += `
+                <div class="skeleton-item">
+                    <div class="skeleton-bar" style="width: 40%;"></div>
+                    <div class="skeleton-bar" style="width: 100%;"></div>
+                    <div class="skeleton-bar" style="width: 70%;"></div>
+                </div>`;
+        }
+        html += '</div>';
+        return html;
+    }
+
+    // ============ 渲染错误状态 ============
+    function renderError() {
+        return `
+            <div class="releases-error">
+                <p>${t('releases.fetch_error')}</p>
+                <button id="releasesRetryBtn">${t('releases.retry')}</button>
+            </div>`;
+    }
+
+    // ============ 渲染空状态 ============
+    function renderEmpty() {
+        return `<div class="releases-empty">${t('releases.no_releases')}</div>`;
+    }
+
+    // ============ 渲染版本列表 ============
+    function renderReleases() {
+        if (releases.length === 0) return renderEmpty();
+
+        let html = '<div class="releases-list">';
+        releases.forEach(function (release, index) {
+            const name = release.name || release.tag_name;
+            const isNew = isNewer(release.tag_name);
+
+            // 标签
+            let badges = '';
+            if (index === 0) {
+                badges += `<span class="badge badge-latest">${t('releases.latest')}</span>`;
+            }
+            if (isNew) {
+                badges += `<span class="badge badge-new">${t('releases.new_available')}</span>`;
+            }
+            if (release.prerelease) {
+                badges += `<span class="badge badge-pre">${t('releases.prerelease')}</span>`;
+            }
+
+            // Release body
+            const bodyHtml = release.body
+                ? `<div class="release-body">${renderMarkdown(release.body)}</div>`
+                : '';
+
+            // GitHub link
+            const linkHtml = release.html_url
+                ? `<a class="release-link" href="${release.html_url}" target="_blank" rel="noopener noreferrer">
+                       ${t('releases.view_on_github')}
+                       <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                           <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                           <polyline points="15 3 21 3 21 9"></polyline>
+                           <line x1="10" y1="14" x2="21" y2="3"></line>
+                       </svg>
+                   </a>`
+                : '';
+
+            html += `
+                <div class="release-item">
+                    <div class="release-header">
+                        <div>
+                            <div class="release-name">${escapeHtml(name)}</div>
+                            <div class="release-badges">${badges}</div>
+                            <div class="release-date">${formatDate(release.published_at)}</div>
+                        </div>
+                    </div>
+                    ${bodyHtml}
+                    ${linkHtml}
+                </div>`;
+        });
+        html += '</div>';
+        return html;
+    }
+
+    // ============ HTML 转义 ============
+    function escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    // ============ 更新按钮高亮 ============
+    function updateButtonHighlight() {
+        const btn = document.getElementById('checkUpdateBtn');
+        if (!btn) return;
+        if (hasNewVersion) {
+            btn.classList.add('has-update');
+        } else {
+            btn.classList.remove('has-update');
+        }
+    }
+
+    // ============ 获取并展示 releases ============
+    async function fetchAndShowReleases(isAutoCheck) {
+        const content = document.getElementById('releasesContent');
+        const badge = document.getElementById('releasesCurrentBadge');
+
+        if (!isAutoCheck && content) {
+            content.innerHTML = renderLoading();
+            openModal();
+        }
+
+        try {
+            const resp = await fetch('/api/releases');
+            if (!resp.ok) throw new Error('HTTP ' + resp.status);
+            const data = await resp.json();
+
+            if (data.error && (!data.releases || data.releases.length === 0)) {
+                throw new Error(data.error);
+            }
+
+            currentVersion = data.current_version || '';
+            releases = data.releases || [];
+            hasNewVersion = checkHasNewVersion();
+            updateButtonHighlight();
+
+            if (!isAutoCheck) {
+                if (badge) {
+                    badge.textContent = t('releases.current_version') + ': ' + currentVersion;
+                }
+                if (content) {
+                    content.innerHTML = renderReleases();
+                    bindRetryButton();
+                }
+            }
+        } catch (e) {
+            console.warn('获取 releases 失败:', e);
+            if (!isAutoCheck && content) {
+                content.innerHTML = renderError();
+                bindRetryButton();
+            }
+        }
+    }
+
+    // ============ 绑定重试按钮 ============
+    function bindRetryButton() {
+        const retryBtn = document.getElementById('releasesRetryBtn');
+        if (retryBtn) {
+            retryBtn.addEventListener('click', function () {
+                fetchAndShowReleases(false);
+            });
+        }
+    }
+
+    // ============ 全局入口：打开弹窗 ============
+    window.openReleasesModal = function () {
+        fetchAndShowReleases(false);
+    };
+
+    // ============ 初始化 ============
+    async function init() {
+        // 等待 i18n 就绪
+        if (window.i18nReady) {
+            try { await window.i18nReady; } catch (e) { /* ignore */ }
+        }
+
+        injectStyles();
+        createModal();
+
+        // 静默检查更新（不弹窗）
+        fetchAndShowReleases(true);
+    }
+
+    // DOMContentLoaded 启动
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+
+})();

--- a/live-2d/webui/static/js/releases.js
+++ b/live-2d/webui/static/js/releases.js
@@ -9,6 +9,7 @@
     let currentVersion = '';
     let releases = [];
     let hasNewVersion = false;
+    let latestReleaseTag = '';
 
     // ============ 注入样式 ============
     function injectStyles() {
@@ -262,21 +263,41 @@
     }
 
     // ============ 版本比较 ============
+    function parseVersion(tagName) {
+        const match = String(tagName || '').trim().match(/^[vV]?(\d+(?:\.\d+)*)(?:[-_].*)?$/);
+        if (!match) return null;
+        return match[1].split('.').map(part => Number.parseInt(part, 10));
+    }
+
+    function compareVersions(left, right) {
+        const leftVersion = parseVersion(left);
+        const rightVersion = parseVersion(right);
+        if (!leftVersion || !rightVersion) return 0;
+
+        const maxLength = Math.max(leftVersion.length, rightVersion.length);
+        for (let i = 0; i < maxLength; i++) {
+            const leftPart = leftVersion[i] || 0;
+            const rightPart = rightVersion[i] || 0;
+            if (leftPart > rightPart) return 1;
+            if (leftPart < rightPart) return -1;
+        }
+        return 0;
+    }
+
     function isNewer(tagName) {
-        const currentRelease = releases.find(r => r.tag_name === currentVersion);
-        if (!currentRelease || !currentRelease.published_at) return false;
-        const targetRelease = releases.find(r => r.tag_name === tagName);
-        if (!targetRelease || !targetRelease.published_at) return false;
-        return new Date(targetRelease.published_at).getTime() > new Date(currentRelease.published_at).getTime();
+        const release = releases.find(r => r.tag_name === tagName);
+        if (release && typeof release.is_newer === 'boolean') return release.is_newer;
+        return compareVersions(tagName, currentVersion) > 0;
     }
 
     function checkHasNewVersion() {
-        const currentRelease = releases.find(r => r.tag_name === currentVersion);
-        if (!currentRelease || !currentRelease.published_at) return false;
-        return releases.some(r =>
-            !r.prerelease && r.published_at &&
-            new Date(r.published_at).getTime() > new Date(currentRelease.published_at).getTime()
-        );
+        return releases.some(r => !r.prerelease && isNewer(r.tag_name));
+    }
+
+    function getLatestStableRelease() {
+        return releases
+            .filter(r => !r.prerelease && parseVersion(r.tag_name))
+            .sort((a, b) => compareVersions(b.tag_name, a.tag_name))[0] || null;
     }
 
     // ============ Markdown 渲染 ============
@@ -339,13 +360,14 @@
         if (releases.length === 0) return renderEmpty();
 
         let html = '<div class="releases-list">';
-        releases.forEach(function (release, index) {
+        releases.forEach(function (release) {
             const name = release.name || release.tag_name;
             const isNew = isNewer(release.tag_name);
+            const isLatest = release.is_latest || release.tag_name === latestReleaseTag;
 
             // 标签
             let badges = '';
-            if (index === 0) {
+            if (isLatest) {
                 badges += `<span class="badge badge-latest">${t('releases.latest')}</span>`;
             }
             if (isNew) {
@@ -428,7 +450,11 @@
 
             currentVersion = data.current_version || '';
             releases = data.releases || [];
-            hasNewVersion = checkHasNewVersion();
+            const latestRelease = data.latest_release || getLatestStableRelease();
+            latestReleaseTag = latestRelease ? latestRelease.tag_name : '';
+            hasNewVersion = typeof data.has_new_version === 'boolean'
+                ? data.has_new_version
+                : checkHasNewVersion();
             updateButtonHighlight();
 
             if (!isAutoCheck) {

--- a/live-2d/webui/static/locales/en/translation.json
+++ b/live-2d/webui/static/locales/en/translation.json
@@ -384,5 +384,18 @@
     "hour": "h",
     "minute": "m",
     "second": "s"
+  },
+  "releases": {
+    "check_update": "Check for Updates",
+    "title": "Releases",
+    "current_version": "Current",
+    "latest": "Latest",
+    "new_available": "New version",
+    "prerelease": "Pre-release",
+    "view_on_github": "View on GitHub",
+    "no_releases": "No releases found",
+    "fetch_error": "Failed to fetch releases",
+    "retry": "Retry",
+    "loading": "Loading..."
   }
 }

--- a/live-2d/webui/static/locales/zh/translation.json
+++ b/live-2d/webui/static/locales/zh/translation.json
@@ -384,5 +384,18 @@
     "hour": "小时",
     "minute": "分钟",
     "second": "秒"
+  },
+  "releases": {
+    "check_update": "检查更新",
+    "title": "版本更新",
+    "current_version": "当前版本",
+    "latest": "最新版",
+    "new_available": "有新版本",
+    "prerelease": "预发布",
+    "view_on_github": "在 GitHub 查看",
+    "no_releases": "暂无版本信息",
+    "fetch_error": "获取版本信息失败",
+    "retry": "重试",
+    "loading": "加载中..."
   }
 }

--- a/live-2d/webui/templates/index.html
+++ b/live-2d/webui/templates/index.html
@@ -10,6 +10,8 @@
     <script src="/static/js/libs/i18nextHttpBackend.min.js"></script>
     <script src="/static/js/libs/i18nextBrowserLanguageDetector.min.js"></script>
     <script src="/static/js/i18n.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
 </head>
 <body>
     <!-- Toast 通知容器 -->
@@ -40,6 +42,13 @@
                     <a href="https://github.com/morettt/my-neuro" target="_blank" rel="noopener noreferrer" class="header-icon" title="GitHub">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                             <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
+                        </svg>
+                    </a>
+                    <a href="javascript:void(0)" class="header-icon" id="checkUpdateBtn" data-i18n-title="releases.check_update" title="检查更新" onclick="window.openReleasesModal && window.openReleasesModal()">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                            <polyline points="7 10 12 15 17 10"></polyline>
+                            <line x1="12" y1="15" x2="12" y2="3"></line>
                         </svg>
                     </a>
                 </div>
@@ -828,5 +837,6 @@
         window.i18nReady = initI18n();
     </script>
     <script src="static/js/app.js?v=20260322"></script>
+    <script src="static/js/releases.js?v=20260627"></script>
 </body>
 </html>

--- a/live-2d/webui/templates/index.html
+++ b/live-2d/webui/templates/index.html
@@ -10,8 +10,6 @@
     <script src="/static/js/libs/i18nextHttpBackend.min.js"></script>
     <script src="/static/js/libs/i18nextBrowserLanguageDetector.min.js"></script>
     <script src="/static/js/i18n.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
 </head>
 <body>
     <!-- Toast 通知容器 -->

--- a/live-2d/webui/updater.py
+++ b/live-2d/webui/updater.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+WebUI 模块化重构 - 版本更新检查模块
+负责从 GitHub API 获取 releases 信息
+"""
+
+import json
+from flask import Blueprint, jsonify
+
+from .utils import PROJECT_ROOT, logger
+
+# 优先使用 requests，不可用时降级到 urllib.request
+try:
+    import requests as _requests
+    _use_requests = True
+except ImportError:
+    import urllib.request
+    import ssl
+    _use_requests = False
+
+# GitHub 仓库信息
+GITHUB_OWNER = "morettt"
+GITHUB_REPO = "my-neuro"
+
+updater_bp = Blueprint('updater', __name__)
+
+_HEADERS = {
+    'Accept': 'application/vnd.github.v3+json',
+    'User-Agent': 'my-neuro-webui',
+}
+
+
+def _http_get(url, timeout=10):
+    """统一 HTTP GET，返回解析后的 JSON"""
+    if _use_requests:
+        resp = _requests.get(url, timeout=timeout, headers=_HEADERS)
+        resp.raise_for_status()
+        return resp.json()
+    else:
+        req = urllib.request.Request(url, headers=_HEADERS)
+        ctx = ssl.create_default_context()
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            return json.loads(resp.read().decode('utf-8'))
+
+
+@updater_bp.route('/api/releases')
+def get_releases():
+    """获取 GitHub releases 列表和当前版本"""
+    # 读取当前版本
+    current_version = 'unknown'
+    config_path = PROJECT_ROOT / 'config.json'
+    try:
+        with open(config_path, 'r', encoding='utf-8') as f:
+            config = json.load(f)
+            current_version = config.get('version', 'unknown')
+    except Exception as e:
+        logger.warning(f'读取版本信息失败：{e}')
+
+    # 从 GitHub API 获取 releases
+    releases = []
+    try:
+        for page in range(1, 6):
+            url = (
+                f"https://api.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases"
+                f"?per_page=30&page={page}"
+            )
+            data = _http_get(url)
+            if not data:
+                break
+            for item in data:
+                releases.append({
+                    'tag_name': item.get('tag_name'),
+                    'name': item.get('name'),
+                    'body': item.get('body'),
+                    'html_url': item.get('html_url'),
+                    'published_at': item.get('published_at'),
+                    'prerelease': item.get('prerelease', False),
+                    'draft': item.get('draft', False),
+                })
+            if len(data) < 30:
+                break
+    except Exception as e:
+        logger.error(f'获取 GitHub releases 失败：{e}')
+        return jsonify({
+            'error': str(e),
+            'current_version': current_version,
+            'releases': [],
+        }), 502
+
+    # 过滤掉 draft releases
+    releases = [r for r in releases if not r.get('draft')]
+
+    return jsonify({
+        'current_version': current_version,
+        'releases': releases,
+    })

--- a/live-2d/webui/updater.py
+++ b/live-2d/webui/updater.py
@@ -6,6 +6,8 @@ WebUI 模块化重构 - 版本更新检查模块
 """
 
 import json
+import re
+import time
 from flask import Blueprint, jsonify
 
 from .utils import PROJECT_ROOT, logger
@@ -22,6 +24,7 @@ except ImportError:
 # GitHub 仓库信息
 GITHUB_OWNER = "morettt"
 GITHUB_REPO = "my-neuro"
+RELEASE_CACHE_TTL_SECONDS = 15 * 60
 
 updater_bp = Blueprint('updater', __name__)
 
@@ -29,6 +32,29 @@ _HEADERS = {
     'Accept': 'application/vnd.github.v3+json',
     'User-Agent': 'my-neuro-webui',
 }
+
+
+_VERSION_RE = re.compile(r'^[vV]?(\d+(?:\.\d+){0,3})(?:[-_].*)?$')
+_releases_cache = {
+    'expires_at': 0,
+    'releases': None,
+}
+
+
+def _version_key(value):
+    """Return a comparable numeric version tuple, or None for non-version tags."""
+    match = _VERSION_RE.match(str(value or '').strip())
+    if not match:
+        return None
+    return tuple(int(part) for part in match.group(1).split('.'))
+
+
+def _compare_version_keys(left, right):
+    """Compare version tuples while treating missing components as zero."""
+    max_len = max(len(left), len(right))
+    left = left + (0,) * (max_len - len(left))
+    right = right + (0,) * (max_len - len(right))
+    return (left > right) - (left < right)
 
 
 def _http_get(url, timeout=10):
@@ -44,6 +70,61 @@ def _http_get(url, timeout=10):
             return json.loads(resp.read().decode('utf-8'))
 
 
+def _clone_releases(releases):
+    return [dict(release) for release in releases]
+
+
+def _fetch_releases():
+    """Fetch recent releases from GitHub, with a short cache to avoid rate limits."""
+    now = time.time()
+    cached_releases = _releases_cache.get('releases')
+    if cached_releases is not None and now < _releases_cache.get('expires_at', 0):
+        return _clone_releases(cached_releases)
+
+    url = f"https://api.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases?per_page=100"
+    data = _http_get(url)
+    releases = []
+    for item in data:
+        if item.get('draft'):
+            continue
+        releases.append({
+            'tag_name': item.get('tag_name'),
+            'name': item.get('name'),
+            'body': item.get('body'),
+            'html_url': item.get('html_url'),
+            'published_at': item.get('published_at'),
+            'prerelease': item.get('prerelease', False),
+            'draft': item.get('draft', False),
+        })
+
+    _releases_cache['releases'] = _clone_releases(releases)
+    _releases_cache['expires_at'] = now + RELEASE_CACHE_TTL_SECONDS
+    return releases
+
+
+def _apply_version_metadata(releases, current_version):
+    current_key = _version_key(current_version)
+    stable_releases = []
+    for release in releases:
+        version_key = _version_key(release.get('tag_name'))
+        release['is_newer'] = (
+            not release.get('prerelease')
+            and current_key is not None
+            and version_key is not None
+            and _compare_version_keys(version_key, current_key) > 0
+        )
+        release['is_latest'] = False
+        if not release.get('prerelease') and version_key is not None:
+            stable_releases.append((version_key, release))
+
+    latest_release = None
+    if stable_releases:
+        latest_release = max(stable_releases, key=lambda item: item[0])[1]
+        latest_release['is_latest'] = True
+
+    return latest_release
+
+
 @updater_bp.route('/api/releases')
 def get_releases():
     """获取 GitHub releases 列表和当前版本"""
@@ -57,41 +138,25 @@ def get_releases():
     except Exception as e:
         logger.warning(f'读取版本信息失败：{e}')
 
-    # 从 GitHub API 获取 releases
-    releases = []
     try:
-        for page in range(1, 6):
-            url = (
-                f"https://api.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases"
-                f"?per_page=30&page={page}"
-            )
-            data = _http_get(url)
-            if not data:
-                break
-            for item in data:
-                releases.append({
-                    'tag_name': item.get('tag_name'),
-                    'name': item.get('name'),
-                    'body': item.get('body'),
-                    'html_url': item.get('html_url'),
-                    'published_at': item.get('published_at'),
-                    'prerelease': item.get('prerelease', False),
-                    'draft': item.get('draft', False),
-                })
-            if len(data) < 30:
-                break
+        releases = _fetch_releases()
     except Exception as e:
         logger.error(f'获取 GitHub releases 失败：{e}')
-        return jsonify({
-            'error': str(e),
-            'current_version': current_version,
-            'releases': [],
-        }), 502
+        cached_releases = _releases_cache.get('releases')
+        if cached_releases is not None:
+            releases = _clone_releases(cached_releases)
+        else:
+            return jsonify({
+                'error': str(e),
+                'current_version': current_version,
+                'releases': [],
+            }), 502
 
-    # 过滤掉 draft releases
-    releases = [r for r in releases if not r.get('draft')]
+    latest_release = _apply_version_metadata(releases, current_version)
 
     return jsonify({
         'current_version': current_version,
+        'latest_release': latest_release,
+        'has_new_version': any(r.get('is_newer') for r in releases),
         'releases': releases,
     })

--- a/live-2d/启动 WebUI 控制面板.bat
+++ b/live-2d/启动 WebUI 控制面板.bat
@@ -14,12 +14,20 @@ if exist %~dp0..\env\python.exe (
         echo Flask 未安装，正在安装...
         %~dp0..\env\python.exe -m pip install flask
     )
+    %~dp0..\env\python.exe -c "import requests" >nul 2>&1 || (
+        echo requests 未安装，正在安装...
+        %~dp0..\env\python.exe -m pip install requests
+    )
     %~dp0..\env\python.exe -c "from webui import run_app; run_app()"
 ) else (
     call conda activate my-neuro
     python -c "import flask" >nul 2>&1 || (
         echo Flask 未安装，正在安装...
         pip install flask
+    )
+    python -c "import requests" >nul 2>&1 || (
+        echo requests 未安装，正在安装...
+        pip install requests
     )
     python -c "from webui import run_app; run_app()"
 )


### PR DESCRIPTION
## Summary
- Add a "Check for Updates" button in the WebUI header that fetches releases from GitHub and displays them in a modal
- Button highlights blue when a newer release is available (compares `published_at` timestamps)
- Modal shows release list with badges (Latest / New version / Pre-release), Markdown release notes (rendered via marked.js + DOMPurify), and GitHub links
- All UI strings use i18n (zh/en supported)
- Backend uses `requests` with automatic `urllib.request` fallback; launcher bat auto-installs `requests` if missing

## Changes
| File | Change |
|------|--------|
| `live-2d/webui/updater.py` | New Blueprint with `GET /api/releases` (fetches from morettt/my-neuro GitHub API) |
| `live-2d/webui/static/js/releases.js` | Self-contained frontend module: auto-check, button highlight, modal rendering |
| `live-2d/webui/main_app.py` | Register `updater_bp` |
| `live-2d/webui/templates/index.html` | Add update button in header, CDN scripts for marked.js + DOMPurify, releases.js script tag |
| `live-2d/webui/static/css/style.css` | Reset button default styles in `.header-icon` for consistent alignment |
| `live-2d/webui/static/locales/zh/translation.json` | Add `releases.*` i18n keys |
| `live-2d/webui/static/locales/en/translation.json` | Add `releases.*` i18n keys |
| `live-2d/启动 WebUI 控制面板.bat` | Auto-install `requests` if missing |

## Test plan
- [ ] Start webui via bat, verify no import errors
- [ ] Header shows download-arrow update button aligned with other icons
- [ ] On page load, button silently checks for updates (no popup)
- [ ] If newer release exists, button turns blue
- [ ] Click button opens modal with release list, badges, Markdown body, GitHub links
- [ ] Close modal via X button, click outside, or ESC key
- [ ] Switch language (zh/en), verify all release UI strings translate
- [ ] If GitHub API unreachable, click shows error state with retry button