### PR TITLE
fix: 输入框聚焦后恢复鼠标穿透，避免视频画面冻结

### DIFF
--- a/live-2d/js/ui/ui-controller.js
+++ b/live-2d/js/ui/ui-controller.js
@@ -107,32 +107,52 @@ class UIController {
             subtitleContainer.style.setProperty('display', 'block', 'important');
         }
 
-        textChatContainer.addEventListener('mouseenter', () => {
+        const setMousePassthrough = (ignore, forward = true) => {
             ipcRenderer.send('set-ignore-mouse-events', {
-                ignore: false,
-                options: { forward: false }
+                ignore,
+                options: { forward }
             });
-        });
+        };
+
+        let chatPointerDown = false;
+
+        const captureChatMouse = () => {
+            setMousePassthrough(false, false);
+        };
+
+        const releaseChatMouseForTyping = () => {
+            requestAnimationFrame(() => {
+                if (chatPointerDown || document.activeElement !== chatInput) return;
+                // Keep keyboard focus in the editor, but let video windows underneath keep rendering.
+                setMousePassthrough(true, true);
+            });
+        };
+
+        textChatContainer.addEventListener('mouseenter', captureChatMouse);
 
         textChatContainer.addEventListener('mouseleave', () => {
-            ipcRenderer.send('set-ignore-mouse-events', {
-                ignore: true,
-                options: { forward: true }
-            });
+            setMousePassthrough(true, true);
+        });
+
+        chatInput.addEventListener('pointerdown', () => {
+            chatPointerDown = true;
+            captureChatMouse();
+        });
+
+        document.addEventListener('pointerup', () => {
+            if (!chatPointerDown) return;
+            chatPointerDown = false;
+            releaseChatMouseForTyping();
         });
 
         chatInput.addEventListener('focus', () => {
-            ipcRenderer.send('set-ignore-mouse-events', {
-                ignore: false,
-                options: { forward: false }
-            });
+            captureChatMouse();
+            releaseChatMouseForTyping();
         });
 
         chatInput.addEventListener('blur', () => {
-            ipcRenderer.send('set-ignore-mouse-events', {
-                ignore: true,
-                options: { forward: true }
-            });
+            chatPointerDown = false;
+            setMousePassthrough(true, true);
         });
         
     }

--- a/live-2d/js/ui/ui-controller.js
+++ b/live-2d/js/ui/ui-controller.js
@@ -131,19 +131,34 @@ class UIController {
         textChatContainer.addEventListener('mouseenter', captureChatMouse);
 
         textChatContainer.addEventListener('mouseleave', () => {
+            if (chatPointerDown) return;
             setMousePassthrough(true, true);
         });
 
-        chatInput.addEventListener('pointerdown', () => {
-            chatPointerDown = true;
-            captureChatMouse();
-        });
+        const releasePointerCapture = (event) => {
+            if (
+                event?.pointerId != null &&
+                chatInput.hasPointerCapture?.(event.pointerId)
+            ) {
+                chatInput.releasePointerCapture(event.pointerId);
+            }
+        };
 
-        document.addEventListener('pointerup', () => {
+        const finishChatPointer = (event) => {
             if (!chatPointerDown) return;
             chatPointerDown = false;
+            releasePointerCapture(event);
             releaseChatMouseForTyping();
+        };
+
+        chatInput.addEventListener('pointerdown', (event) => {
+            chatPointerDown = true;
+            captureChatMouse();
+            chatInput.setPointerCapture?.(event.pointerId);
         });
+
+        document.addEventListener('pointerup', finishChatPointer);
+        document.addEventListener('pointercancel', finishChatPointer);
 
         chatInput.addEventListener('focus', () => {
             captureChatMouse();


### PR DESCRIPTION
## 背景

用户反馈：看视频时点击肥牛的输入框后，视频画面会出现“冻结”的现象。

原因是主窗口是透明置顶窗口。输入框获得焦点时，当前逻辑会一直调用 `setIgnoreMouseEvents(false, { forward: false })`，导致整块透明窗口持续接管鼠标事件。这样在视频窗口之上输入时，底层视频窗口可能被长期遮挡/失焦，表现为画面停止刷新。

## 修改内容

- 抽出 `setMousePassthrough`，统一聊天框区域的鼠标穿透切换。
- 输入框 `pointerdown` 时短暂接管鼠标，保证点击和聚焦仍然正常。
- 输入框获得焦点并完成点击后，恢复 `setIgnoreMouseEvents(true, { forward: true })`，保留键盘输入焦点，同时让底层视频窗口继续刷新。
- 输入框 `blur` 和鼠标离开聊天框时继续恢复穿透，避免透明窗口长期拦截视频窗口。

## 验证

- `node --check live-2d/js/ui/ui-controller.js`
- `git diff --check`