### PR TITLE
在插件市场显示插件来源链接

### DIFF
--- a/live-2d/webui/static/css/style.css
+++ b/live-2d/webui/static/css/style.css
@@ -1079,6 +1079,9 @@ h3, h4 { border-bottom: 1px solid rgba(255,255,255,0.2); padding-bottom: 10px; }
 .market-card-meta .market-card-author {
     flex: 1;
     min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .market-card-source-link {

--- a/live-2d/webui/static/css/style.css
+++ b/live-2d/webui/static/css/style.css
@@ -1067,6 +1067,33 @@ h3, h4 { border-bottom: 1px solid rgba(255,255,255,0.2); padding-bottom: 10px; }
     margin: 0;
 }
 
+.market-card-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.market-card-meta .market-card-author {
+    flex: 1;
+    min-width: 0;
+}
+
+.market-card-source-link {
+    color: var(--accent-light);
+    text-decoration: none;
+    font-size: 12px;
+    white-space: nowrap;
+    transition: var(--transition);
+}
+
+.market-card-source-link:hover {
+    color: #c7d2fe;
+    text-decoration: underline;
+}
+
 .market-card-summary {
     font-size: 14px;
     color: rgba(255, 255, 255, 0.7);

--- a/live-2d/webui/static/js/app.js
+++ b/live-2d/webui/static/js/app.js
@@ -3099,6 +3099,8 @@ function createPluginMarketCard(plugin) {
         buttonAction = `installPlugin('${escapeJsString(pluginName)}', '${escapeJsString(downloadUrl)}')`;
     }
 
+    const authorLine = escapeHtml(author);
+    const repoHref = repo ? escapeHtml(repo) : '';
     const versionBlock = `<div class="market-card-versions">
             ${localVersion ? `<span class="version-badge">${escapeHtml(t('market.version_current', { version: localVersion }))}</span>` : ''}
             ${latestVersion ? `<span class="version-badge ${hasUpdate ? 'update-badge' : ''}">${escapeHtml(t('market.version_latest', { version: latestVersion }))}</span>` : ''}
@@ -3115,9 +3117,16 @@ function createPluginMarketCard(plugin) {
                 onclick="togglePluginStar('${escapeJsString(pluginName)}', this)">★ <span class="star-count">${escapeHtml(formatCount(stars))}</span></button>
            </div>`;
 
+    const metaBlock = repo
+        ? `<div class="market-card-meta">
+            <span class="market-card-author">${t('plugins.author')}${authorLine}</span>
+            <a class="market-card-source-link" href="${repoHref}" target="_blank" rel="noopener noreferrer">📎 ${escapeHtml(t('market.view_source'))}</a>
+           </div>`
+        : `<p class="market-card-author">${t('plugins.author')}${authorLine}</p>`;
+
     const html = `<div class="market-card-header">
         <h4 class="market-card-title">🧩 ${escapeHtml(displayName)}</h4>
-        <p class="market-card-author">${t('plugins.author')}${escapeHtml(author)}</p>
+        ${metaBlock}
         ${versionBlock}
         ${statsBlock}
         <p class="market-card-summary">${escapeHtml(desc)}</p>

--- a/live-2d/webui/static/js/app.js
+++ b/live-2d/webui/static/js/app.js
@@ -2958,6 +2958,15 @@ function escapeAttribute(value) {
     return escapeHtml(value).replace(/"/g, '&quot;');
 }
 
+function getSafeExternalHref(value) {
+    try {
+        const url = new URL(String(value || '').trim());
+        return (url.protocol === 'http:' || url.protocol === 'https:') ? url.href : '';
+    } catch (e) {
+        return '';
+    }
+}
+
 function formatCount(value) {
     const count = Number(value) || 0;
     if (count >= 1000000) {
@@ -3100,7 +3109,7 @@ function createPluginMarketCard(plugin) {
     }
 
     const authorLine = escapeHtml(author);
-    const repoHref = repo ? escapeHtml(repo) : '';
+    const repoHref = getSafeExternalHref(repo);
     const versionBlock = `<div class="market-card-versions">
             ${localVersion ? `<span class="version-badge">${escapeHtml(t('market.version_current', { version: localVersion }))}</span>` : ''}
             ${latestVersion ? `<span class="version-badge ${hasUpdate ? 'update-badge' : ''}">${escapeHtml(t('market.version_latest', { version: latestVersion }))}</span>` : ''}
@@ -3117,10 +3126,10 @@ function createPluginMarketCard(plugin) {
                 onclick="togglePluginStar('${escapeJsString(pluginName)}', this)">★ <span class="star-count">${escapeHtml(formatCount(stars))}</span></button>
            </div>`;
 
-    const metaBlock = repo
+    const metaBlock = repoHref
         ? `<div class="market-card-meta">
             <span class="market-card-author">${t('plugins.author')}${authorLine}</span>
-            <a class="market-card-source-link" href="${repoHref}" target="_blank" rel="noopener noreferrer">📎 ${escapeHtml(t('market.view_source'))}</a>
+            <a class="market-card-source-link" href="${escapeAttribute(repoHref)}" target="_blank" rel="noopener noreferrer">📎 ${escapeHtml(t('market.view_source'))}</a>
            </div>`
         : `<p class="market-card-author">${t('plugins.author')}${authorLine}</p>`;
 

--- a/live-2d/webui/static/locales/en/translation.json
+++ b/live-2d/webui/static/locales/en/translation.json
@@ -165,6 +165,7 @@
     "plugin_installing": "⏳ Installing...",
     "plugin_installed": "✓ Installed",
     "author": "Author",
+    "view_source": "View source",
     "unknown_author": "Unknown Author",
     "no_desc": "No description",
     "install_failed": "Install failed",

--- a/live-2d/webui/static/locales/zh/translation.json
+++ b/live-2d/webui/static/locales/zh/translation.json
@@ -165,6 +165,7 @@
     "plugin_installing": "⏳ 安装中...",
     "plugin_installed": "✓ 已安装",
     "author": "作者",
+    "view_source": "查看来源",
     "unknown_author": "未知作者",
     "no_desc": "无描述",
     "install_failed": "安装失败",


### PR DESCRIPTION
### 变更内容

- 在 Web UI 插件市场卡片中，当插件配置了 `repo` 时显示“📎 查看来源”链接。
- 未配置 `repo` 的插件保持原有作者信息展示，不显示空链接。
- 补充中英文 i18n 文案：`查看来源` / `View source`。

### 验证

- `node -e` 解析中英文翻译 JSON 通过。
- `git diff --check` 通过。
- 已检查本次 diff，未新增 API Key、本地路径或私密提示词。