### PR TITLE
fix(webui): prevent state loss and cross-process races

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ plugins-dlc/memos/memos_system/data/**
 
 live-2d/plugins/**/outputs/
 live-2d/plugins/**/.runtime/
+live-2d/plugins/.plugin-update-backups/
 live-2d/plugins/.stats_client_id
 live-2d/plugins/community/agent-dream/dream_logs/
 live-2d/plugins/community/agent-dream/dream_state.json

--- a/live-2d/plugins/README.md
+++ b/live-2d/plugins/README.md
@@ -38,6 +38,36 @@ plugins/community/my-plugin/
 
 `repo` 是插件的 GitHub 地址，方便用户找到来源和提 issue。不填也行，但社区插件建议填上。
 
+### 更新时保留运行数据
+
+插件市场更新会自动保留 `plugin_config.json`、常见数据目录、数据库文件和
+典型的状态文件。插件使用自定义位置保存用户数据时，请在 `metadata.json`
+中声明相对路径：
+
+```json
+{
+  "name": "my-plugin",
+  "persistent_paths": [
+    "custom-state",
+    "user-settings.json"
+  ]
+}
+```
+
+也可以在插件根目录添加 `plugin_persistence.json`：
+
+```json
+{
+  "paths": [
+    "custom-state",
+    "user-settings.json"
+  ]
+}
+```
+
+路径必须位于插件目录内，不能使用绝对路径或 `..`。更新成功后，旧版本会
+保留在 `plugins/.plugin-update-backups/`，同一插件最多保留 3 份。
+
 **启用插件**，在 `plugins/enabled_plugins.json` 里加上插件路径：
 
 ```json

--- a/live-2d/webui/log_monitor.py
+++ b/live-2d/webui/log_monitor.py
@@ -8,7 +8,6 @@ WebUI 模块化重构 - 日志与监控模块
 import json
 import datetime
 import urllib.request
-from collections import deque
 from flask import Blueprint, request, jsonify
 
 from .utils import PROJECT_ROOT, DATA_ROOT, logger
@@ -16,8 +15,125 @@ from .utils import PROJECT_ROOT, DATA_ROOT, logger
 # 创建日志监控蓝图
 log_bp = Blueprint('log', __name__)
 
+RUNTIME_INITIAL_LINES = 200
+TAIL_READ_LIMIT_BYTES = 512 * 1024
+INCREMENTAL_READ_LIMIT_BYTES = 256 * 1024
+
+
+def _read_last_lines(path, max_lines, max_bytes=TAIL_READ_LIMIT_BYTES):
+    with open(path, 'rb') as stream:
+        stream.seek(0, 2)
+        position = stream.tell()
+        chunks = []
+        bytes_read = 0
+        newline_count = 0
+
+        while (
+            position > 0
+            and bytes_read < max_bytes
+            and newline_count <= max_lines
+        ):
+            chunk_size = min(64 * 1024, position, max_bytes - bytes_read)
+            position -= chunk_size
+            stream.seek(position)
+            chunk = stream.read(chunk_size)
+            chunks.append(chunk)
+            bytes_read += len(chunk)
+            newline_count += chunk.count(b'\n')
+
+    data = b''.join(reversed(chunks))
+    if position > 0:
+        first_newline = data.find(b'\n')
+        if first_newline >= 0:
+            data = data[first_newline + 1:]
+    return data.decode('utf-8', errors='ignore').splitlines()[-max_lines:]
+
+
+def _read_lines_from_offset(
+    path,
+    offset,
+    max_bytes=INCREMENTAL_READ_LIMIT_BYTES,
+):
+    with open(path, 'rb') as stream:
+        stream.seek(offset)
+        data = stream.read(max_bytes + 1)
+
+    if len(data) > max_bytes:
+        bounded = data[:max_bytes]
+        last_newline = bounded.rfind(b'\n')
+        consumed = last_newline + 1 if last_newline >= 0 else max_bytes
+        data = bounded[:consumed]
+    else:
+        consumed = len(data)
+
+    return (
+        data.decode('utf-8', errors='ignore').splitlines(),
+        offset + consumed,
+    )
+
+
+def _runtime_cursor(stat_result):
+    return f'{stat_result.st_dev}:{stat_result.st_ino}'
+
+
+def _categorize_runtime_lines(lines):
+    result = {'pet': [], 'tool': []}
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line:
+            continue
+        category = 'tool' if '[TOOL]' in line else 'pet'
+        result[category].append(line)
+    return result
+
 
 # ============ 日志 API ============
+
+@log_bp.route('/api/logs/runtime')
+def get_runtime_logs():
+    """Return one bounded initial tail or the bytes appended after a cursor."""
+    log_file = PROJECT_ROOT / 'runtime.log'
+    if not log_file.exists():
+        return jsonify({
+            'logs': {'pet': [], 'tool': []},
+            'offset': 0,
+            'cursor': '',
+            'reset': True,
+        })
+
+    try:
+        stat_result = log_file.stat()
+        cursor = _runtime_cursor(stat_result)
+        requested_cursor = request.args.get('cursor', '')
+        requested_offset = request.args.get('offset', type=int)
+        reset = (
+            requested_offset is None
+            or requested_offset < 0
+            or requested_offset > stat_result.st_size
+            or requested_cursor != cursor
+        )
+
+        if reset:
+            lines = _read_last_lines(log_file, RUNTIME_INITIAL_LINES)
+            next_offset = stat_result.st_size
+        else:
+            lines, next_offset = _read_lines_from_offset(
+                log_file,
+                requested_offset,
+            )
+
+        return jsonify({
+            'logs': _categorize_runtime_lines(lines),
+            'offset': next_offset,
+            'cursor': cursor,
+            'reset': reset,
+        })
+    except Exception as e:
+        return jsonify({
+            'logs': {'pet': [], 'tool': []},
+            'error': str(e),
+        }), 500
+
 
 @log_bp.route('/api/logs/<log_type>')
 def get_logs(log_type):
@@ -27,23 +143,8 @@ def get_logs(log_type):
         if not log_file.exists():
             return jsonify({'logs': [], 'error': '日志文件不存在'})
 
-        try:
-            with open(log_file, 'r', encoding='utf-8', errors='ignore') as f:
-                last_lines = deque(f, maxlen=100)
-
-                logs = []
-                for line in last_lines:
-                    line = line.strip()
-                    if line:
-                        is_tool_log = '[TOOL]' in line
-                        if log_type == 'tool' and is_tool_log:
-                            logs.append(line)
-                        elif log_type == 'pet' and not is_tool_log:
-                            logs.append(line)
-
-                return jsonify({'logs': logs})
-        except Exception as e:
-            return jsonify({'logs': [], 'error': str(e)})
+        categories = _categorize_runtime_lines(_read_last_lines(log_file, 100))
+        return jsonify({'logs': categories.get(log_type, [])})
     except Exception as e:
         return jsonify({'logs': [], 'error': str(e)})
 
@@ -56,23 +157,8 @@ def tail_logs(log_type):
         if not log_file.exists():
             return jsonify({'logs': [], 'error': '日志文件不存在'})
 
-        try:
-            with open(log_file, 'r', encoding='utf-8', errors='ignore') as f:
-                last_lines = deque(f, maxlen=10)
-
-                logs = []
-                for line in last_lines:
-                    line = line.strip()
-                    if line:
-                        is_tool_log = '[TOOL]' in line
-                        if log_type == 'tool' and is_tool_log:
-                            logs.append(line)
-                        elif log_type == 'pet' and not is_tool_log:
-                            logs.append(line)
-
-                return jsonify({'logs': logs})
-        except Exception as e:
-            return jsonify({'logs': [], 'error': str(e)})
+        categories = _categorize_runtime_lines(_read_last_lines(log_file, 10))
+        return jsonify({'logs': categories.get(log_type, [])})
     except Exception as e:
         return jsonify({'logs': [], 'error': str(e)})
 

--- a/live-2d/webui/marketplace.py
+++ b/live-2d/webui/marketplace.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import threading
 import shutil
+import time
 import urllib.request
 import urllib.error
 from pathlib import Path
@@ -25,6 +26,12 @@ from .marketplace_updater import (
     get_local_metadata,
     install_plugin_from_archive,
     update_plugin_safe,
+)
+from .state_io import (
+    delete_resource_state,
+    read_resource_state,
+    resource_lock,
+    write_resource_state,
 )
 
 # 尝试导入 requests 库，如果不可用则使用 urllib
@@ -40,6 +47,10 @@ market_bp = Blueprint('market', __name__)
 
 # 存储正在进行的安装任务
 installing_tasks = {}
+_installing_tasks_lock = threading.RLock()
+INSTALL_TASK_RETENTION_SECONDS = 10 * 60
+INSTALL_TASK_ACTIVE_STALE_SECONDS = 15 * 60
+TERMINAL_INSTALL_STATUSES = {"completed", "failed"}
 
 PLUGIN_UPDATE_CONCURRENCY = 3
 
@@ -48,6 +59,103 @@ PLUGIN_HUB_RAW_URL = (
     'https://raw.githubusercontent.com/morettt/my-neuro/main/'
     'live-2d/plugins/plugin-house/plugin_hub.json'
 )
+
+
+def _task_is_active(task):
+    return bool(task) and task.get('status') not in TERMINAL_INSTALL_STATUSES
+
+
+def _install_task_resource(plugin_name):
+    return f'plugin-task:{PROJECT_ROOT.resolve()}:{plugin_name}'
+
+
+def _task_is_expired(task, now):
+    if not task:
+        return False
+    if task.get('status') in TERMINAL_INSTALL_STATUSES:
+        finished_at = task.get(
+            'finished_at',
+            task.get('updated_at', task.get('created_at', now)),
+        )
+        return (
+            now - finished_at
+            >= INSTALL_TASK_RETENTION_SECONDS
+        )
+    return (
+        now - task.get('updated_at', task.get('created_at', now))
+        >= INSTALL_TASK_ACTIVE_STALE_SECONDS
+    )
+
+
+def _get_install_task(plugin_name):
+    now = time.time()
+    resource = _install_task_resource(plugin_name)
+    with resource_lock(resource):
+        shared_task = read_resource_state(resource)
+        with _installing_tasks_lock:
+            local_task = installing_tasks.get(plugin_name)
+            task = shared_task or local_task
+            if _task_is_expired(task, now):
+                installing_tasks.pop(plugin_name, None)
+                delete_resource_state(resource)
+                return None
+            if shared_task:
+                installing_tasks[plugin_name] = dict(shared_task)
+            return dict(task) if task else None
+
+
+def _reserve_install_task(plugin_name, status, progress, operation):
+    now = time.time()
+    resource = _install_task_resource(plugin_name)
+    with resource_lock(resource):
+        shared_task = read_resource_state(resource)
+        with _installing_tasks_lock:
+            existing = shared_task or installing_tasks.get(plugin_name)
+        if _task_is_active(existing) and not _task_is_expired(existing, now):
+            return False
+
+        task = {
+            'status': status,
+            'progress': progress,
+            'operation': operation,
+            'created_at': now,
+            'updated_at': now,
+            'error': '',
+            'webui_pid': os.getpid(),
+        }
+        write_resource_state(resource, task)
+        with _installing_tasks_lock:
+            installing_tasks[plugin_name] = dict(task)
+        return True
+
+
+def _update_install_task(plugin_name, **changes):
+    now = time.time()
+    resource = _install_task_resource(plugin_name)
+    with resource_lock(resource):
+        shared_task = read_resource_state(resource)
+        with _installing_tasks_lock:
+            local_task = installing_tasks.get(plugin_name)
+        task = dict(
+            shared_task
+            or local_task
+            or {
+                'status': 'queued',
+                'progress': 0,
+                'operation': 'install',
+                'created_at': now,
+                'error': '',
+                'webui_pid': os.getpid(),
+            }
+        )
+        task.update(changes)
+        task['updated_at'] = now
+        if task.get('status') in TERMINAL_INSTALL_STATUSES:
+            task['finished_at'] = now
+        write_resource_state(resource, task)
+        with _installing_tasks_lock:
+            installing_tasks[plugin_name] = dict(task)
+        return dict(task)
 
 
 def load_plugin_hub_catalog():
@@ -94,6 +202,7 @@ def _build_market_plugin_items(check_updates=True):
     for key, value in plugins_data.items():
         plugin_dir = _get_market_plugin_dir(key)
         is_installed = plugin_dir.exists() and any(plugin_dir.iterdir())
+        task = _get_install_task(key)
         local_metadata = get_local_metadata(plugin_dir) if is_installed else {}
         repo_url = value.get('repo', '') or local_metadata.get('repo', '')
         local_version = local_metadata.get('version', '')
@@ -113,9 +222,10 @@ def _build_market_plugin_items(check_updates=True):
             'has_update': False,
             'update_error': '',
             'installed': is_installed,
-            'installing': key in installing_tasks,
-            'status': installing_tasks.get(key, {}).get('status', ''),
-            'progress': installing_tasks.get(key, {}).get('progress', 0),
+            'installing': _task_is_active(task),
+            'status': task.get('status', '') if task else '',
+            'progress': task.get('progress', 0) if task else 0,
+            'install_error': task.get('error', '') if task else '',
         })
 
     if check_updates and plugins:
@@ -158,8 +268,11 @@ def _install_requirements_with_task_status(plugin_name):
         req_path = Path(plugin_dir) / 'requirements.txt'
         if not req_path.exists():
             return
-        installing_tasks[plugin_name]['status'] = 'installing_deps'
-        installing_tasks[plugin_name]['progress'] = 75
+        _update_install_task(
+            plugin_name,
+            status='installing_deps',
+            progress=75,
+        )
         result = subprocess.run(
             [sys.executable, '-m', 'pip', 'install', '-r', str(req_path)],
             capture_output=True,
@@ -247,10 +360,6 @@ def download_plugin():
         if not plugin_name or not plugin_url:
             return jsonify({'success': False, 'error': '缺少参数'}), 400
 
-        # 检查是否正在安装中
-        if plugin_name in installing_tasks:
-            return jsonify({'success': False, 'error': '该插件正在安装中'}), 400
-
         # 检查是否已安装
         community_path = PROJECT_ROOT / 'plugins' / 'community'
         plugin_dir = community_path / plugin_name
@@ -260,13 +369,29 @@ def download_plugin():
         # 只创建父目录。插件目录由安装成功后原子落盘，避免失败留下空壳。
         community_path.mkdir(parents=True, exist_ok=True)
 
+        if not _reserve_install_task(
+            plugin_name,
+            status='queued',
+            progress=0,
+            operation='install',
+        ):
+            return jsonify({'success': False, 'error': '该插件正在安装中'}), 409
+
         # 启动后台线程进行下载和安装
         thread = threading.Thread(
             target=_install_plugin_worker,
             args=(plugin_name, plugin_url, plugin_dir),
             daemon=True
         )
-        thread.start()
+        try:
+            thread.start()
+        except Exception as exc:
+            _update_install_task(
+                plugin_name,
+                status='failed',
+                error=str(exc),
+            )
+            raise
 
         return jsonify({
             'success': True,
@@ -279,49 +404,46 @@ def download_plugin():
 def _install_plugin_worker(plugin_name, plugin_url, plugin_dir):
     """后台安装插件的工作线程"""
     try:
-        installing_tasks[plugin_name] = {'status': 'downloading', 'progress': 0}
+        _update_install_task(
+            plugin_name,
+            status='downloading',
+            progress=0,
+            operation='install',
+            error='',
+        )
         logger.info(f'开始下载插件：{plugin_name}')
 
         # 下载、解压、依赖安装都在辅助模块中完成；它会自动处理 main/master/default_branch。
-        installing_tasks[plugin_name]['progress'] = 20
-        installing_tasks[plugin_name]['status'] = 'extracting'
-        installing_tasks[plugin_name]['progress'] = 50
+        _update_install_task(plugin_name, status='downloading', progress=20)
+        _update_install_task(plugin_name, status='extracting', progress=50)
         install_plugin_from_archive(
             plugin_dir,
             plugin_url,
             requirements_installer=_install_requirements_with_task_status(plugin_name),
         )
 
-        installing_tasks[plugin_name]['status'] = 'completed'
-        installing_tasks[plugin_name]['progress'] = 100
+        _update_install_task(
+            plugin_name,
+            status='completed',
+            progress=100,
+            error='',
+        )
         marketplace_stats.increment_download(plugin_name)
         logger.info(f'插件安装完成：{plugin_name}')
-        
-        # 清理任务记录（让刷新列表时能正确显示已安装状态）
-        import time
-        time.sleep(0.3)  # 短暂等待，确保文件写入完成
-        if plugin_name in installing_tasks:
-            del installing_tasks[plugin_name]
 
     except Exception as e:
         logger.error(f'插件安装失败：{plugin_name}, {str(e)}')
-        installing_tasks[plugin_name]['status'] = 'failed'
-        installing_tasks[plugin_name]['error'] = str(e)
-        
-        # 失败时也清理任务记录
-        import time
-        time.sleep(0.3)
-        if plugin_name in installing_tasks:
-            del installing_tasks[plugin_name]
-    
-    finally:
-        # 确保任务被清理
-        pass
+        _update_install_task(
+            plugin_name,
+            status='failed',
+            error=str(e),
+        )
 
 
 @market_bp.route('/api/market/plugins/update', methods=['POST'])
 def update_market_plugin():
     """更新单个已安装插件。"""
+    task_reserved = False
     try:
         data = request.get_json() or {}
         plugin_name = data.get('plugin_name') or data.get('name') or ''
@@ -329,7 +451,7 @@ def update_market_plugin():
 
         if not plugin_name:
             return jsonify({'success': False, 'error': '缺少 plugin_name 参数'}), 400
-        if plugin_name in installing_tasks:
+        if _task_is_active(_get_install_task(plugin_name)):
             return jsonify({'success': False, 'error': '该插件正在安装或更新中'}), 400
 
         plugin_info = _find_market_plugin(plugin_name)
@@ -341,27 +463,39 @@ def update_market_plugin():
         if not plugin_dir.exists() or not any(plugin_dir.iterdir()):
             return jsonify({'success': False, 'error': '插件尚未安装'}), 404
 
-        installing_tasks[plugin_name] = {'status': 'updating', 'progress': 10}
+        if not _reserve_install_task(
+            plugin_name,
+            status='updating',
+            progress=10,
+            operation='update',
+        ):
+            return jsonify({
+                'success': False,
+                'error': '该插件正在安装或更新中',
+            }), 409
+        task_reserved = True
         result = update_plugin_safe(
             plugin_dir,
             plugin_name,
             repo_url,
             requirements_installer=_install_requirements_with_task_status(plugin_name),
         )
-        installing_tasks[plugin_name]['status'] = 'completed'
-        installing_tasks[plugin_name]['progress'] = 100
+        _update_install_task(
+            plugin_name,
+            status='completed',
+            progress=100,
+            error='',
+        )
         return jsonify({'success': True, 'message': '插件更新完成', 'result': result})
     except Exception as e:
         logger.error(f'插件更新失败：{str(e)}', exc_info=True)
-        if 'plugin_name' in locals() and plugin_name in installing_tasks:
-            installing_tasks[plugin_name]['status'] = 'failed'
-            installing_tasks[plugin_name]['error'] = str(e)
+        if task_reserved:
+            _update_install_task(
+                plugin_name,
+                status='failed',
+                error=str(e),
+            )
         return jsonify({'success': False, 'error': str(e)}), 500
-    finally:
-        if 'plugin_name' in locals() and plugin_name in installing_tasks:
-            import time
-            time.sleep(0.3)
-            installing_tasks.pop(plugin_name, None)
 
 
 @market_bp.route('/api/market/plugins/update-all', methods=['POST'])
@@ -387,22 +521,35 @@ def update_all_market_plugins():
             repo_url = plugin.get('repo', '')
             if not repo_url:
                 return {'name': name, 'success': False, 'error': '插件未配置 repo'}
+            if not _reserve_install_task(
+                name,
+                status='updating',
+                progress=10,
+                operation='update',
+            ):
+                return {
+                    'name': name,
+                    'success': False,
+                    'error': '插件正在安装或更新中',
+                }
             try:
-                installing_tasks[name] = {'status': 'updating', 'progress': 10}
                 result = update_plugin_safe(
                     _get_market_plugin_dir(name),
                     name,
                     repo_url,
                     requirements_installer=_install_requirements_with_task_status(name),
                 )
-                installing_tasks[name]['status'] = 'completed'
-                installing_tasks[name]['progress'] = 100
+                _update_install_task(
+                    name,
+                    status='completed',
+                    progress=100,
+                    error='',
+                )
                 return {'name': name, 'success': True, 'result': result}
             except Exception as exc:
                 logger.error(f'批量更新插件失败 {name}: {exc}', exc_info=True)
+                _update_install_task(name, status='failed', error=str(exc))
                 return {'name': name, 'success': False, 'error': str(exc)}
-            finally:
-                installing_tasks.pop(name, None)
 
         results = []
         workers = min(PLUGIN_UPDATE_CONCURRENCY, len(plugin_names))
@@ -452,12 +599,19 @@ def check_market_plugin_updates():
 @market_bp.route('/api/market/plugins/install-status/<plugin_name>', methods=['GET'])
 def get_install_status(plugin_name):
     """获取插件安装状态"""
-    if plugin_name in installing_tasks:
-        task = installing_tasks[plugin_name]
+    task = _get_install_task(plugin_name)
+    if task:
+        status = task.get('status', 'unknown')
+        terminal = status in TERMINAL_INSTALL_STATUSES
+        community_path = PROJECT_ROOT / 'plugins' / 'community'
+        plugin_dir = community_path / plugin_name
+        is_installed = plugin_dir.exists() and any(plugin_dir.iterdir())
         return jsonify({
             'success': True,
-            'installing': True,
-            'status': task.get('status', 'unknown'),
+            'installing': not terminal,
+            'terminal': terminal,
+            'installed': is_installed,
+            'status': status,
             'progress': task.get('progress', 0),
             'error': task.get('error', '')
         })

--- a/live-2d/webui/marketplace_updater.py
+++ b/live-2d/webui/marketplace_updater.py
@@ -35,6 +35,43 @@ GITHUB_REPO_RE = re.compile(
 )
 
 DEFAULT_TIMEOUT = 12
+PERSISTENCE_MANIFEST_NAME = "plugin_persistence.json"
+DEFAULT_PERSISTENT_PATHS = (
+    "plugin_config.json",
+    PERSISTENCE_MANIFEST_NAME,
+    "data",
+    "cache",
+    ".cache",
+    ".runtime",
+    "storage",
+    "state",
+    "logs",
+    "downloads",
+    "media",
+    "output",
+    "generated",
+)
+PERSISTENT_DATABASE_SUFFIXES = {".db", ".sqlite", ".sqlite3"}
+PERSISTENT_DATA_SUFFIXES = {".json", ".jsonl", ".txt", ".csv", ".yaml", ".yml"}
+PERSISTENT_FILE_TOKENS = {
+    "activity",
+    "archive",
+    "cache",
+    "config",
+    "context",
+    "data",
+    "database",
+    "diary",
+    "history",
+    "memory",
+    "profile",
+    "record",
+    "session",
+    "snapshot",
+    "state",
+    "store",
+}
+MAX_RETAINED_UPDATE_BACKUPS = 3
 
 
 def parse_github_repo(repo_url):
@@ -303,15 +340,143 @@ def install_requirements_if_present(plugin_dir):
     )
 
 
+def _normalize_persistent_path(value):
+    if not isinstance(value, str):
+        return None
+    text = value.strip().replace("\\", "/")
+    if not text:
+        return None
+    relative = Path(text)
+    if relative.is_absolute() or ".." in relative.parts or relative == Path("."):
+        raise ValueError(f"Invalid persistent plugin path: {value}")
+    return relative
+
+
+def _declared_persistent_paths(plugin_dir):
+    plugin_path = Path(plugin_dir)
+    declared = set()
+
+    metadata = get_local_metadata(plugin_path)
+    metadata_paths = (
+        metadata.get("persistent_paths", [])
+        if isinstance(metadata, dict)
+        else []
+    )
+    if metadata_paths and not isinstance(metadata_paths, list):
+        raise ValueError("metadata.json persistent_paths must be an array")
+
+    manifest_path = plugin_path / PERSISTENCE_MANIFEST_NAME
+    manifest_paths = []
+    if manifest_path.is_file():
+        with manifest_path.open("r", encoding="utf-8-sig") as file:
+            manifest = json.load(file)
+        if isinstance(manifest, list):
+            manifest_paths = manifest
+        elif isinstance(manifest, dict):
+            manifest_paths = manifest.get("paths", [])
+        else:
+            raise ValueError(
+                f"{PERSISTENCE_MANIFEST_NAME} must be an object or array"
+            )
+        if not isinstance(manifest_paths, list):
+            raise ValueError(
+                f"{PERSISTENCE_MANIFEST_NAME} paths must be an array"
+            )
+
+    for value in [*metadata_paths, *manifest_paths]:
+        normalized = _normalize_persistent_path(value)
+        if normalized is not None:
+            declared.add(normalized)
+    return declared
+
+
+def _discover_persistent_paths(old_plugin_dir, new_plugin_dir):
+    old_path = Path(old_plugin_dir)
+    paths = {Path(value) for value in DEFAULT_PERSISTENT_PATHS}
+    paths.update(_declared_persistent_paths(old_path))
+    paths.update(_declared_persistent_paths(new_plugin_dir))
+
+    for child in old_path.iterdir():
+        if not child.is_file() or child.is_symlink():
+            continue
+        suffix = child.suffix.lower()
+        stem_tokens = {
+            token
+            for token in re.split(r"[^a-z0-9]+", child.stem.lower())
+            if token
+        }
+        if (
+            suffix in PERSISTENT_DATABASE_SUFFIXES
+            or (
+                suffix in PERSISTENT_DATA_SUFFIXES
+                and stem_tokens.intersection(PERSISTENT_FILE_TOKENS)
+            )
+        ):
+            paths.add(Path(child.name))
+
+    return sorted(paths, key=lambda value: value.as_posix())
+
+
+def _copy_persistent_path(source_root, target_root, relative_path):
+    source = Path(source_root) / relative_path
+    target = Path(target_root) / relative_path
+    if not source.exists() or source.is_symlink():
+        return False
+    if (
+        relative_path == Path(PERSISTENCE_MANIFEST_NAME)
+        and target.exists()
+    ):
+        return False
+
+    if source.is_dir():
+        if target.exists() and not target.is_dir():
+            target.unlink()
+        shutil.copytree(source, target, dirs_exist_ok=True, symlinks=True)
+    elif source.is_file():
+        if target.exists() and target.is_dir():
+            shutil.rmtree(target)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+    else:
+        return False
+    return True
+
+
 def _unique_backup_path(plugin_dir, plugin_name):
     timestamp = time.strftime("%Y%m%d%H%M%S")
-    parent = Path(plugin_dir).parent
+    plugin_path = Path(plugin_dir)
+    category_dir = plugin_path.parent
+    backup_root = (
+        category_dir.parent
+        / ".plugin-update-backups"
+        / category_dir.name
+        / plugin_path.name
+    )
+    backup_root.mkdir(parents=True, exist_ok=True)
     for index in range(100):
         suffix = f"{timestamp}-{index}" if index else timestamp
-        backup_path = parent / f".{plugin_name}.backup-{suffix}"
+        backup_path = backup_root / f"backup-{suffix}"
         if not backup_path.exists():
             return backup_path
     raise RuntimeError("无法创建唯一备份目录")
+
+
+def _prune_old_backups(backup_path, keep=MAX_RETAINED_UPDATE_BACKUPS):
+    backup = Path(backup_path)
+    try:
+        candidates = sorted(
+            (
+                path
+                for path in backup.parent.iterdir()
+                if path.is_dir() and path.name.startswith("backup-")
+            ),
+            key=lambda path: path.stat().st_mtime_ns,
+            reverse=True,
+        )
+    except OSError:
+        return
+    for stale in candidates[max(1, keep):]:
+        shutil.rmtree(stale, ignore_errors=True)
 
 
 def update_plugin_safe(
@@ -321,39 +486,55 @@ def update_plugin_safe(
     archive_downloader=download_archive,
     requirements_installer=install_requirements_if_present,
 ):
-    """原子更新插件：失败时恢复旧目录，成功时保留 plugin_config.json。"""
+    """Stage an update, preserve plugin-owned state, and retain rollback data."""
     plugin_path = Path(plugin_dir)
     if not plugin_path.exists():
         raise FileNotFoundError(f"插件目录不存在：{plugin_path}")
 
-    backup_path = _unique_backup_path(plugin_path, plugin_name)
-    config_path = plugin_path / "plugin_config.json"
-    config_bytes = config_path.read_bytes() if config_path.exists() else None
-
-    archive_bytes = None
-    plugin_path.rename(backup_path)
+    backup_path = None
+    staged_path = Path(
+        tempfile.mkdtemp(
+            prefix=f".{plugin_path.name}.update-",
+            dir=str(plugin_path.parent),
+        )
+    )
+    old_directory_moved = False
     try:
         archive_bytes = archive_downloader(repo_url)
         if not archive_bytes:
             raise RuntimeError("下载到的插件压缩包为空")
 
-        extract_archive_strip_root(archive_bytes, plugin_path)
-        if config_bytes is not None:
-            (plugin_path / "plugin_config.json").write_bytes(config_bytes)
+        extract_archive_strip_root(archive_bytes, staged_path)
+        persistent_paths = _discover_persistent_paths(plugin_path, staged_path)
+        preserved_paths = [
+            relative.as_posix()
+            for relative in persistent_paths
+            if _copy_persistent_path(plugin_path, staged_path, relative)
+        ]
 
-        requirements_installer(plugin_path)
-        metadata = get_local_metadata(plugin_path)
-        shutil.rmtree(backup_path, ignore_errors=True)
+        requirements_installer(staged_path)
+        metadata = get_local_metadata(staged_path)
+
+        backup_path = _unique_backup_path(plugin_path, plugin_name)
+        plugin_path.rename(backup_path)
+        old_directory_moved = True
+        staged_path.rename(plugin_path)
+        old_directory_moved = False
+        _prune_old_backups(backup_path)
         return {
             "name": metadata.get("name", plugin_name),
             "version": metadata.get("version", ""),
             "plugin_dir": str(plugin_path),
+            "preserved_paths": preserved_paths,
+            "backup_path": str(backup_path),
         }
     except Exception:
-        shutil.rmtree(plugin_path, ignore_errors=True)
-        if backup_path.exists():
+        if old_directory_moved and backup_path is not None:
+            shutil.rmtree(plugin_path, ignore_errors=True)
             backup_path.rename(plugin_path)
         raise
+    finally:
+        shutil.rmtree(staged_path, ignore_errors=True)
 
 
 def install_plugin_from_archive(

--- a/live-2d/webui/plugin_manager.py
+++ b/live-2d/webui/plugin_manager.py
@@ -15,6 +15,7 @@ from .marketplace_updater import (
     check_framework_compatibility,
     check_updates_for_plugins,
 )
+from .state_io import atomic_write_json, resource_lock
 
 # 创建插件管理蓝图
 plugin_bp = Blueprint('plugin', __name__)
@@ -22,15 +23,41 @@ plugin_bp = Blueprint('plugin', __name__)
 PLUGIN_FRAMEWORK_VERSION = '1.0.0'
 
 
+def _read_enabled_plugins_file(enabled_path):
+    if not enabled_path.exists():
+        return []
+    with open(enabled_path, 'r', encoding='utf-8-sig') as f:
+        data = json.load(f)
+    plugins = data.get('plugins', []) if isinstance(data, dict) else []
+    if not isinstance(plugins, list):
+        raise ValueError('enabled_plugins.json plugins must be an array')
+    return plugins
+
+
+def _build_updated_plugin_config(original_config, config_data):
+    ordered_config = OrderedDict()
+    for key in original_config.keys():
+        original_item = original_config[key]
+        if isinstance(original_item, dict) and 'type' in original_item:
+            ordered_config[key] = OrderedDict(original_item)
+            if key in config_data:
+                ordered_config[key]['value'] = config_data[key]
+        elif key in config_data:
+            ordered_config[key] = config_data[key]
+        else:
+            ordered_config[key] = original_item
+
+    for key in config_data.keys():
+        if key not in ordered_config:
+            ordered_config[key] = config_data[key]
+    return ordered_config
+
+
 def load_enabled_plugins():
     """从 enabled_plugins.json 加载已启用的插件列表"""
     enabled_path = PROJECT_ROOT / 'plugins' / 'enabled_plugins.json'
-    if not enabled_path.exists():
-        return []
     try:
-        with open(enabled_path, 'r', encoding='utf-8') as f:
-            data = json.load(f)
-        return data.get('plugins', [])
+        return _read_enabled_plugins_file(enabled_path)
     except Exception as e:
         logger.error(f'加载 enabled_plugins.json 失败：{e}')
         return []
@@ -40,8 +67,8 @@ def save_enabled_plugins(enabled_list):
     """保存已启用的插件列表到 enabled_plugins.json"""
     enabled_path = PROJECT_ROOT / 'plugins' / 'enabled_plugins.json'
     try:
-        with open(enabled_path, 'w', encoding='utf-8') as f:
-            json.dump({'plugins': enabled_list}, f, ensure_ascii=False, indent=2)
+        with resource_lock(enabled_path):
+            atomic_write_json(enabled_path, {'plugins': enabled_list})
         return True
     except Exception as e:
         logger.error(f'保存 enabled_plugins.json 失败：{e}')
@@ -128,8 +155,6 @@ def toggle_plugin():
     
     使用 POST body 传递 plugin_path，避免 URL 中/的问题
     """
-    enabled_plugins = load_enabled_plugins()
-    
     data = request.get_json()
     if not data:
         return jsonify({'success': False, 'error': '无效的请求数据'}), 400
@@ -152,21 +177,26 @@ def toggle_plugin():
     if not plugin_dir.exists():
         return jsonify({'success': False, 'error': f'插件目录不存在：{plugin_path}'}), 404
     
-    # 切换状态
-    if plugin_path in enabled_plugins:
-        enabled_plugins.remove(plugin_path)
-        action = 'disabled'
-    else:
-        enabled_plugins.append(plugin_path)
-        action = 'enabled'
-    
-    if save_enabled_plugins(enabled_plugins):
+    enabled_path = PROJECT_ROOT / 'plugins' / 'enabled_plugins.json'
+    try:
+        with resource_lock(enabled_path):
+            enabled_plugins = _read_enabled_plugins_file(enabled_path)
+            if plugin_path in enabled_plugins:
+                enabled_plugins.remove(plugin_path)
+                action = 'disabled'
+            else:
+                enabled_plugins.append(plugin_path)
+                action = 'enabled'
+            atomic_write_json(enabled_path, {'plugins': enabled_plugins})
+
         return jsonify({
             'success': True,
             'action': action,
             'plugin_path': plugin_path
         })
-    return jsonify({'success': False, 'error': '保存失败'}), 500
+    except Exception as e:
+        logger.error(f'保存 enabled_plugins.json 失败：{e}')
+        return jsonify({'success': False, 'error': '保存失败'}), 500
 
 
 @plugin_bp.route('/api/plugins/open-config', methods=['POST'])
@@ -407,36 +437,14 @@ def save_plugin_config(plugin_name):
         if not config_file:
             return jsonify({'error': f'插件 {plugin_name} 没有配置文件'}), 404
         
-        # 读取原始配置文件以保持顺序和元数据
-        with open(config_file, 'r', encoding='utf-8') as f:
-            original_config = json.load(f, object_pairs_hook=OrderedDict)
-        
-        # 按照原始配置文件的键顺序重新排列新配置
-        ordered_config = OrderedDict()
-        for key in original_config.keys():
-            original_item = original_config[key]
-            
-            # 检查是否是带元数据的配置项（有 title, type 等字段）
-            if isinstance(original_item, dict) and 'type' in original_item:
-                # 这是带元数据的配置项，只更新 value 字段
-                ordered_config[key] = OrderedDict(original_item)
-                if key in config_data:
-                    ordered_config[key]['value'] = config_data[key]
-            else:
-                # 这是简单值配置，直接更新
-                if key in config_data:
-                    ordered_config[key] = config_data[key]
-                else:
-                    ordered_config[key] = original_item
-        
-        # 添加新配置中新增的键（如果有）
-        for key in config_data.keys():
-            if key not in ordered_config:
-                ordered_config[key] = config_data[key]
-        
-        # 保存新配置（保持原始顺序和 2 空格缩进）
-        with open(config_file, 'w', encoding='utf-8') as f:
-            json.dump(ordered_config, f, ensure_ascii=False, indent=2)
+        with resource_lock(config_file):
+            with open(config_file, 'r', encoding='utf-8') as f:
+                original_config = json.load(f, object_pairs_hook=OrderedDict)
+            ordered_config = _build_updated_plugin_config(
+                original_config,
+                config_data,
+            )
+            atomic_write_json(config_file, ordered_config)
         
         return jsonify({
             'success': True,

--- a/live-2d/webui/service_controller.py
+++ b/live-2d/webui/service_controller.py
@@ -10,12 +10,21 @@ import subprocess
 import time
 import os
 import json
+from pathlib import Path
 from flask import Blueprint, jsonify
 
-from .utils import PROJECT_ROOT, logger, service_processes, service_pids, is_service_running
+from .utils import PROJECT_ROOT, logger, service_processes, service_pids
+from .state_io import (
+    delete_resource_state,
+    read_resource_state,
+    resource_lock,
+    write_resource_state,
+)
 
 # Windows 下隐藏窗口的标志
 CREATE_NO_WINDOW = 0x08000000 if sys.platform.startswith('win') else 0
+MANAGED_SERVICES = ('live2d', 'asr', 'tts', 'bert', 'memos', 'rag')
+SERVICE_OPERATION_LOCK_TIMEOUT = 20.0
 
 # 创建服务控制蓝图
 service_bp = Blueprint('service', __name__)
@@ -25,12 +34,108 @@ import datetime
 START_TIME = datetime.datetime.now()
 
 
+def _service_resource(service):
+    return f'service:{PROJECT_ROOT.resolve()}:{service}'
+
+
+def _read_service_owner(service):
+    return read_resource_state(_service_resource(service))
+
+
+def _write_service_owner(service, proc):
+    write_resource_state(
+        _service_resource(service),
+        {
+            'service': service,
+            'service_pid': int(proc.pid),
+            'webui_pid': os.getpid(),
+            'updated_at': time.time(),
+        },
+    )
+
+
+def _clear_service_owner(service):
+    delete_resource_state(_service_resource(service))
+
+
+def _pid_is_running(pid):
+    try:
+        process_id = int(pid)
+    except (TypeError, ValueError):
+        return False
+    if process_id <= 0:
+        return False
+
+    if sys.platform.startswith('win'):
+        import ctypes
+
+        process_query_limited_information = 0x1000
+        still_active = 259
+        handle = ctypes.windll.kernel32.OpenProcess(
+            process_query_limited_information,
+            False,
+            process_id,
+        )
+        if not handle:
+            return False
+        try:
+            exit_code = ctypes.c_ulong()
+            return bool(
+                ctypes.windll.kernel32.GetExitCodeProcess(
+                    handle,
+                    ctypes.byref(exit_code),
+                )
+                and exit_code.value == still_active
+            )
+        finally:
+            ctypes.windll.kernel32.CloseHandle(handle)
+
+    try:
+        os.kill(process_id, 0)
+        return True
+    except OSError:
+        return False
+
+
+def _get_service_state(service):
+    proc = service_processes.get(service)
+    locally_tracked = bool(proc and proc.poll() is None)
+    if proc and not locally_tracked:
+        service_processes.pop(service, None)
+
+    owner = _read_service_owner(service)
+    owner_pid = owner.get('service_pid') if isinstance(owner, dict) else None
+    shared_tracked = bool(owner_pid and _pid_is_running(owner_pid))
+    if owner and not shared_tracked:
+        _clear_service_owner(service)
+        owner_pid = None
+
+    running = locally_tracked or shared_tracked
+    service_pids[service] = running
+    return {
+        'running': running,
+        'locally_tracked': locally_tracked,
+        'shared_tracked': shared_tracked,
+        'owner_pid': owner_pid,
+    }
+
+
+def _batch_command(script_path):
+    if not sys.platform.startswith('win'):
+        return [str(script_path)]
+    command = os.environ.get('COMSPEC', 'cmd.exe')
+    return [command, '/d', '/c', 'call', str(script_path)]
+
+
 @service_bp.route('/api/status')
 def get_status():
     """获取所有服务的状态"""
     status = {}
-    for service in service_pids.keys():
-        status[service] = 'running' if service_pids.get(service, False) else 'stopped'
+    services = set(MANAGED_SERVICES) | set(service_pids) | set(service_processes)
+    for service in services:
+        status[service] = (
+            'running' if _get_service_state(service)['running'] else 'stopped'
+        )
     return jsonify(status)
 
 
@@ -64,11 +169,37 @@ def get_system_info():
 
 @service_bp.route('/api/start/<service>', methods=['POST'])
 def start_service(service):
+    try:
+        with resource_lock(
+            _service_resource(service),
+            timeout=SERVICE_OPERATION_LOCK_TIMEOUT,
+        ):
+            return _start_service_locked(service)
+    except TimeoutError:
+        return jsonify({
+            'success': False,
+            'error': '服务启动操作正由另一个 WebUI 执行，请稍后重试',
+        }), 409
+    except Exception as error:
+        logger.error(f'获取 {service} 服务启动锁失败：{error}')
+        return jsonify({
+            'success': False,
+            'error': f'服务启动锁失败：{error}',
+        }), 500
+
+
+def _start_service_locked(service):
     """启动指定服务"""
     try:
         # 检查服务是否已在运行
-        if is_service_running(service):
-            return jsonify({'success': False, 'error': '服务已在运行中'})
+        state = _get_service_state(service)
+        if state['running']:
+            return jsonify({
+                'success': False,
+                'already_running': True,
+                'pid': state.get('owner_pid'),
+                'error': '服务已在运行中',
+            })
 
         # 根据服务类型启动对应的脚本
         # live2d 使用特殊方式启动（不显示控制台），其他服务保持原样
@@ -121,6 +252,12 @@ def start_service(service):
             return jsonify({'success': False, 'error': f'未知服务：{service}'})
 
         config = script_map[service]
+        script_path = Path(config['script'])
+        if not script_path.is_file():
+            return jsonify({
+                'success': False,
+                'error': f'找不到启动脚本：{script_path}',
+            })
 
         # 对于 Live2D 服务，启动前清空日志文件
         if service == 'live2d' and config.get('log_file'):
@@ -137,8 +274,7 @@ def start_service(service):
             # Live2D 服务：不显示控制台窗口，直接运行 bat
             # 使用 shell=True 让 bat 文件能正确执行
             proc = subprocess.Popen(
-                config['script'],
-                shell=True,
+                _batch_command(script_path),
                 cwd=config['cwd'],
                 creationflags=CREATE_NO_WINDOW if sys.platform.startswith('win') else 0,
                 stdout=subprocess.PIPE,
@@ -150,17 +286,22 @@ def start_service(service):
             if proc.poll() is not None:
                 # 进程已退出，尝试用 cmd /c 方式启动
                 proc = subprocess.Popen(
-                    ['cmd', '/c', config['script']],
+                    _batch_command(script_path),
                     cwd=config['cwd'],
                     creationflags=CREATE_NO_WINDOW if sys.platform.startswith('win') else 0,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT
                 )
                 time.sleep(1)
+                if proc.poll() is not None:
+                    return jsonify({
+                        'success': False,
+                        'error': '服务启动脚本立即退出',
+                    })
         else:
             # 其他服务：保持原有方式（显示控制台窗口）
             proc = subprocess.Popen(
-                config['args'],
+                _batch_command(script_path),
                 cwd=config['cwd'],
                 creationflags=subprocess.CREATE_NEW_CONSOLE if sys.platform.startswith('win') else 0
             )
@@ -168,6 +309,16 @@ def start_service(service):
         service_processes[service] = proc
         # 记录服务已启动（即使进程对象可能立即结束）
         service_pids[service] = True
+        try:
+            _write_service_owner(service, proc)
+        except Exception:
+            try:
+                proc.terminate()
+            except Exception:
+                pass
+            service_processes.pop(service, None)
+            service_pids[service] = False
+            raise
         logger.warning(f'{service} 服务已启动 (PID: {proc.pid})')
 
         return jsonify({'success': True, 'pid': proc.pid})
@@ -179,7 +330,30 @@ def start_service(service):
 
 @service_bp.route('/api/stop/<service>', methods=['POST'])
 def stop_service(service):
+    try:
+        with resource_lock(
+            _service_resource(service),
+            timeout=SERVICE_OPERATION_LOCK_TIMEOUT,
+        ):
+            return _stop_service_locked(service)
+    except TimeoutError:
+        return jsonify({
+            'success': False,
+            'error': '服务停止操作正由另一个 WebUI 执行，请稍后重试',
+        }), 409
+    except Exception as error:
+        logger.error(f'获取 {service} 服务停止锁失败：{error}')
+        return jsonify({
+            'success': False,
+            'error': f'服务停止锁失败：{error}',
+        }), 500
+
+
+def _stop_service_locked(service):
     """停止指定服务"""
+    if service not in MANAGED_SERVICES:
+        return jsonify({'success': False, 'error': f'未知服务：{service}'}), 404
+
     try:
         # 使用 PowerShell 根据命令行参数查找 PID，然后用 taskkill /T 终止进程树
         if sys.platform.startswith('win'):
@@ -193,17 +367,28 @@ def stop_service(service):
                     pids = [str(proc.pid)]
                     logger.debug(f'使用记录的 PID: {proc.pid}')
 
+            if not pids:
+                owner = _read_service_owner(service)
+                owner_pid = (
+                    owner.get('service_pid')
+                    if isinstance(owner, dict)
+                    else None
+                )
+                if owner_pid and _pid_is_running(owner_pid):
+                    pids = [str(owner_pid)]
+                    logger.debug(f'使用共享 PID: {owner_pid}')
+
             # 如果没有找到记录的 PID，使用 PowerShell 查找
             if not pids:
                 # 构建 bat 文件名
-                if service == 'live2d':
-                    bat_name = 'go.bat'
-                elif service == 'memos':
-                    bat_name = 'start_memos.bat'
-                elif service == 'rag':
-                    bat_name = 'RAG.bat'
-                else:
-                    bat_name = f'{service}.bat'
+                bat_name = {
+                    'live2d': 'go.bat',
+                    'asr': '1.ASR.bat',
+                    'tts': '2.TTS.bat',
+                    'bert': '3.bert.bat',
+                    'memos': 'start_memos.bat',
+                    'rag': 'RAG.bat',
+                }.get(service, f'{service}.bat')
 
                 # 使用 PowerShell 查找包含 bat 文件名的进程 PID
                 ps_script = f"""
@@ -229,6 +414,7 @@ def stop_service(service):
                 service_pids[service] = False
                 if service in service_processes:
                     del service_processes[service]
+                _clear_service_owner(service)
                 return jsonify({'success': True, 'message': '服务已停止'})
 
             # 对每个 PID 使用 taskkill /T 终止进程树
@@ -259,28 +445,37 @@ def stop_service(service):
                         killed_count += 1
                         logger.debug(f'已终止进程树 PID: {pid} (返回码=0)')
 
-            # 清除服务标记（无论成功与否都重置按钮）
-            service_pids[service] = False
-            if service in service_processes:
-                del service_processes[service]
-
             if killed_count > 0:
+                service_pids[service] = False
+                service_processes.pop(service, None)
+                _clear_service_owner(service)
                 logger.info(f'{service} 服务已停止（终止了 {killed_count} 个进程树）')
                 return jsonify({'success': True, 'message': f'成功终止 {killed_count} 个进程'})
             elif failed_pids:
-                logger.warning(f'{service} 服务停止：所有进程终止失败，但已重置状态')
-                return jsonify({'success': True, 'warning': '进程可能已自行关闭'})
+                service_pids[service] = _get_service_state(service)['running']
+                logger.warning(f'{service} 服务停止：进程终止失败')
+                return jsonify({
+                    'success': False,
+                    'error': '进程终止失败',
+                }), 500
             else:
+                service_pids[service] = False
+                service_processes.pop(service, None)
+                _clear_service_owner(service)
                 return jsonify({'success': True, 'message': '服务已停止'})
         else:
             return jsonify({'success': False, 'error': '仅支持 Windows 系统'})
     except subprocess.TimeoutExpired:
         logger.error(f'停止 {service} 服务超时')
-        # 即使超时也清除标记
-        service_pids[service] = False
-        return jsonify({'success': True, 'warning': '停止命令已发送，但可能未完全终止'})
+        service_pids[service] = _get_service_state(service)['running']
+        return jsonify({
+            'success': False,
+            'error': '停止命令超时，服务状态已重新检查',
+        }), 504
     except Exception as e:
         logger.error(f'停止 {service} 服务失败：{str(e)}')
-        # 异常时也清除标记
-        service_pids[service] = False
-        return jsonify({'success': True, 'warning': f'停止服务时出错：{str(e)}'})
+        service_pids[service] = _get_service_state(service)['running']
+        return jsonify({
+            'success': False,
+            'error': f'停止服务时出错：{str(e)}',
+        }), 500

--- a/live-2d/webui/state_io.py
+++ b/live-2d/webui/state_io.py
@@ -1,0 +1,147 @@
+"""Cross-thread and cross-process state helpers for the WebUI."""
+
+import hashlib
+import json
+import os
+import tempfile
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+
+_LOCK_ROOT = Path(tempfile.gettempdir()) / "my-neuro-webui-locks"
+_STATE_ROOT = Path(tempfile.gettempdir()) / "my-neuro-webui-state"
+_THREAD_LOCKS = {}
+_THREAD_LOCKS_GUARD = threading.Lock()
+
+
+def _resource_key(resource):
+    if isinstance(resource, Path):
+        value = str(resource.resolve())
+    else:
+        value = str(resource)
+    return os.path.normcase(value)
+
+
+def _resource_digest(resource):
+    return hashlib.sha256(_resource_key(resource).encode("utf-8")).hexdigest()
+
+
+def _thread_lock(resource):
+    key = _resource_key(resource)
+    with _THREAD_LOCKS_GUARD:
+        return _THREAD_LOCKS.setdefault(key, threading.RLock())
+
+
+def _try_lock_file(stream):
+    stream.seek(0)
+    if os.name == "nt":
+        import msvcrt
+
+        msvcrt.locking(stream.fileno(), msvcrt.LK_NBLCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(stream.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+
+def _unlock_file(stream):
+    stream.seek(0)
+    if os.name == "nt":
+        import msvcrt
+
+        msvcrt.locking(stream.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def resource_lock(resource, timeout=15.0, poll_interval=0.025):
+    """Serialize one logical resource across threads and WebUI processes."""
+    thread_lock = _thread_lock(resource)
+    with thread_lock:
+        _LOCK_ROOT.mkdir(parents=True, exist_ok=True)
+        lock_path = _LOCK_ROOT / f"{_resource_digest(resource)}.lock"
+        with lock_path.open("a+b") as stream:
+            deadline = time.monotonic() + timeout
+            while True:
+                try:
+                    stream.seek(0, os.SEEK_END)
+                    if stream.tell() == 0:
+                        stream.write(b"\0")
+                        stream.flush()
+                    _try_lock_file(stream)
+                    break
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError(
+                            f"Timed out waiting for resource lock: "
+                            f"{_resource_key(resource)}"
+                        )
+                    time.sleep(poll_interval)
+
+            try:
+                yield
+            finally:
+                _unlock_file(stream)
+
+
+def atomic_write_json(path, data, *, indent=2):
+    """Write JSON through a same-directory temporary file and atomic replace."""
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="\n",
+            dir=target.parent,
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as stream:
+            temp_path = Path(stream.name)
+            json.dump(data, stream, ensure_ascii=False, indent=indent)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temp_path, target)
+        temp_path = None
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except OSError:
+                pass
+
+
+def resource_state_path(resource):
+    _STATE_ROOT.mkdir(parents=True, exist_ok=True)
+    return _STATE_ROOT / f"{_resource_digest(resource)}.json"
+
+
+def read_resource_state(resource):
+    path = resource_state_path(resource)
+    try:
+        with path.open("r", encoding="utf-8") as stream:
+            value = json.load(stream)
+        return value if isinstance(value, dict) else None
+    except (OSError, ValueError):
+        return None
+
+
+def write_resource_state(resource, data):
+    atomic_write_json(resource_state_path(resource), data)
+
+
+def delete_resource_state(resource):
+    try:
+        resource_state_path(resource).unlink()
+    except FileNotFoundError:
+        pass

--- a/live-2d/webui/static/js/app.js
+++ b/live-2d/webui/static/js/app.js
@@ -8,8 +8,11 @@ const configDirtyItems = new Set();
 let isConfigDirtyTrackingReady = false;
 let currentLogTab = 'system-log';
 let logPollingInterval = null;
-let lastPetLogCount = 0;  // 记录上次桌宠日志数量
-let lastToolLogCount = 0; // 记录上次工具日志数量
+let runtimeLogOffset = null;
+let runtimeLogCursor = '';
+let runtimeLogRequestInFlight = false;
+const LOG_POLL_INTERVAL_MS = 1000;
+const MAX_RENDERED_LOG_ENTRIES = 500;
 
 // 对话历史状态
 let chatHistoryState = {
@@ -159,7 +162,12 @@ function addLog(message, level = 'info', logType = 'system') {
 function appendNewLogs(logType, newLogs) {
     const outputId = logType + '-log-output';
     const logOutput = document.getElementById(outputId);
-    
+    if (!logOutput) return;
+
+    const wasAtBottom = (
+        logOutput.scrollHeight - logOutput.clientHeight - logOutput.scrollTop < 50
+    );
+
     // 为每条新日志添加条目（不添加时间戳，直接使用日志文件中的时间）
     newLogs.forEach(log => {
         const level = log.includes('错误') || log.includes('失败') || log.includes('error') || log.includes('fail') || log.includes('❌') ? 'error' :
@@ -170,10 +178,13 @@ function appendNewLogs(logType, newLogs) {
         logEntry.textContent = log;  // 直接使用日志内容，不添加额外时间戳
         logOutput.appendChild(logEntry);
     });
-    
+
+    while (logOutput.children.length > MAX_RENDERED_LOG_ENTRIES) {
+        logOutput.firstElementChild?.remove();
+    }
+
     // 只有当用户已经在底部时才自动滚动到底部
-    const isAtBottom = logOutput.scrollHeight - logOutput.clientHeight - logOutput.scrollTop < 50;
-    if (isAtBottom) {
+    if (wasAtBottom) {
         logOutput.scrollTop = logOutput.scrollHeight;
     }
     
@@ -204,6 +215,8 @@ function switchLogTab(tabId) {
     } else {
         stopChatHistoryPolling();
     }
+
+    pollVisibleLogs();
 
     // 不再同步第二个面板，两个面板的选项卡独立操作，方便对照不同日志
 }
@@ -321,6 +334,7 @@ function switchLogTab2(tabId) {
     } else {
         stopChatHistoryPolling();
     }
+    pollVisibleLogs();
 }
 
 // 清空第二个面板的当前日志
@@ -666,62 +680,78 @@ function syncLogToPanel2() {
     // 右侧面板现在只显示历史对话，无需同步日志
 }
 
-// 加载日志（增量更新）
-async function loadLogs(logType) {
-    try {
-        const response = await fetch('/api/logs/' + logType);
-        if (response.ok) {
-            const data = await response.json();
-            if (data.logs && data.logs.length > 0) {
-                const outputId = logType + '-log-output';
-                const logOutput = document.getElementById(outputId);
-                
-                // 检查日志数量是否变化
-                const currentCount = logType === 'pet' ? lastPetLogCount : lastToolLogCount;
-                const newCount = data.logs.length;
-                
-                // 只有当日志数量增加时才添加新日志
-                if (newCount > currentCount) {
-                    const newLogs = data.logs.slice(currentCount);  // 只取新增的日志
-                    appendNewLogs(logType, newLogs);
-                    
-                    // 更新计数
-                    if (logType === 'pet') {
-                        lastPetLogCount = newCount;
-                    } else {
-                        lastToolLogCount = newCount;
-                    }
-                }
-                // 如果日志数量减少（文件被清空），重置并重新加载
-                else if (newCount < currentCount) {
-                    logOutput.innerHTML = '';
-                    if (logType === 'pet') {
-                        lastPetLogCount = 0;
-                    } else {
-                        lastToolLogCount = 0;
-                    }
-                    // 重新加载所有日志
-                    appendNewLogs(logType, data.logs);
-                    if (logType === 'pet') {
-                        lastPetLogCount = data.logs.length;
-                    } else {
-                        lastToolLogCount = data.logs.length;
-                    }
-                }
-            }
+function runtimeLogIsVisible() {
+    const dashboard = document.getElementById('dashboard');
+    if (document.hidden || !dashboard?.classList.contains('active')) {
+        return false;
+    }
+
+    return Array.from(document.querySelectorAll(
+        '#logPanelContainer1 .log-panel.active, '
+        + '#logPanelContainer2 .log-panel.active'
+    )).some(panel => {
+        const container = panel.closest('.log-panel-container');
+        if (!container || getComputedStyle(container).display === 'none') {
+            return false;
         }
+        return panel.id.startsWith('pet-log')
+            || panel.id.startsWith('tool-log');
+    });
+}
+
+
+async function loadRuntimeLogs() {
+    if (runtimeLogRequestInFlight) return;
+    runtimeLogRequestInFlight = true;
+    try {
+        const params = new URLSearchParams();
+        if (runtimeLogOffset !== null) {
+            params.set('offset', String(runtimeLogOffset));
+            params.set('cursor', runtimeLogCursor);
+        }
+        const suffix = params.toString() ? '?' + params.toString() : '';
+        const response = await fetch('/api/logs/runtime' + suffix);
+        const data = await response.json();
+        if (!response.ok) {
+            throw new Error(data.error || '运行日志读取失败');
+        }
+
+        if (data.reset) {
+            document.getElementById('pet-log-output')?.replaceChildren();
+            document.getElementById('tool-log-output')?.replaceChildren();
+        }
+
+        const logs = data.logs || {};
+        if (Array.isArray(logs.pet) && logs.pet.length > 0) {
+            appendNewLogs('pet', logs.pet);
+        }
+        if (Array.isArray(logs.tool) && logs.tool.length > 0) {
+            appendNewLogs('tool', logs.tool);
+        }
+        runtimeLogOffset = Number.isFinite(Number(data.offset))
+            ? Number(data.offset)
+            : runtimeLogOffset;
+        runtimeLogCursor = data.cursor || runtimeLogCursor;
     } catch (error) {
-        console.error('Load logs failed:', error);
+        console.error('加载运行日志失败:', error);
+    } finally {
+        runtimeLogRequestInFlight = false;
     }
 }
 
+
+function pollVisibleLogs() {
+    if (runtimeLogIsVisible()) {
+        loadRuntimeLogs();
+    }
+}
+
+
 // 启动日志轮询
 function startLogPolling() {
-    // 每 500 毫秒轮询一次桌宠日志和工具日志
-    logPollingInterval = setInterval(() => {
-        loadLogs('pet');
-        loadLogs('tool');
-    }, 500);
+    stopLogPolling();
+    pollVisibleLogs();
+    logPollingInterval = setInterval(pollVisibleLogs, LOG_POLL_INTERVAL_MS);
 }
 
 // 停止日志轮询
@@ -816,8 +846,11 @@ async function startService(serviceName) {
         addLog(t('services.starting') + ' ' + serviceName + ' ' + t('services.service_suffix'), 'info', 'system');
         const response = await fetch('/api/start/' + serviceName, { method: 'POST' });
         const result = await response.json();
-        
-        if (response.ok && result.success) {
+
+        if (response.ok && result.already_running) {
+            updateServiceStatus(serviceName, 'running');
+            addLog(serviceName + ' ' + t('services.already_running'), 'info', 'system');
+        } else if (response.ok && result.success) {
             updateServiceStatus(serviceName, 'running');
             addLog(serviceName + ' ' + t('services.start_success'), 'success', 'system');
         } else {
@@ -878,9 +911,17 @@ async function startAllServices() {
                 const response = await fetch('/api/start/' + service, { method: 'POST' });
                 const result = await response.json();
 
-                if (response.ok && result.success) {
+                if (response.ok && (result.success || result.already_running)) {
                     updateServiceStatus(service, 'running');
-                    addLog(service + ' ' + t('services.start_success'), 'success', 'system');
+                    addLog(
+                        service + ' ' + (
+                            result.already_running
+                                ? t('services.already_running')
+                                : t('services.start_success')
+                        ),
+                        result.already_running ? 'info' : 'success',
+                        'system'
+                    );
                     successCount++;
                 } else {
                     addLog(service + ' ' + t('services.start_failed') + '：' + (result.error || t('common.unknown_error')), 'error', 'system');
@@ -1031,6 +1072,10 @@ function switchTab(tabName) {
     const targetButton = document.querySelector(`.tab-button[onclick="switchTab('${tabName}')"]`);
     if (targetButton) {
         targetButton.classList.add('active');
+    }
+
+    if (tabName === 'dashboard') {
+        pollVisibleLogs();
     }
 
     // 保存按钮已移至各面板底部，此处不再需要动态控制
@@ -1475,10 +1520,6 @@ document.addEventListener('DOMContentLoaded', async function() {
 
     // 初始化文件拖拽
     initFileDragDrop();
-
-    // 重置日志计数器
-    lastPetLogCount = 0;
-    lastToolLogCount = 0;
 
     addLog(t('logs.webui_ready'), 'success', 'system');
 
@@ -2833,6 +2874,7 @@ async function resetModelPosition() {
 document.addEventListener('visibilitychange', function() {
     if (!document.hidden) {
         checkServiceStatus();
+        pollVisibleLogs();
     }
 });
 
@@ -3248,41 +3290,58 @@ function restoreInstallButton(pluginName, text) {
     if (progressDiv) progressDiv.style.display = 'none';
 }
 
-// 轮询检测插件是否已安装（检测目录存在）
+// 轮询持久任务状态，让后台安装错误能够直接显示。
 async function pollPluginInstalled(pluginName) {
-    const maxAttempts = 180;  // 最多轮询 180 次（约 3 分钟）
+    const maxAttempts = 180;
     let attempts = 0;
-    
+
     const poll = async () => {
         try {
-            // 直接检查插件目录是否存在
-            const response = await fetch(`/api/market/plugins/check-installed/${pluginName}`);
+            const response = await fetch(
+                `/api/market/plugins/install-status/${encodeURIComponent(pluginName)}`
+            );
             const data = await response.json();
-            
+
             const progressDiv = document.getElementById(`progress-${pluginName}`);
             const progressFill = progressDiv ? progressDiv.querySelector('.progress-fill') : null;
             const progressText = progressDiv ? progressDiv.querySelector('.progress-text') : null;
-            
-            if (data.installed) {
-                // 插件已安装，成功！
+
+            if (!response.ok || data.success === false) {
+                throw new Error(data.error || t('common.unknown_error'));
+            }
+
+            if (data.status === 'failed') {
+                const errorMessage = data.error || t('common.unknown_error');
+                showError(t('market.install_failed') + '：' + errorMessage);
+                restoreInstallButton(pluginName, t('market.plugin_install'));
+                return;
+            }
+
+            if (data.status === 'completed' || data.installed) {
                 if (progressFill) progressFill.style.width = '100%';
                 if (progressText) progressText.textContent = t('market.progress_done');
-                // 延迟刷新列表，让后端有时间清理任务状态
                 setTimeout(() => refreshPluginMarket(), 500);
                 return;
             }
-            
-            // 还未安装，进度条动画
+
+            if (!data.installing && !data.status) {
+                showError(t('market.install_task_missing'));
+                restoreInstallButton(pluginName, t('market.plugin_install'));
+                return;
+            }
+
             if (progressFill) {
-                const progress = (attempts % 50) * 2;  // 0-100 循环动画
+                const reported = Number(data.progress);
+                const progress = Number.isFinite(reported)
+                    ? Math.max(0, Math.min(100, reported))
+                    : (attempts % 50) * 2;
                 progressFill.style.width = progress + '%';
             }
-            
+
             attempts++;
             if (attempts < maxAttempts) {
-                setTimeout(poll, 1000);  // 每秒检查一次
+                setTimeout(poll, 1000);
             } else {
-                // 超时
                 if (progressText) progressText.textContent = t('market.progress_timeout');
                 restoreInstallButton(pluginName, t('market.plugin_install'));
             }
@@ -3292,11 +3351,12 @@ async function pollPluginInstalled(pluginName) {
             if (attempts < maxAttempts) {
                 setTimeout(poll, 1000);
             } else {
+                showError(t('market.install_failed') + '：' + error.message);
                 restoreInstallButton(pluginName, t('market.plugin_install'));
             }
         }
     };
-    
+
     poll();
 }
 

--- a/live-2d/webui/static/locales/en/translation.json
+++ b/live-2d/webui/static/locales/en/translation.json
@@ -170,6 +170,7 @@
     "no_desc": "No description",
     "install_failed": "Install failed",
     "install_error": "Error during installation",
+    "install_task_missing": "Install task state was lost. Please retry.",
     "progress_ready": "Preparing...",
     "progress_done": "✓ Install complete",
     "progress_timeout": "Install timeout, please retry",

--- a/live-2d/webui/static/locales/zh/translation.json
+++ b/live-2d/webui/static/locales/zh/translation.json
@@ -170,6 +170,7 @@
     "no_desc": "无描述",
     "install_failed": "安装失败",
     "install_error": "安装时出错",
+    "install_task_missing": "安装任务状态已丢失，请重试",
     "progress_ready": "准备中...",
     "progress_done": "✓ 安装完成",
     "progress_timeout": "安装超时，请重试",

--- a/live-2d/webui/test_webui_state_safety.py
+++ b/live-2d/webui/test_webui_state_safety.py
@@ -1,0 +1,554 @@
+import json
+import multiprocessing
+import os
+import sys
+import tempfile
+import threading
+import time
+import unittest
+import urllib.parse
+import zipfile
+from io import BytesIO
+from pathlib import Path
+from unittest import mock
+
+from flask import Flask
+
+
+LIVE2D_ROOT = Path(__file__).resolve().parent.parent
+if str(LIVE2D_ROOT) not in sys.path:
+    sys.path.insert(0, str(LIVE2D_ROOT))
+
+from webui import log_monitor
+from webui import marketplace
+from webui import marketplace_updater
+from webui import plugin_manager
+from webui import service_controller
+from webui import state_io
+from webui import tool_manager
+
+
+def _cross_process_lock_worker(lock_root, state_root, barrier, results):
+    state_io._LOCK_ROOT = Path(lock_root)
+    state_io._STATE_ROOT = Path(state_root)
+    for index in range(10):
+        try:
+            barrier.wait(timeout=10)
+            with state_io.resource_lock(f"initialization-race-{index}"):
+                results.put(("acquired", os.getpid(), index))
+                time.sleep(0.02)
+        except Exception as exc:
+            results.put(("error", type(exc).__name__, str(exc)))
+        finally:
+            try:
+                barrier.wait(timeout=10)
+            except threading.BrokenBarrierError:
+                return
+
+
+def make_app(name, blueprint):
+    app = Flask(name)
+    app.config.update(TESTING=True)
+    app.register_blueprint(blueprint)
+    return app
+
+
+def archive_bytes(files):
+    output = BytesIO()
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, content in files.items():
+            archive.writestr(name, content)
+    return output.getvalue()
+
+
+def run_two_requests(app, path, payloads):
+    barrier = threading.Barrier(3)
+    responses = [None, None]
+    errors = []
+
+    def worker(index):
+        try:
+            barrier.wait(timeout=3)
+            response = app.test_client().post(path, json=payloads[index])
+            responses[index] = (response.status_code, response.get_json())
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=worker, args=(index,))
+        for index in range(2)
+    ]
+    for thread in threads:
+        thread.start()
+    barrier.wait(timeout=3)
+    for thread in threads:
+        thread.join(timeout=5)
+
+    if errors:
+        raise errors[0]
+    if any(thread.is_alive() for thread in threads):
+        raise AssertionError("concurrent request did not finish")
+    return responses
+
+
+class IsolatedStateTestCase(unittest.TestCase):
+    def setUp(self):
+        self.state_temp = tempfile.TemporaryDirectory()
+        root = Path(self.state_temp.name)
+        self.state_patch = mock.patch.multiple(
+            state_io,
+            _LOCK_ROOT=root / "locks",
+            _STATE_ROOT=root / "state",
+        )
+        self.state_patch.start()
+        marketplace.installing_tasks.clear()
+        service_controller.service_processes.clear()
+        service_controller.service_pids.clear()
+
+    def tearDown(self):
+        marketplace.installing_tasks.clear()
+        service_controller.service_processes.clear()
+        service_controller.service_pids.clear()
+        self.state_patch.stop()
+        self.state_temp.cleanup()
+
+
+class StateIoCrossProcessTests(unittest.TestCase):
+    def test_first_lock_file_creation_is_race_safe(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            context = multiprocessing.get_context("spawn")
+            barrier = context.Barrier(2)
+            results = context.Queue()
+            processes = [
+                context.Process(
+                    target=_cross_process_lock_worker,
+                    args=(
+                        str(root / "locks"),
+                        str(root / "state"),
+                        barrier,
+                        results,
+                    ),
+                )
+                for _ in range(2)
+            ]
+            for process in processes:
+                process.start()
+            for process in processes:
+                process.join(timeout=20)
+
+            self.assertTrue(all(not process.is_alive() for process in processes))
+            self.assertEqual([process.exitcode for process in processes], [0, 0])
+            messages = [results.get(timeout=3) for _ in range(20)]
+            self.assertTrue(
+                all(message[0] == "acquired" for message in messages),
+                messages,
+            )
+
+
+class MarketplaceStateSafetyTests(IsolatedStateTestCase):
+    def test_update_preserves_state_and_retains_external_backup(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project_root = Path(tmp) / "live-2d"
+            plugin_dir = (
+                project_root / "plugins" / "community" / "demo"
+            )
+            (plugin_dir / "data").mkdir(parents=True)
+            (plugin_dir / "custom-state").mkdir()
+            (plugin_dir / "metadata.json").write_text(
+                json.dumps({"name": "demo", "version": "1.0.0"}),
+                encoding="utf-8",
+            )
+            (plugin_dir / "plugin_persistence.json").write_text(
+                json.dumps({"paths": ["custom-state"]}),
+                encoding="utf-8",
+            )
+            (plugin_dir / "plugin_config.json").write_text(
+                json.dumps({"token": {"value": "keep"}}),
+                encoding="utf-8",
+            )
+            (plugin_dir / "data" / "state.json").write_text(
+                '{"counter":42}',
+                encoding="utf-8",
+            )
+            (plugin_dir / "custom-state" / "user.json").write_text(
+                '{"name":"local"}',
+                encoding="utf-8",
+            )
+            (plugin_dir / "watch_history.json").write_text(
+                '["episode-1"]',
+                encoding="utf-8",
+            )
+            (plugin_dir / "user-cache.db").write_bytes(b"db-state")
+            (plugin_dir / "old-code.txt").write_text(
+                "stale",
+                encoding="utf-8",
+            )
+
+            new_archive = archive_bytes({
+                "demo-main/metadata.json": json.dumps(
+                    {"name": "demo", "version": "2.0.0"}
+                ),
+                "demo-main/plugin_persistence.json": json.dumps(
+                    {"paths": ["custom-state", "future-state"]}
+                ),
+                "demo-main/index.js": "module.exports = {};",
+            })
+            result = marketplace_updater.update_plugin_safe(
+                plugin_dir,
+                "demo",
+                "https://example.invalid/demo",
+                archive_downloader=lambda _url: new_archive,
+                requirements_installer=lambda _path: None,
+            )
+
+            self.assertEqual(
+                json.loads(
+                    (plugin_dir / "plugin_config.json").read_text(
+                        encoding="utf-8"
+                    )
+                ),
+                {"token": {"value": "keep"}},
+            )
+            self.assertEqual(
+                (plugin_dir / "data" / "state.json").read_text(
+                    encoding="utf-8"
+                ),
+                '{"counter":42}',
+            )
+            self.assertTrue(
+                (plugin_dir / "custom-state" / "user.json").is_file()
+            )
+            self.assertTrue((plugin_dir / "watch_history.json").is_file())
+            self.assertEqual(
+                (plugin_dir / "user-cache.db").read_bytes(),
+                b"db-state",
+            )
+            self.assertFalse((plugin_dir / "old-code.txt").exists())
+            self.assertTrue((plugin_dir / "index.js").is_file())
+            self.assertEqual(
+                json.loads(
+                    (plugin_dir / "plugin_persistence.json").read_text(
+                        encoding="utf-8"
+                    )
+                )["paths"],
+                ["custom-state", "future-state"],
+            )
+
+            backup_path = Path(result["backup_path"])
+            self.assertTrue(backup_path.is_dir())
+            self.assertIn(".plugin-update-backups", backup_path.parts)
+            self.assertNotEqual(backup_path.parent, plugin_dir.parent)
+
+            latest_backup = backup_path
+            for _ in range(3):
+                result = marketplace_updater.update_plugin_safe(
+                    plugin_dir,
+                    "demo",
+                    "https://example.invalid/demo",
+                    archive_downloader=lambda _url: new_archive,
+                    requirements_installer=lambda _path: None,
+                )
+                latest_backup = Path(result["backup_path"])
+
+            retained = list(latest_backup.parent.glob("backup-*"))
+            self.assertEqual(len(retained), 3)
+            self.assertTrue(latest_backup.is_dir())
+
+    def test_duplicate_install_is_reserved_before_worker_start(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "live-2d"
+            (root / "plugins" / "community").mkdir(parents=True)
+            deferred = []
+
+            class DeferredThread:
+                def __init__(self, target, args, daemon=True, **_kwargs):
+                    self.target = target
+                    self.args = args
+                    self.daemon = daemon
+
+                def start(self):
+                    deferred.append(self.args)
+
+            app = make_app("install-admission", marketplace.market_bp)
+            with mock.patch.object(marketplace, "PROJECT_ROOT", root), \
+                    mock.patch.object(
+                        marketplace.threading,
+                        "Thread",
+                        DeferredThread,
+                    ):
+                client = app.test_client()
+                payload = {
+                    "plugin_name": "demo",
+                    "repo": "https://example.invalid/demo",
+                }
+                first = client.post(
+                    "/api/market/plugins/download",
+                    json=payload,
+                )
+                second = client.post(
+                    "/api/market/plugins/download",
+                    json=payload,
+                )
+                task = marketplace._get_install_task("demo")
+
+            self.assertEqual(first.status_code, 200)
+            self.assertEqual(second.status_code, 409)
+            self.assertEqual(len(deferred), 1)
+            self.assertEqual(task["status"], "queued")
+
+    def test_install_failure_remains_queryable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "live-2d"
+            plugin_dir = root / "plugins" / "community" / "demo"
+            plugin_dir.parent.mkdir(parents=True)
+            app = make_app("install-failure", marketplace.market_bp)
+
+            def fail_install(*_args, **_kwargs):
+                raise RuntimeError("synthetic install failure")
+
+            with mock.patch.object(marketplace, "PROJECT_ROOT", root), \
+                    mock.patch.object(
+                        marketplace,
+                        "install_plugin_from_archive",
+                        fail_install,
+                    ):
+                marketplace._install_plugin_worker(
+                    "demo",
+                    "https://example.invalid/demo",
+                    plugin_dir,
+                )
+                response = app.test_client().get(
+                    "/api/market/plugins/install-status/demo"
+                )
+
+            payload = response.get_json()
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(payload["status"], "failed")
+            self.assertTrue(payload["terminal"])
+            self.assertEqual(
+                payload["error"],
+                "synthetic install failure",
+            )
+
+            source = (
+                LIVE2D_ROOT / "webui" / "static" / "js" / "app.js"
+            ).read_text(encoding="utf-8")
+            start = source.index("async function pollPluginInstalled")
+            end = source.index("\nasync function", start + 1)
+            polling_source = source[start:end]
+            self.assertIn(
+                "/api/market/plugins/install-status/",
+                polling_source,
+            )
+            self.assertNotIn(
+                "/api/market/plugins/check-installed/",
+                polling_source,
+            )
+            self.assertIn("data.status === 'failed'", polling_source)
+
+
+class ConcurrentJsonSafetyTests(IsolatedStateTestCase):
+    def test_non_conflicting_concurrent_updates_are_preserved(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "live-2d"
+            for name in ("alpha", "beta"):
+                (root / "plugins" / "built-in" / name).mkdir(parents=True)
+            enabled_path = root / "plugins" / "enabled_plugins.json"
+            enabled_path.write_text('{"plugins":[]}', encoding="utf-8")
+            app = make_app("plugin-toggle", plugin_manager.plugin_bp)
+
+            with mock.patch.object(plugin_manager, "PROJECT_ROOT", root):
+                responses = run_two_requests(
+                    app,
+                    "/api/plugins/toggle",
+                    [
+                        {"plugin_path": "built-in/alpha"},
+                        {"plugin_path": "built-in/beta"},
+                    ],
+                )
+
+            self.assertTrue(all(status == 200 for status, _ in responses))
+            self.assertEqual(
+                set(json.loads(enabled_path.read_text())["plugins"]),
+                {"built-in/alpha", "built-in/beta"},
+            )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "live-2d"
+            config_path = root / "mcp" / "mcp_config.json"
+            config_path.parent.mkdir(parents=True)
+            config_path.write_text(
+                json.dumps({
+                    "alpha": {"command": "node"},
+                    "beta": {"command": "node"},
+                }),
+                encoding="utf-8",
+            )
+            app = make_app("mcp-toggle", tool_manager.tool_bp)
+
+            with mock.patch.object(tool_manager, "PROJECT_ROOT", root):
+                responses = run_two_requests(
+                    app,
+                    "/api/tools/toggle",
+                    [
+                        {
+                            "name": "alpha",
+                            "type": "mcp",
+                            "is_external": True,
+                        },
+                        {
+                            "name": "beta",
+                            "type": "mcp",
+                            "is_external": True,
+                        },
+                    ],
+                )
+
+            self.assertTrue(all(status == 200 for status, _ in responses))
+            self.assertEqual(
+                set(json.loads(config_path.read_text()).keys()),
+                {"alpha_disabled", "beta_disabled"},
+            )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "live-2d"
+            plugin_dir = root / "plugins" / "community" / "demo"
+            plugin_dir.mkdir(parents=True)
+            (plugin_dir / "metadata.json").write_text(
+                json.dumps({"name": "Demo", "displayName": "Demo"}),
+                encoding="utf-8",
+            )
+            config_path = plugin_dir / "plugin_config.json"
+            config_path.write_text(
+                json.dumps({
+                    "alpha": {"type": "string", "value": "base-a"},
+                    "beta": {"type": "string", "value": "base-b"},
+                }),
+                encoding="utf-8",
+            )
+            app = make_app("plugin-config", plugin_manager.plugin_bp)
+
+            with mock.patch.object(plugin_manager, "PROJECT_ROOT", root):
+                responses = run_two_requests(
+                    app,
+                    "/api/plugins/Demo/config",
+                    [{"alpha": "new-a"}, {"beta": "new-b"}],
+                )
+
+            self.assertTrue(all(status == 200 for status, _ in responses))
+            saved = json.loads(config_path.read_text())
+            self.assertEqual(saved["alpha"]["value"], "new-a")
+            self.assertEqual(saved["beta"]["value"], "new-b")
+
+
+class IncrementalLogTests(IsolatedStateTestCase):
+    def test_runtime_endpoint_returns_only_appended_lines(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "live-2d"
+            root.mkdir()
+            log_path = root / "runtime.log"
+            with log_path.open("w", encoding="utf-8") as stream:
+                for index in range(5000):
+                    prefix = "[TOOL] " if index % 2 else ""
+                    stream.write(f"{prefix}line-{index}\n")
+
+            app = make_app("runtime-logs", log_monitor.log_bp)
+            with mock.patch.object(log_monitor, "PROJECT_ROOT", root):
+                client = app.test_client()
+                initial = client.get("/api/logs/runtime")
+                initial_payload = initial.get_json()
+                with log_path.open("a", encoding="utf-8") as stream:
+                    stream.write("appended pet\n")
+                    stream.write("[TOOL] appended tool\n")
+                query = urllib.parse.urlencode({
+                    "offset": initial_payload["offset"],
+                    "cursor": initial_payload["cursor"],
+                })
+                incremental = client.get(f"/api/logs/runtime?{query}")
+
+            payload = incremental.get_json()
+            self.assertEqual(initial.status_code, 200)
+            self.assertLessEqual(
+                len(initial_payload["logs"]["pet"])
+                + len(initial_payload["logs"]["tool"]),
+                log_monitor.RUNTIME_INITIAL_LINES,
+            )
+            self.assertFalse(payload["reset"])
+            self.assertEqual(payload["logs"]["pet"], ["appended pet"])
+            self.assertEqual(
+                payload["logs"]["tool"],
+                ["[TOOL] appended tool"],
+            )
+
+            source = (
+                LIVE2D_ROOT / "webui" / "static" / "js" / "app.js"
+            ).read_text(encoding="utf-8")
+            self.assertIn("/api/logs/runtime", source)
+            self.assertIn("const LOG_POLL_INTERVAL_MS = 1000", source)
+            self.assertIn("document.hidden", source)
+            self.assertNotIn("loadLogs('pet')", source)
+            self.assertNotIn("loadLogs('tool')", source)
+
+
+class SharedServiceOwnershipTests(IsolatedStateTestCase):
+    def test_second_webui_observes_shared_owner(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "live-2d"
+            root.mkdir()
+            (root / "go.bat").write_text("@echo off\n", encoding="utf-8")
+            app_one = make_app("service-one", service_controller.service_bp)
+            app_two = make_app("service-two", service_controller.service_bp)
+            launches = []
+
+            class FakeProcess:
+                pid = 4242
+
+                def poll(self):
+                    return None
+
+                def terminate(self):
+                    return None
+
+            def fake_popen(*args, **kwargs):
+                launches.append((args, kwargs))
+                return FakeProcess()
+
+            with mock.patch.object(
+                service_controller,
+                "PROJECT_ROOT",
+                root,
+            ), mock.patch.object(
+                service_controller.subprocess,
+                "Popen",
+                side_effect=fake_popen,
+            ), mock.patch.object(
+                service_controller.time,
+                "sleep",
+                return_value=None,
+            ), mock.patch.object(
+                service_controller,
+                "_pid_is_running",
+                side_effect=lambda pid: int(pid) == 4242,
+            ):
+                first = app_one.test_client().post("/api/start/live2d")
+                service_controller.service_processes.clear()
+                service_controller.service_pids.clear()
+                second = app_two.test_client().post("/api/start/live2d")
+                status = app_two.test_client().get("/api/status")
+
+            self.assertTrue(first.get_json()["success"])
+            self.assertFalse(second.get_json()["success"])
+            self.assertTrue(second.get_json()["already_running"])
+            self.assertEqual(second.get_json()["pid"], 4242)
+            self.assertEqual(len(launches), 1)
+            self.assertEqual(status.get_json()["live2d"], "running")
+
+            source = (
+                LIVE2D_ROOT / "webui" / "static" / "js" / "app.js"
+            ).read_text(encoding="utf-8")
+            self.assertIn("result.already_running", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/live-2d/webui/tool_manager.py
+++ b/live-2d/webui/tool_manager.py
@@ -3,10 +3,12 @@
 """
 import json
 import logging
+import os
 import sys
 from pathlib import Path
 
 from flask import Blueprint, request, jsonify
+from .state_io import atomic_write_json, resource_lock
 
 # 设置项目根目录
 PROJECT_ROOT = Path(__file__).parent.parent.absolute()
@@ -112,9 +114,6 @@ def get_external_mcp_tools():
         logger.error(f'读取外部 MCP 工具失败：{e}')
         return tools
 
-
-import os
-
 @tool_bp.route('/api/tools/list')
 def list_tools():
     """列出可用工具（已废弃，保留用于兼容）"""
@@ -189,27 +188,26 @@ def toggle_tool():
             if not mcp_config_path.exists():
                 return jsonify({'success': False, 'error': 'MCP 配置文件不存在'}), 404
 
-            with open(mcp_config_path, 'r', encoding='utf-8') as f:
-                mcp_config = json.load(f)
+            with resource_lock(mcp_config_path):
+                with open(mcp_config_path, 'r', encoding='utf-8') as f:
+                    mcp_config = json.load(f)
 
-            # 查找实际名称对应的配置键（可能是 name 或 name_disabled）
-            disabled_key = tool_name + '_disabled'
-            is_disabled = disabled_key in mcp_config
-            config_key = disabled_key if is_disabled else tool_name
+                # 查找实际名称对应的配置键（可能是 name 或 name_disabled）
+                disabled_key = tool_name + '_disabled'
+                is_disabled = disabled_key in mcp_config
 
-            if is_disabled:
-                # 当前是禁用状态，启用它
-                tool_config = mcp_config.pop(disabled_key)
-                mcp_config[tool_name] = tool_config
-                action = 'enabled'
-            else:
-                # 当前是启用状态，禁用它
-                tool_config = mcp_config.pop(tool_name)
-                mcp_config[disabled_key] = tool_config
-                action = 'disabled'
+                if is_disabled:
+                    # 当前是禁用状态，启用它
+                    tool_config = mcp_config.pop(disabled_key)
+                    mcp_config[tool_name] = tool_config
+                    action = 'enabled'
+                else:
+                    # 当前是启用状态，禁用它
+                    tool_config = mcp_config.pop(tool_name)
+                    mcp_config[disabled_key] = tool_config
+                    action = 'disabled'
 
-            with open(mcp_config_path, 'w', encoding='utf-8') as f:
-                json.dump(mcp_config, f, indent=2, ensure_ascii=False)
+                atomic_write_json(mcp_config_path, mcp_config)
 
             return jsonify({
                 'success': True,


### PR DESCRIPTION
## Summary

- make plugin updates transactional, preserve declared/common state, and keep bounded backups outside plugin discovery
- reserve install/update tasks across processes and retain terminal failures for 10 minutes
- protect plugin, MCP, and config JSON state with cross-process locks and atomic replacement
- consolidate runtime log reads behind a bounded cursor endpoint with visible-only frontend polling
- coordinate service start/stop through a shared owner PID and cross-process lock
- document persisted plugin state and ignore generated backup directories

## Validation

- WebUI regression suite: 15/15 passed
- Python compilation, JavaScript syntax, locale JSON parsing, and `git diff --check` passed
- real two-process service probe confirmed one launch and one duplicate rejection, with both callers observing the running service