### PR TITLE
fix: sync trimmed messages back into ConversationCore instead of overwriting them

### DIFF
--- a/live-2d/js/ai/conversation/ConversationCore.js
+++ b/live-2d/js/ai/conversation/ConversationCore.js
@@ -71,6 +71,13 @@ class ConversationCore {
     }
 
     /**
+     * 用裁剪后的数组替换消息数组（保持本对象为唯一的消息来源）
+     */
+    setMessages(messages) {
+        this.messages = messages;
+    }
+
+    /**
      * 获取消息数组的副本（用于API调用）
      */
     getMessagesCopy() {

--- a/live-2d/js/ai/conversation/VoiceChatFacade.js
+++ b/live-2d/js/ai/conversation/VoiceChatFacade.js
@@ -188,8 +188,8 @@ class VoiceChatFacade {
 
     trimMessages() {
         this.contextManager.trimMessages();
-        // 同步messages引用
-        this.messages = this.conversationCore.getMessages();
+        // 把裁剪后的数组写回 conversationCore，而不是反过来用它覆盖裁剪结果
+        this.conversationCore.setMessages(this.messages);
     }
 
     saveConversationHistory() {


### PR DESCRIPTION
`VoiceChatFacade.trimMessages()` calls `ContextManager.trimMessages()`, which correctly
trims the facade's own `messages` array, then immediately runs
`this.messages = this.conversationCore.getMessages();`. `ConversationCore` keeps its own
separate `messages` array and had no way to receive the trimmed result, so that line always
pulled the untrimmed array back over the just-trimmed one. The context-limit setting
therefore had no lasting effect, matching the report.

Fix: `ConversationCore` gets a `setMessages()` method, and `trimMessages()` writes the
trimmed array back into it instead of overwriting the trim with the stale copy.

Verification:
- Instantiated the real `VoiceChatFacade` (mocking only `electron`'s `ipcRenderer`, since
  this file has no other way to load outside Electron) and called its unmodified
  `trimMessages()` directly: on `main` the message count after trim was 6 (unchanged from
  before the trim), on this branch it drops to 3 as configured, and `conversationCore`'s own
  array matches.
- This repo has no JS test runner or existing `.test.js` files to extend, so the check above
  is a standalone Docker script rather than a committed test; happy to add one in whatever
  shape you prefer if you'd like it checked in.
- `node --check` on both changed files.

Fixes #74
