### PR TITLE
修复 Star History 图表（改用 star-history.dera.page）

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ my-neuro的目标是打造专属个人的 AI 角色,打造出逼近真人的AI�
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=morettt/my-neuro&type=Date&t=20251015)](https://www.star-history.com/#morettt/my-neuro&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=morettt/my-neuro&type=Date&t=20251015)](https://star-history.dera.page/#morettt/my-neuro&Date)
 
 ## 致谢
 

--- a/README_English.md
+++ b/README_English.md
@@ -99,7 +99,7 @@ My goal is to have all of the above ideas realized by the end of this year.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=morettt/my-neuro&type=Date&t=20251015)](https://www.star-history.com/#morettt/my-neuro&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=morettt/my-neuro&type=Date&t=20251015)](https://star-history.dera.page/#morettt/my-neuro&Date)
 
 ---
 


### PR DESCRIPTION
当前 README 中的 Star History 图表已损坏，无法正常显示。原因是 GitHub stargazer API 的限制，旧服务（api.star-history.com）已不可用。

本次修改将 README.md 和 README_English.md 中的 Star History 图表切换到 star-history.dera.page（一个无需 API token 的替代数据源），让图表恢复正常显示。