### PR TITLE
feat: migrate unified Live2D and VRM runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ live-2d/plugins/**/.runtime/
 live-2d/plugins/.stats_client_id
 live-2d/plugins/community/agent-dream/dream_logs/
 live-2d/plugins/community/agent-dream/dream_state.json
+
+# Avatar runtime preferences generated on the local machine
+live-2d/model-preferences.json

--- a/live-2d/app.js
+++ b/live-2d/app.js
@@ -1,7 +1,7 @@
 // 导入所需模块
 // 跨屏桥接：注入 window.electronScreen（必须在任何模型交互逻辑之前加载）
 require('./js/services/electron-screen-bridge.js');
-const { ModelInteractionController } = require('./js/model/model-interaction.js');
+const { Live2DInteractionController: ModelInteractionController } = require('./js/avatar/live2d/interaction.js');
 const { configLoader } = require('./js/core/config-loader.js');
 const { logToTerminal } = require('./js/api-utils.js');
 const { AppInitializer } = require('./js/app-initializer.js');

--- a/live-2d/css/styles.css
+++ b/live-2d/css/styles.css
@@ -7,12 +7,22 @@ body {
     -webkit-user-select: none;
 }
 
-#canvas {
+.avatar-container {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.avatar-container canvas {
     position: fixed;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
+}
+
+#canvas {
     image-rendering: auto; 
     image-rendering: crisp-edges;
     image-rendering: pixelated;

--- a/live-2d/index.html
+++ b/live-2d/index.html
@@ -16,7 +16,12 @@
 </head>
 
 <body>
-    <canvas id="canvas"></canvas>
+    <div id="live2d-container" class="avatar-container">
+        <canvas id="canvas"></canvas>
+    </div>
+    <div id="vrm-container" class="avatar-container" style="display: none;">
+        <canvas id="vrm-canvas"></canvas>
+    </div>
     <div id="subtitle-container">
         <div id="subtitle-confirm-btn">确定</div>
         <p id="subtitle-text"></p>
@@ -64,7 +69,7 @@
         <div id="quick-gear" title="快捷功能">⚙</div>
     </div>
 
-    <!-- 引入 Live2D 依赖 -->
+    <!-- 上游 PIXI 6 + pixi-live2d-display 运行时 -->
     <script src="libs/live2d.min.js"></script>
     <script src="libs/live2dcubismcore.min.js"></script>
     <script src="libs/pixi.min.js"></script>

--- a/live-2d/js/app-initializer.js
+++ b/live-2d/js/app-initializer.js
@@ -3,8 +3,8 @@ const { MCPManager } = require('./ai/mcp-manager.js');
 const { VoiceChatFacade } = require('./ai/conversation/VoiceChatFacade.js');
 const { UIController } = require('./ui/ui-controller.js');
 const { TTSFactory } = require('./voice/tts-factory.js');
-const { ModelSetup } = require('./model/model-setup.js');
-const { VRMModelSetup } = require('./model/vrm-model-setup.js');
+const { avatarFacade } = require('./avatar/avatar-facade.js');
+const { registerBuiltinDrivers } = require('./avatar/drivers.js');
 const { BarrageManager } = require('./live/barrage-manager.js');
 // LiveStreamModule → plugins/built-in/bilibili-live
 // AutoChatModule   → plugins/built-in/auto-chat
@@ -235,52 +235,28 @@ class AppInitializer {
         }
     }
 
-    // 第五阶段: 加载模型（Live2D或VRM）
+    // 第五阶段: 通过统一 Avatar facade 加载皮套
     async initializeModel() {
         const modelType = this.config.ui?.model_type || 'live2d';
         console.log(`模型类型: ${modelType}`);
 
-        let result;
-        if (modelType === 'vrm') {
-            // 使用VRM模型
-            logToTerminal('info', '正在加载VRM 3D模型...');
-            result = await VRMModelSetup.initialize(
-                this.modelController,
-                this.config,
-                this.ttsEnabled,
-                this.asrEnabled,
-                this.ttsProcessor,
-                this.voiceChat
-            );
-        } else {
-            // 默认使用Live2D模型
-            result = await ModelSetup.initialize(
-                this.modelController,
-                this.config,
-                this.ttsEnabled,
-                this.asrEnabled,
-                this.ttsProcessor,
-                this.voiceChat
-            );
-        }
+        registerBuiltinDrivers();
+        const result = await avatarFacade.init(modelType, {
+            modelController: this.modelController,
+            config: this.config,
+            ttsEnabled: this.ttsEnabled,
+            asrEnabled: this.asrEnabled,
+            ttsProcessor: this.ttsProcessor,
+            voiceChat: this.voiceChat
+        });
 
         this.model = result.model;
         this.emotionMapper = result.emotionMapper;
         this.musicPlayer = result.musicPlayer;
 
-        // VRM模式：替换modelController并更新TTS唇形回调
-        if (result.vrmController) {
-            this.modelController = result.vrmController;
-            global.modelController = result.vrmController;
-            if (this.ttsProcessor?.playbackEngine) {
-                this.ttsProcessor.playbackEngine.onAudioDataCallback =
-                    (value) => result.vrmController.setMouthOpenY(value);
-            }
-        } else {
-            global.modelController = this.modelController;
-        }
-
-        global.currentModel = this.model;
+        this.modelController = avatarFacade.getController() || this.modelController;
+        global.modelController = this.modelController;
+        global.currentModel = avatarFacade.getModel() || this.model;
         global.pixiApp = result.app;
     }
 

--- a/live-2d/js/avatar/avatar-facade.js
+++ b/live-2d/js/avatar/avatar-facade.js
@@ -1,0 +1,486 @@
+// avatar-facade.js - 四形态皮套统一门面（driver 分发表）
+// 参考 N.E.K.O live2d-init.js 的 LanLan1 门面 + _getActiveModelType 分发模式：
+//   每种形态注册一个 driver：{ init, dispose, setEmotion, setMouth, playMotion, getModel, getController }
+//   门面按 config.ui.model_type 分发；未实现的方法允许 no-op；
+//   形态切换 = dispose 当前 driver -> init 新 driver（dispose 不支持时降级整窗 reload）。
+// AI/TTS/插件层只跟门面（或 global 兼容别名）交互，对具体渲染栈无感知。
+const { ipcRenderer } = require('electron');
+const { logToTerminal } = require('../api-utils.js');
+
+const AVATAR_TYPES = ['live2d', 'vrm', 'mmd', 'pngtuber'];
+const IPC_RESULT_PHASES = new Set([
+    'ready',
+    'busy',
+    'failed',
+    'rolled-back',
+    'reload-required',
+    'reload-scheduled'
+]);
+const CONTAINER_IDS = {
+    live2d: 'live2d-container',
+    vrm: 'vrm-container',
+    mmd: 'mmd-container',
+    pngtuber: 'pngtuber-container'
+};
+
+function normalizeType(type) {
+    const t = String(type || 'live2d').toLowerCase();
+    return AVATAR_TYPES.includes(t) ? t : 'live2d';
+}
+
+function summarizeIPCResult(result) {
+    const summary = {
+        success: result?.success === true,
+        message: typeof result?.message === 'string'
+            ? result.message
+            : (result?.success === true ? '操作成功' : '操作失败')
+    };
+    if (Object.prototype.hasOwnProperty.call(result || {}, 'restored')) {
+        summary.restored = result.restored === true;
+    }
+    if (Object.prototype.hasOwnProperty.call(result || {}, 'reloadRequired')) {
+        summary.reloadRequired = result.reloadRequired === true;
+    }
+    if (IPC_RESULT_PHASES.has(result?.phase)) {
+        summary.phase = result.phase;
+    }
+    if (AVATAR_TYPES.includes(result?.targetType)) {
+        summary.targetType = result.targetType;
+    }
+    if (AVATAR_TYPES.includes(result?.activeType)) {
+        summary.activeType = result.activeType;
+    } else if (Object.prototype.hasOwnProperty.call(result || {}, 'activeType')) {
+        summary.activeType = null;
+    }
+    return summary;
+}
+
+async function reportIPCResult(channel, requestId, result) {
+    if (!requestId) return;
+    const summary = summarizeIPCResult(result);
+    try {
+        await ipcRenderer.invoke(channel, { requestId, ...summary });
+    } catch (error) {
+        console.warn(`[AvatarFacade] 上报 ${channel} 失败:`, error);
+    }
+}
+
+async function reportAvatarRuntimeReady(result) {
+    const summary = summarizeIPCResult(result);
+    try {
+        await ipcRenderer.invoke('avatar-runtime-ready', summary);
+    } catch (error) {
+        console.warn('[AvatarFacade] 上报运行时 ready 失败:', error);
+    }
+}
+
+class AvatarFacade {
+    constructor() {
+        this._drivers = {};        // type -> driver 工厂产物
+        this._activeType = null;
+        this._activeDriver = null;
+        this._context = null;      // { modelController, config, ttsEnabled, asrEnabled, ttsProcessor, voiceChat }
+        this._switching = false;
+        this._ipcBound = false;
+        this._webglEnginesUsed = new Set();  // 本页已创建过上下文的 WebGL 引擎（pixi/three）
+    }
+
+    /** 注册形态 driver（factory: (facade) => driver 对象） */
+    register(type, driver) {
+        this._drivers[normalizeType(type)] = driver;
+    }
+
+    getActiveType() {
+        return this._activeType;
+    }
+
+    getModel() {
+        return this._activeDriver?.getModel?.() || null;
+    }
+
+    getController() {
+        return this._activeDriver?.getController?.() || null;
+    }
+
+    getActiveCanvas() {
+        const containerId = CONTAINER_IDS[this._activeType] || 'live2d-container';
+        return document.querySelector(`#${containerId} canvas`);
+    }
+
+    /** 初始化指定形态（app-initializer 启动时调用一次） */
+    async init(type, context) {
+        this._context = context;
+        const t = normalizeType(type);
+        const driver = this._drivers[t];
+        if (!driver) {
+            const error = new Error(`形态 "${t}" 的 driver 未注册（该形态尚未移植完成）`);
+            await reportAvatarRuntimeReady({
+                success: false,
+                phase: 'failed',
+                targetType: t,
+                activeType: null,
+                message: error.message
+            });
+            throw error;
+        }
+
+        try {
+            this._showContainer(t);
+            const result = await driver.init(context);
+            this._activeType = t;
+            this._activeDriver = driver;
+            if (['pixi', 'three', 'three-mmd'].includes(driver.engine)) {
+                this._webglEnginesUsed.add(driver.engine);
+            }
+
+            this._wireMouthSink();
+            this._bindIPC();
+            logToTerminal('info', `[AvatarFacade] 形态已激活: ${t}`);
+            await reportAvatarRuntimeReady({
+                success: true,
+                phase: 'ready',
+                targetType: t,
+                activeType: t,
+                message: `${t} 形态已就绪`
+            });
+            return result;
+        } catch (error) {
+            this._activeType = null;
+            this._activeDriver = null;
+            await reportAvatarRuntimeReady({
+                success: false,
+                phase: 'failed',
+                targetType: t,
+                activeType: null,
+                message: `初始化 ${t} 失败: ${error.message}`
+            });
+            throw error;
+        }
+    }
+
+    /** 形态切换（写配置由主进程完成，这里只做渲染侧交接） */
+    async switchType(nextType) {
+        const t = normalizeType(nextType);
+        if (this._switching) {
+            return {
+                success: false,
+                phase: 'busy',
+                targetType: t,
+                activeType: this._activeType,
+                message: '形态切换进行中'
+            };
+        }
+        if (t === this._activeType) {
+            return {
+                success: true,
+                phase: 'ready',
+                targetType: t,
+                activeType: t,
+                reloadRequired: false,
+                message: `已是 ${t} 形态`
+            };
+        }
+        const nextDriver = this._drivers[t];
+        if (!nextDriver) {
+            return {
+                success: false,
+                phase: 'failed',
+                targetType: t,
+                activeType: this._activeType,
+                message: `形态 "${t}" 尚未移植`
+            };
+        }
+
+        // 跨 WebGL 引擎切换（PIXI <-> Three）必须整窗 reload：
+        // 透明桌宠窗口中在已有 WebGL 上下文的渲染进程里再创建另一引擎的上下文，
+        // 会在 ANGLE/D3D11 原生层死锁冻结主线程（实测，Debugger 都无法中断）。
+        // 判定基于"本页已创建过的引擎集合"（覆盖经由 pngtuber 的间接路径），
+        // config.ui.model_type 由主进程先持久化；这里只报告需要 reload，
+        // reload 的调度与启动确认也全部由主进程负责。
+        const WEBGL_ENGINES = ['pixi', 'three', 'three-mmd'];
+        const nextEngine = nextDriver.engine || 'none';
+        if (WEBGL_ENGINES.includes(nextEngine)) {
+            const conflicting = [...this._webglEnginesUsed].some(e => e !== nextEngine);
+            if (conflicting) {
+                logToTerminal('info', `[AvatarFacade] 页内已存在其他 WebGL 引擎(${[...this._webglEnginesUsed].join(',')})，切换 ${t} 需要窗口重载`);
+                return {
+                    success: true,
+                    phase: 'reload-required',
+                    targetType: t,
+                    activeType: this._activeType,
+                    reloadRequired: true,
+                    message: `切换到 ${t} 需要重载（跨渲染引擎）`
+                };
+            }
+        }
+
+        this._switching = true;
+        const previousType = this._activeType;
+        const previousDriver = this._activeDriver;
+        const previousConfigType = this._context?.config?.ui?.model_type;
+        try {
+            // 1. dispose 当前形态
+            if (previousDriver) {
+                if (typeof previousDriver.dispose === 'function') {
+                    await previousDriver.dispose();
+                } else {
+                    logToTerminal('warn', `[AvatarFacade] ${previousType} driver 无 dispose，需要窗口重载`);
+                    return {
+                        success: true,
+                        phase: 'reload-required',
+                        targetType: t,
+                        activeType: previousType,
+                        reloadRequired: true,
+                        message: `${previousType} 不支持热释放，需要重载以切换到 ${t}`
+                    };
+                }
+            }
+            this._activeDriver = null;
+            this._activeType = null;
+
+            // 2. 初始化新形态。只有成功后才更新共享配置，避免失败时
+            // 把 renderer 留在一个没有可用 Avatar 的目标状态。
+            this._showContainer(t);
+            const result = await nextDriver.init(this._context);
+            this._activeType = t;
+            this._activeDriver = nextDriver;
+            if (this._context?.config?.ui) {
+                this._context.config.ui.model_type = t;
+            }
+            if (['pixi', 'three', 'three-mmd'].includes(nextDriver.engine)) {
+                this._webglEnginesUsed.add(nextDriver.engine);
+            }
+            this._wireMouthSink();
+
+            logToTerminal('info', `[AvatarFacade] 形态切换完成: ${previousType} -> ${t}`);
+            return {
+                success: true,
+                phase: 'ready',
+                targetType: t,
+                activeType: t,
+                reloadRequired: false,
+                message: `已切换到 ${t}`,
+                result
+            };
+        } catch (e) {
+            console.error('[AvatarFacade] 形态切换失败:', e);
+            try { await nextDriver.dispose?.(); } catch (_) {}
+
+            this._activeDriver = null;
+            this._activeType = null;
+            if (this._context?.config?.ui && previousConfigType !== undefined) {
+                this._context.config.ui.model_type = previousConfigType;
+            }
+
+            let restored = false;
+            let restoreError = null;
+            if (previousDriver && previousType) {
+                try {
+                    this._showContainer(previousType);
+                    await previousDriver.init(this._context);
+                    this._activeType = previousType;
+                    this._activeDriver = previousDriver;
+                    this._wireMouthSink();
+                    restored = true;
+                    logToTerminal('warn', `[AvatarFacade] 切换失败，已恢复 ${previousType}`);
+                } catch (error) {
+                    restoreError = error;
+                }
+            }
+
+            if (!restored) {
+                logToTerminal('error', `[AvatarFacade] 形态切换失败: ${e.message}，恢复旧形态也失败`);
+            } else {
+                logToTerminal('error', `[AvatarFacade] 形态切换失败: ${e.message}，已恢复旧形态`);
+            }
+            const suffix = restoreError ? `；恢复失败: ${restoreError.message}` : '';
+            return {
+                success: false,
+                phase: restored ? 'rolled-back' : 'reload-required',
+                targetType: t,
+                activeType: restored ? previousType : null,
+                restored,
+                reloadRequired: !restored,
+                message: `切换失败(${e.message})${restored ? '，已恢复原形态' : '，需要主进程重载恢复'}${suffix}`
+            };
+        } finally {
+            this._switching = false;
+        }
+    }
+
+    // ============ 统一能力分发（AI/TTS/插件的稳定入口） ============
+
+    setEmotion(emotion) {
+        try { this._activeDriver?.setEmotion?.(emotion); } catch (_) {}
+    }
+
+    setMouth(value) {
+        try { this._activeDriver?.setMouth?.(value); } catch (_) {}
+    }
+
+    playMotion(indexOrGroup, index) {
+        try { this._activeDriver?.playMotion?.(indexOrGroup, index); } catch (_) {}
+    }
+
+    // ============ 内部 ============
+
+    _showContainer(type) {
+        for (const [t, id] of Object.entries(CONTAINER_IDS)) {
+            const el = document.getElementById(id);
+            if (!el) continue;
+            // vrm/mmd 共用容器：目标形态所在容器显示，其余隐藏
+            el.style.display = (id === CONTAINER_IDS[type]) ? 'block' : 'none';
+        }
+    }
+
+    // TTS 口型回调统一接到门面（形态切换后无需重接 TTS 链路）
+    _wireMouthSink() {
+        const playbackEngine = this._context?.ttsProcessor?.playbackEngine;
+        if (playbackEngine) {
+            playbackEngine.onAudioDataCallback = (value) => this.setMouth(value);
+        }
+    }
+
+    /** 同形态重载（换模型用）：配置与 driver 初始化一起提交，失败时恢复。 */
+    async reloadActiveModel(configPatch = null) {
+        if (this._switching) {
+            return { success: false, message: '形态切换进行中' };
+        }
+        const driver = this._activeDriver;
+        const type = this._activeType;
+        if (!driver || !type) {
+            return { success: false, message: '当前没有激活的形态' };
+        }
+
+        const uiPatch = configPatch && typeof configPatch === 'object'
+            ? configPatch
+            : {};
+        const config = this._context?.config;
+        if (!config) {
+            return { success: false, message: 'Avatar 配置尚未初始化' };
+        }
+        if (!config.ui || typeof config.ui !== 'object') config.ui = {};
+        const previousValues = {};
+        const hadPreviousValue = {};
+        for (const [key, value] of Object.entries(uiPatch)) {
+            hadPreviousValue[key] = Object.prototype.hasOwnProperty.call(config.ui, key);
+            previousValues[key] = config.ui[key];
+            config.ui[key] = value;
+        }
+
+        this._switching = true;
+        try {
+            if (typeof driver.dispose !== 'function') {
+                throw new Error(`${type} driver 不支持重载`);
+            }
+            await driver.dispose();
+            this._activeDriver = null;
+            this._activeType = null;
+            this._showContainer(type);
+            const result = await driver.init(this._context);
+            this._activeDriver = driver;
+            this._activeType = type;
+            this._wireMouthSink();
+            logToTerminal('info', `[AvatarFacade] ${type} 模型已重载`);
+            return { success: true, message: `${type} 模型已重载`, result };
+        } catch (e) {
+            console.error('[AvatarFacade] 模型重载失败:', e);
+            try { await driver.dispose?.(); } catch (_) {}
+
+            for (const key of Object.keys(uiPatch)) {
+                if (hadPreviousValue[key]) config.ui[key] = previousValues[key];
+                else delete config.ui[key];
+            }
+
+            let restored = false;
+            let restoreError = null;
+            try {
+                this._showContainer(type);
+                const restoredResult = await driver.init(this._context);
+                this._activeDriver = driver;
+                this._activeType = type;
+                this._wireMouthSink();
+                restored = true;
+                logToTerminal('warn', `[AvatarFacade] ${type} 重载失败，已恢复原模型`);
+                return {
+                    success: false,
+                    restored: true,
+                    message: `重载失败(${e.message})，已恢复原模型`,
+                    result: restoredResult
+                };
+            } catch (restoreFailure) {
+                restoreError = restoreFailure;
+            }
+
+            this._activeDriver = null;
+            this._activeType = null;
+            logToTerminal('error', `[AvatarFacade] 模型重载失败: ${e.message}，恢复也失败`);
+            const suffix = restoreError ? `；恢复失败: ${restoreError.message}` : '';
+            return {
+                success: false,
+                phase: 'reload-required',
+                targetType: type,
+                activeType: null,
+                restored,
+                reloadRequired: true,
+                message: `重载失败(${e.message})，需要主进程重载恢复${suffix}`
+            };
+        } finally {
+            this._switching = false;
+        }
+    }
+
+    _bindIPC() {
+        if (this._ipcBound) return;
+        this._ipcBound = true;
+        ipcRenderer.on('avatar-switch-type', async (event, payload) => {
+            const requestId = payload?.requestId;
+            let res;
+            try {
+                res = await this.switchType(payload?.type);
+            } catch (error) {
+                res = { success: false, message: `切换异常: ${error.message}` };
+            }
+            const summary = summarizeIPCResult(res);
+            logToTerminal('info', `[AvatarFacade] IPC 切换结果: ${JSON.stringify(summary)}`);
+            await reportIPCResult('avatar-switch-type-result', requestId, res);
+        });
+        ipcRenderer.on('avatar-reload-model', async (event, payload) => {
+            const requestId = payload?.requestId;
+            let res;
+            try {
+                const patch = payload?.configKey
+                    ? { [payload.configKey]: payload.configValue }
+                    : null;
+                res = await this.reloadActiveModel(patch);
+            } catch (error) {
+                res = { success: false, message: `重载异常: ${error.message}` };
+            }
+            logToTerminal('info', `[AvatarFacade] IPC 模型重载结果: ${JSON.stringify(summarizeIPCResult(res))}`);
+            await reportIPCResult('avatar-reload-model-result', requestId, res);
+        });
+        ipcRenderer.on('avatar-config-updated', (_event, payload) => {
+            this._applyConfigPatch(payload);
+        });
+    }
+
+    _applyConfigPatch(payload) {
+        const patch = payload?.ui && typeof payload.ui === 'object'
+            ? payload.ui
+            : payload;
+        if (!patch || typeof patch !== 'object' || !this._context) return;
+        if (!this._context.config || typeof this._context.config !== 'object') {
+            this._context.config = {};
+        }
+        if (!this._context.config.ui || typeof this._context.config.ui !== 'object') {
+            this._context.config.ui = {};
+        }
+        Object.assign(this._context.config.ui, patch);
+    }
+}
+
+const avatarFacade = new AvatarFacade();
+global.avatarFacade = avatarFacade;
+window.avatar = avatarFacade;
+
+module.exports = { avatarFacade, AVATAR_TYPES };

--- a/live-2d/js/avatar/avatar-switch-transaction.js
+++ b/live-2d/js/avatar/avatar-switch-transaction.js
@@ -1,0 +1,386 @@
+'use strict';
+
+const AVATAR_TYPES = new Set(['live2d', 'vrm', 'mmd', 'pngtuber']);
+
+function normalizeAvatarType(value) {
+    const type = String(value || '').trim().toLowerCase();
+    return AVATAR_TYPES.has(type) ? type : null;
+}
+
+function errorMessage(error) {
+    return error instanceof Error ? error.message : String(error);
+}
+
+class AvatarSwitchTransaction {
+    constructor(options = {}) {
+        const required = [
+            'readModelType',
+            'updateModelType',
+            'hasAvatarModel',
+            'requestRendererSwitch',
+            'publishModelType',
+            'scheduleReload'
+        ];
+        for (const name of required) {
+            if (typeof options[name] !== 'function') {
+                throw new Error(`AvatarSwitchTransaction requires ${name}()`);
+            }
+        }
+
+        this.readModelType = options.readModelType;
+        this.updateModelType = options.updateModelType;
+        this.hasAvatarModel = options.hasAvatarModel;
+        this.requestRendererSwitch = options.requestRendererSwitch;
+        this.publishModelType = options.publishModelType;
+        this.scheduleReload = options.scheduleReload;
+        this.log = typeof options.log === 'function' ? options.log : () => {};
+        this.readyTimeoutMs = Number.isFinite(Number(options.readyTimeoutMs))
+            ? Math.max(1000, Number(options.readyTimeoutMs))
+            : 30000;
+        this.setTimer = options.setTimer || setTimeout;
+        this.clearTimer = options.clearTimer || clearTimeout;
+        this._switchingWindows = new Set();
+        this._pendingReloads = new Map();
+    }
+
+    async switchType(targetType, context = {}) {
+        const target = normalizeAvatarType(targetType);
+        const windowId = context.windowId;
+        if (windowId === undefined || windowId === null) {
+            return { success: false, phase: 'failed', message: '缺少切换窗口标识' };
+        }
+        if (!target) {
+            return { success: false, phase: 'failed', message: `未知形态: ${targetType}` };
+        }
+        if (this._switchingWindows.has(windowId) || this._pendingReloads.has(windowId)) {
+            return { success: false, phase: 'busy', targetType: target, message: '形态切换进行中' };
+        }
+
+        this._switchingWindows.add(windowId);
+        try {
+            if (!await this.hasAvatarModel(target, context)) {
+                return {
+                    success: false,
+                    phase: 'failed',
+                    targetType: target,
+                    message: `${target} 形态没有可用模型，未切换`
+                };
+            }
+
+            const previous = normalizeAvatarType(await this.readModelType(context)) || 'live2d';
+            if (previous === target) {
+                return {
+                    success: true,
+                    phase: 'ready',
+                    targetType: target,
+                    activeType: target,
+                    reloadRequired: false,
+                    message: `已是 ${target} 形态`
+                };
+            }
+
+            try {
+                await this.updateModelType(target, context);
+            } catch (error) {
+                return {
+                    success: false,
+                    phase: 'failed',
+                    targetType: target,
+                    activeType: previous,
+                    message: `保存目标形态失败: ${errorMessage(error)}`
+                };
+            }
+
+            let rendererResult;
+            try {
+                rendererResult = await this.requestRendererSwitch(target, context);
+            } catch (error) {
+                const rollback = await this._rollbackModelType(previous, context);
+                return {
+                    success: false,
+                    phase: rollback.success ? 'rolled-back' : 'failed',
+                    targetType: target,
+                    activeType: previous,
+                    restored: rollback.success,
+                    message: rollback.success
+                        ? `通知渲染进程失败，已恢复 ${previous}: ${errorMessage(error)}`
+                        : `通知渲染进程失败，且配置回滚失败: ${rollback.message}`
+                };
+            }
+
+            if (rendererResult?.success === true && rendererResult?.reloadRequired !== true) {
+                await this.publishModelType(target, context);
+                return {
+                    success: true,
+                    phase: 'ready',
+                    targetType: target,
+                    activeType: normalizeAvatarType(rendererResult.activeType) || target,
+                    reloadRequired: false,
+                    message: rendererResult.message || `已切换到 ${target}`
+                };
+            }
+
+            if (rendererResult?.success === true && rendererResult?.reloadRequired === true) {
+                await this.publishModelType(target, context);
+                try {
+                    await this._queueReload({
+                        context,
+                        previousType: previous,
+                        targetType: target,
+                        expectedType: target,
+                        rollbackAttempted: false,
+                        reason: rendererResult.message || '跨渲染引擎切换'
+                    });
+                } catch (error) {
+                    const rollback = await this._rollbackModelType(previous, context);
+                    if (rollback.success) await this.publishModelType(previous, context);
+                    return {
+                        success: false,
+                        phase: rollback.success ? 'rolled-back' : 'failed',
+                        targetType: target,
+                        activeType: previous,
+                        restored: rollback.success,
+                        message: rollback.success
+                            ? `窗口重载安排失败，已恢复 ${previous}: ${errorMessage(error)}`
+                            : `窗口重载安排失败，且配置回滚失败: ${rollback.message}`
+                    };
+                }
+                return {
+                    success: true,
+                    phase: 'reload-scheduled',
+                    targetType: target,
+                    activeType: normalizeAvatarType(rendererResult.activeType) || previous,
+                    reloadRequired: true,
+                    message: rendererResult.message || `已安排重载以切换到 ${target}`
+                };
+            }
+
+            const rollback = await this._rollbackModelType(previous, context);
+            if (!rollback.success) {
+                return {
+                    success: false,
+                    phase: 'failed',
+                    targetType: target,
+                    activeType: normalizeAvatarType(rendererResult?.activeType),
+                    restored: false,
+                    message: `切换失败，且配置回滚失败: ${rollback.message}`
+                };
+            }
+            await this.publishModelType(previous, context);
+
+            const rendererRestored = rendererResult?.restored === true;
+            const rendererUncertain = rendererResult?.reloadRequired === true
+                || rendererResult?.timedOut === true
+                || !rendererRestored;
+            if (rendererUncertain) {
+                try {
+                    await this._queueReload({
+                        context,
+                        previousType: previous,
+                        targetType: target,
+                        expectedType: previous,
+                        rollbackAttempted: true,
+                        reason: rendererResult?.message || '切换失败后恢复旧形态'
+                    });
+                } catch (error) {
+                    return {
+                        success: false,
+                        phase: 'rolled-back',
+                        targetType: target,
+                        activeType: rendererRestored ? previous : null,
+                        restored: rendererRestored,
+                        message: `配置已恢复为 ${previous}，但窗口重载安排失败: ${errorMessage(error)}`
+                    };
+                }
+                return {
+                    success: false,
+                    phase: 'reload-scheduled',
+                    targetType: target,
+                    activeType: rendererRestored ? previous : null,
+                    restored: rendererRestored,
+                    reloadRequired: true,
+                    message: rendererResult?.message || `切换失败，正在重载恢复 ${previous}`
+                };
+            }
+
+            return {
+                success: false,
+                phase: 'rolled-back',
+                targetType: target,
+                activeType: previous,
+                restored: true,
+                reloadRequired: false,
+                message: rendererResult?.message || `切换失败，已恢复 ${previous}`
+            };
+        } finally {
+            this._switchingWindows.delete(windowId);
+        }
+    }
+
+    async handleRuntimeReady(payload = {}) {
+        const windowId = payload.windowId;
+        const activeType = normalizeAvatarType(payload.activeType);
+        const pending = this._pendingReloads.get(windowId);
+
+        if (!pending) {
+            return {
+                success: payload.success === true,
+                phase: payload.success === true ? 'ready' : 'failed',
+                activeType,
+                matchedPending: false,
+                message: payload.message || (payload.success === true ? '运行时已就绪' : '运行时初始化失败')
+            };
+        }
+
+        if (payload.success === true && activeType === pending.expectedType) {
+            this._clearPending(windowId);
+            this.log('info', `Avatar reload ready: ${activeType}`);
+            return {
+                success: true,
+                phase: 'ready',
+                targetType: pending.targetType,
+                activeType,
+                matchedPending: true,
+                message: `${activeType} 形态已就绪`
+            };
+        }
+
+        return this._recoverPendingReload(
+            pending,
+            payload.message || `运行时就绪类型不匹配: expected=${pending.expectedType}, actual=${activeType || 'none'}`
+        );
+    }
+
+    hasPendingReload(windowId) {
+        return this._pendingReloads.has(windowId);
+    }
+
+    clearWindow(windowId) {
+        this._clearPending(windowId);
+        this._switchingWindows.delete(windowId);
+    }
+
+    dispose() {
+        for (const windowId of Array.from(this._pendingReloads.keys())) {
+            this._clearPending(windowId);
+        }
+        this._switchingWindows.clear();
+    }
+
+    async _rollbackModelType(previousType, context) {
+        try {
+            await this.updateModelType(previousType, context);
+            return { success: true };
+        } catch (error) {
+            return { success: false, message: errorMessage(error) };
+        }
+    }
+
+    async _queueReload(pending) {
+        const windowId = pending.context.windowId;
+        this._clearPending(windowId);
+        const entry = { ...pending, timer: null };
+        this._pendingReloads.set(windowId, entry);
+        this._armReadyTimeout(entry);
+        try {
+            await this.scheduleReload({
+                context: entry.context,
+                expectedType: entry.expectedType,
+                targetType: entry.targetType,
+                reason: entry.reason
+            });
+        } catch (error) {
+            this._clearPending(windowId);
+            throw error;
+        }
+    }
+
+    _armReadyTimeout(pending) {
+        if (pending.timer) this.clearTimer(pending.timer);
+        pending.timer = this.setTimer(() => {
+            this._recoverPendingReload(
+                pending,
+                `运行时未在 ${this.readyTimeoutMs}ms 内确认 ready`
+            ).then((result) => {
+                this.log(result.success ? 'info' : 'error', result.message);
+            }).catch((error) => {
+                this.log('error', `Avatar ready 超时恢复失败: ${errorMessage(error)}`);
+            });
+        }, this.readyTimeoutMs);
+        pending.timer?.unref?.();
+    }
+
+    async _recoverPendingReload(pending, reason) {
+        const windowId = pending.context.windowId;
+        if (pending.rollbackAttempted) {
+            this._clearPending(windowId);
+            return {
+                success: false,
+                phase: 'failed',
+                targetType: pending.targetType,
+                activeType: null,
+                restored: false,
+                message: `${reason}；自动恢复已尝试一次，停止继续重载`
+            };
+        }
+
+        const rollback = await this._rollbackModelType(pending.previousType, pending.context);
+        if (!rollback.success) {
+            this._clearPending(windowId);
+            return {
+                success: false,
+                phase: 'failed',
+                targetType: pending.targetType,
+                activeType: null,
+                restored: false,
+                message: `${reason}；配置回滚失败: ${rollback.message}`
+            };
+        }
+        await this.publishModelType(pending.previousType, pending.context);
+
+        pending.expectedType = pending.previousType;
+        pending.rollbackAttempted = true;
+        pending.reason = reason;
+        this._armReadyTimeout(pending);
+        try {
+            await this.scheduleReload({
+                context: pending.context,
+                expectedType: pending.previousType,
+                targetType: pending.targetType,
+                reason
+            });
+        } catch (error) {
+            this._clearPending(windowId);
+            return {
+                success: false,
+                phase: 'rolled-back',
+                targetType: pending.targetType,
+                activeType: null,
+                restored: false,
+                message: `${reason}；配置已回滚，但恢复重载安排失败: ${errorMessage(error)}`
+            };
+        }
+
+        return {
+            success: false,
+            phase: 'rollback-reload-scheduled',
+            targetType: pending.targetType,
+            activeType: null,
+            restored: false,
+            reloadRequired: true,
+            message: `${reason}；已回滚配置并安排恢复重载`
+        };
+    }
+
+    _clearPending(windowId) {
+        const pending = this._pendingReloads.get(windowId);
+        if (pending?.timer) this.clearTimer(pending.timer);
+        this._pendingReloads.delete(windowId);
+    }
+}
+
+module.exports = {
+    AVATAR_TYPES,
+    AvatarSwitchTransaction,
+    normalizeAvatarType
+};

--- a/live-2d/js/avatar/avatar-voice-chat-binding.js
+++ b/live-2d/js/avatar/avatar-voice-chat-binding.js
@@ -1,0 +1,24 @@
+'use strict';
+
+function requireMethod(target, methodName) {
+    if (typeof target?.[methodName] !== 'function') {
+        throw new TypeError(`VoiceChat interface is missing ${methodName}()`);
+    }
+}
+
+function bindVoiceChatAvatar(voiceChat, model, emotionMapper) {
+    if (voiceChat == null) {
+        return { bound: false, reason: 'voice-chat-unavailable' };
+    }
+
+    requireMethod(voiceChat, 'setModel');
+    requireMethod(voiceChat, 'setEmotionMapper');
+
+    voiceChat.setModel(model);
+    voiceChat.setEmotionMapper(emotionMapper);
+
+    requireMethod(voiceChat, 'setEmotionMapper');
+    return { bound: true };
+}
+
+module.exports = { bindVoiceChatAvatar };

--- a/live-2d/js/avatar/drivers.js
+++ b/live-2d/js/avatar/drivers.js
@@ -1,0 +1,115 @@
+// drivers.js - 当前 PR 中可用的 Avatar driver 注册。
+const { avatarFacade } = require('./avatar-facade.js');
+const { logToTerminal } = require('../api-utils.js');
+
+// ============ Live2D driver（v2 渲染栈） ============
+function createLive2DDriver() {
+    let state = null; // { app, model, emotionMapper, expressionMapper, musicPlayer, stage, loader, controller }
+
+    return {
+        engine: 'pixi',
+        async init(context) {
+            const { Live2DSetup } = require('./live2d/setup.js');
+            const result = await Live2DSetup.initialize(
+                context.modelController,
+                context.config,
+                context.ttsEnabled,
+                context.asrEnabled,
+                context.ttsProcessor,
+                context.voiceChat
+            );
+            state = { ...result, controller: context.modelController };
+            global.pixiApp = result.app;
+            global.modelController = context.modelController;
+            global.live2dStage = result.stage;
+            global.live2dLoader = result.loader;
+            return result;
+        },
+
+        async dispose() {
+            if (!state) return;
+            const { Live2DSetup } = require('./live2d/setup.js');
+            try { state.controller?.destroy?.(); } catch (_) {}
+            await Live2DSetup.suspend();
+            global.pixiApp = null;
+            global.currentModel = null;
+            state = null;
+            logToTerminal('info', '[Live2DDriver] 已挂起（上下文保留）');
+        },
+
+        getModel() { return state?.loader?.currentModel || null; },
+        getController() { return state?.controller || null; },
+
+        setEmotion(emotion) {
+            global.emotionMapper?.playConfiguredEmotion?.(emotion);
+            global.expressionMapper?.triggerExpressionByEmotion?.(emotion);
+        },
+        setMouth(value) {
+            state?.controller?.setMouthOpenY?.(value);
+        },
+        playMotion(indexOrGroup, index) {
+            if (typeof indexOrGroup === 'number') {
+                global.emotionMapper?.playMotion?.(indexOrGroup);
+            } else if (state?.loader?.currentModel) {
+                try { state.loader.currentModel.motion(indexOrGroup, index); } catch (_) {}
+            }
+        }
+    };
+}
+
+// ============ VRM driver（v2 组合式栈：manager/adapter/interaction/emotion） ============
+function createVRMDriver() {
+    let state = null; // { app, model, emotionMapper, expressionMapper, musicPlayer, vrmController, manager }
+
+    return {
+        engine: 'three',
+        async init(context) {
+            const { VRMSetup } = require('./vrm/setup.js');
+            logToTerminal('info', '[VRMDriver] 正在加载 VRM 3D 模型...');
+            const result = await VRMSetup.initialize(
+                context.modelController,
+                context.config,
+                context.ttsEnabled,
+                context.asrEnabled,
+                context.ttsProcessor,
+                context.voiceChat
+            );
+            state = result;
+            global.pixiApp = result.app;      // appProxy（周边弱引用兼容）
+            global.modelController = result.vrmController;
+            global.currentModel = result.model;
+            return result;
+        },
+
+        async dispose() {
+            if (!state) return;
+            const { VRMSetup } = require('./vrm/setup.js');
+            await VRMSetup.suspend();
+            global.pixiApp = null;
+            global.currentModel = null;
+            global.currentVRMAdapter = null;
+            state = null;
+            logToTerminal('info', '[VRMDriver] 已挂起（上下文保留）');
+        },
+
+        getModel() { return state?.model || null; },
+        getController() { return state?.vrmController || null; },
+
+        setEmotion(emotion) {
+            global.emotionMapper?.playConfiguredEmotion?.(emotion);
+        },
+        setMouth(value) {
+            state?.vrmController?.setMouthOpenY?.(value);
+        },
+        playMotion(group) {
+            try { state?.model?.motion?.(typeof group === 'string' ? group : 'Tap'); } catch (_) {}
+        }
+    };
+}
+
+function registerBuiltinDrivers() {
+    avatarFacade.register('live2d', createLive2DDriver());
+    avatarFacade.register('vrm', createVRMDriver());
+}
+
+module.exports = { registerBuiltinDrivers };

--- a/live-2d/js/avatar/live2d/core.js
+++ b/live-2d/js/avatar/live2d/core.js
@@ -1,0 +1,189 @@
+// core.js - Live2D 渲染舞台（PIXI 7）
+// Adapted from Project-N-E-K-O/N.E.K.O (Apache-2.0): static/live2d-core.js 的
+// PIXI 初始化 / 分辨率策略 / Idle FPS Governor 思路。
+//
+// 坐标系约定（v2）：
+//   舞台坐标 = CSS 像素（resolution + autoDensity 负责高清渲染），
+//   不再使用旧实现的 "canvas 内部 2 倍尺寸" hack。
+//   为兼容旧消费者（avatar-drop / http-server），window.canvasScaleFactor 恒为 1。
+const { logToTerminal } = require('../../api-utils.js');
+
+// 旧实现 canvas 为窗口 2 倍，config.ui.model_scale 的历史语义随之偏大 2 倍。
+// 存储层（config/preferences）继续沿用旧语义，应用到模型时除以该系数。
+const LEGACY_SCALE_RATIO = 2;
+
+const DEFAULT_RENDER_RESOLUTION = 2; // 与旧实现 2 倍超采样画质对齐
+const ACTIVE_FPS = 60;
+const IDLE_FPS = 30;
+const IDLE_TIMEOUT_MS = 8000;
+const IDLE_CHECK_INTERVAL_MS = 2000;
+
+class Live2DStage {
+    constructor() {
+        this.app = null;
+        this.canvas = null;
+        this._lastActivityAt = Date.now();
+        this._idleTimer = null;
+        this._resizeHandler = null;
+        this._activeFps = ACTIVE_FPS;
+        this._idleFps = IDLE_FPS;
+        this._isIdle = false;
+    }
+
+    // 初始化 PIXI Application（挂到指定 canvas 上）
+    // 注意：形态热切换时不销毁 PIXI/WebGL（destroy 上下文后立刻建 Three 上下文
+    // 会在 ANGLE/D3D11 原生层死锁冻结渲染进程），切走用 suspend()，切回用 init() 复用。
+    async init(canvasId = 'canvas', config = {}) {
+        const { ipcRenderer } = require('electron');
+
+        // 复用路径：app 仍存活时只需恢复 ticker 与尺寸
+        if (this.app && this.app.renderer) {
+            this.resume();
+            return this.app;
+        }
+
+        let width = window.innerWidth;
+        let height = window.innerHeight;
+        try {
+            const bounds = await ipcRenderer.invoke('get-window-bounds');
+            if (bounds && Number.isFinite(bounds.width) && bounds.width > 0) {
+                width = bounds.width;
+                height = bounds.height;
+            }
+        } catch (_) { /* 回退到 window.innerWidth */ }
+
+        const resolution = Number(config?.ui?.render_resolution) > 0
+            ? Number(config.ui.render_resolution)
+            : DEFAULT_RENDER_RESOLUTION;
+
+        this.canvas = document.getElementById(canvasId);
+        if (!this.canvas) {
+            throw new Error(`Live2DStage: 找不到 canvas 元素 #${canvasId}`);
+        }
+
+        this.app = new PIXI.Application({
+            view: this.canvas,
+            autoStart: true,
+            backgroundAlpha: 0,
+            width,
+            height,
+            resolution,
+            autoDensity: true
+        });
+
+        // 兼容旧全局：新坐标系下缩放因子恒为 1
+        window.canvasScaleFactor = 1;
+        window.actualWindowWidth = width;
+        window.actualWindowHeight = height;
+
+        this._resizeHandler = () => {
+            if (!this.app || !this.app.renderer) return;
+            const w = window.innerWidth;
+            const h = window.innerHeight;
+            this.app.renderer.resize(w, h);
+            window.actualWindowWidth = w;
+            window.actualWindowHeight = h;
+        };
+        window.addEventListener('resize', this._resizeHandler);
+
+        const maxFps = Number(config?.ui?.max_fps);
+        if (Number.isFinite(maxFps) && maxFps >= 15) {
+            this._activeFps = maxFps;
+            this._idleFps = Math.min(IDLE_FPS, maxFps);
+        }
+        this._startFpsGovernor();
+
+        const diag = `[Live2DStage] 初始化完成: ${width}x${height} CSS px, resolution=${resolution}, maxFPS=${this._activeFps}`;
+        console.log(diag);
+        logToTerminal('info', diag);
+        return this.app;
+    }
+
+    get width() {
+        return this.app ? this.app.screen.width : window.innerWidth;
+    }
+
+    get height() {
+        return this.app ? this.app.screen.height : window.innerHeight;
+    }
+
+    // 有任何交互/语音活动时调用：恢复满帧率
+    notifyActivity() {
+        this._lastActivityAt = Date.now();
+        if (this._isIdle && this.app) {
+            this.app.ticker.maxFPS = this._activeFps;
+            this._isIdle = false;
+        }
+    }
+
+    // Idle FPS Governor：静止一段时间后降帧省 CPU/GPU
+    _startFpsGovernor() {
+        if (!this.app) return;
+        this.app.ticker.maxFPS = this._activeFps;
+        this._idleTimer = setInterval(() => {
+            if (!this.app) return;
+            const idle = Date.now() - this._lastActivityAt > IDLE_TIMEOUT_MS;
+            if (idle && !this._isIdle) {
+                this.app.ticker.maxFPS = this._idleFps;
+                this._isIdle = true;
+            } else if (!idle && this._isIdle) {
+                this.app.ticker.maxFPS = this._activeFps;
+                this._isIdle = false;
+            }
+        }, IDLE_CHECK_INTERVAL_MS);
+    }
+
+    // 挂起舞台（形态切走时调用）：停 ticker、清空舞台，但保留 PIXI app 与 WebGL 上下文
+    suspend() {
+        if (!this.app) return;
+        try {
+            this.app.ticker.stop();
+            if (this.app.stage) this.app.stage.removeChildren();
+            this.app.renderer.clear();
+        } catch (e) {
+            console.warn('[Live2DStage] 挂起时出现警告:', e);
+        }
+    }
+
+    // 恢复舞台（形态切回时调用）
+    resume() {
+        if (!this.app) return;
+        try {
+            const w = window.innerWidth;
+            const h = window.innerHeight;
+            this.app.renderer.resize(w, h);
+            window.canvasScaleFactor = 1;
+            window.actualWindowWidth = w;
+            window.actualWindowHeight = h;
+            this.app.ticker.start();
+            this.notifyActivity();
+        } catch (e) {
+            console.warn('[Live2DStage] 恢复时出现警告:', e);
+        }
+    }
+
+    // 彻底销毁（仅应用退出/异常兜底使用；热切换请用 suspend/resume）
+    destroy() {
+        if (this._idleTimer) {
+            clearInterval(this._idleTimer);
+            this._idleTimer = null;
+        }
+        if (this._resizeHandler) {
+            window.removeEventListener('resize', this._resizeHandler);
+            this._resizeHandler = null;
+        }
+        if (this.app) {
+            try {
+                this.app.ticker.stop();
+                if (this.app.stage) this.app.stage.removeChildren();
+                this.app.destroy(false, { children: true, texture: true, baseTexture: true });
+            } catch (e) {
+                console.warn('[Live2DStage] 销毁 PIXI 应用时出现警告:', e);
+            }
+            this.app = null;
+        }
+        this.canvas = null;
+    }
+}
+
+module.exports = { Live2DStage, LEGACY_SCALE_RATIO };

--- a/live-2d/js/avatar/live2d/duration-utils.js
+++ b/live-2d/js/avatar/live2d/duration-utils.js
@@ -1,0 +1,41 @@
+'use strict';
+
+function parseDuration(value) {
+    if (value === undefined || value === null) return null;
+    if (typeof value === 'string' && value.trim() === '') return null;
+    const number = Number(value);
+    return Number.isFinite(number) ? number : null;
+}
+
+function normalizeDuration(value, fallback, options = {}) {
+    const fallbackNumber = parseDuration(fallback);
+    if (fallbackNumber === null) {
+        throw new TypeError('Duration fallback must be a finite number');
+    }
+
+    const min = Number.isFinite(Number(options.min)) ? Number(options.min) : 0;
+    const maxCandidate = Number(options.max);
+    const max = Number.isFinite(maxCandidate) ? Math.max(min, maxCandidate) : Infinity;
+    const parsed = parseDuration(value);
+    const number = parsed === null ? fallbackNumber : parsed;
+    return Math.max(min, Math.min(max, number));
+}
+
+function normalizeDurationField(source, keys, fallback, options = {}) {
+    const record = source && typeof source === 'object' ? source : {};
+    const candidates = Array.isArray(keys) ? keys : [keys];
+    let value;
+    for (const key of candidates) {
+        if (Object.prototype.hasOwnProperty.call(record, key)) {
+            value = record[key];
+            break;
+        }
+    }
+    return normalizeDuration(value, fallback, options);
+}
+
+module.exports = {
+    normalizeDuration,
+    normalizeDurationField,
+    parseDuration
+};

--- a/live-2d/js/avatar/live2d/emotion-archetypes.js
+++ b/live-2d/js/avatar/live2d/emotion-archetypes.js
@@ -1,0 +1,192 @@
+'use strict';
+
+const VAD_PRESETS = {
+    happy: { valence: 0.75, arousal: 0.45, dominance: 0.35 },
+    excited: { valence: 0.85, arousal: 0.85, dominance: 0.45 },
+    shy: { valence: 0.35, arousal: 0.6, dominance: -0.45 },
+    sad: { valence: -0.65, arousal: -0.45, dominance: -0.5 },
+    angry: { valence: -0.7, arousal: 0.75, dominance: 0.55 },
+    anger: { valence: -0.7, arousal: 0.75, dominance: 0.55 },
+    calm: { valence: 0.25, arousal: -0.45, dominance: 0.2 },
+    surprised: { valence: 0.35, arousal: 0.72, dominance: 0.05 },
+    playful: { valence: 0.6, arousal: 0.5, dominance: 0.3 },
+    anxiety: { valence: -0.6, arousal: 0.7, dominance: -0.55 },
+    tired: { valence: -0.25, arousal: -0.7, dominance: -0.3 },
+    neutral: { valence: 0, arousal: 0, dominance: 0 }
+};
+
+const ARCHETYPES = {
+    happy: {
+        base: { AU12: [0.42, 0.74], AU6: [0.18, 0.45], AU2: [0.04, 0.18], blush: [0.02, 0.16], gazeY: [0.02, 0.16] },
+        variants: {
+            soft_smile: { AU12: [0.32, 0.55], AU6: [0.14, 0.32], gazeY: [-0.04, 0.08] },
+            bright_smile: { AU12: [0.62, 0.88], AU6: [0.34, 0.58], AU5: [0.08, 0.2], blush: [0.08, 0.24] },
+            shy_happy: { AU12: [0.36, 0.62], AU6: [0.2, 0.44], gazeY: [-0.22, -0.06], blush: [0.22, 0.55] }
+        }
+    },
+    playful: {
+        base: { AU12: [0.38, 0.68], AU6: [0.26, 0.54], AU2: [0.1, 0.32], gazeX: [-0.22, 0.22], blush: [0.06, 0.22] },
+        variants: {
+            tease: { AU12: [0.46, 0.78], AU6: [0.32, 0.62], AU2: [0.18, 0.42], gazeX: [-0.36, 0.36], AU18: [0.06, 0.18] },
+            wink_side: { AU12: [0.48, 0.74], AU6: [0.28, 0.55], AU7: [0.04, 0.16], gazeX: [-0.3, 0.3] }
+        }
+    },
+    surprised: {
+        base: { AU1: [0.2, 0.48], AU2: [0.25, 0.58], AU5: [0.36, 0.72], AU25: [0.12, 0.34], AU26: [0.08, 0.28], gazeY: [0.04, 0.24] },
+        variants: {
+            startled: { AU1: [0.36, 0.7], AU2: [0.35, 0.75], AU5: [0.48, 0.86], AU25: [0.16, 0.38] },
+            delighted: { AU12: [0.28, 0.58], AU6: [0.12, 0.28], AU5: [0.32, 0.64], AU2: [0.22, 0.5] }
+        }
+    },
+    angry: {
+        base: { AU4: [0.36, 0.72], AU7: [0.16, 0.4], AU15: [0.24, 0.55], AU23: [0.16, 0.36], gazeY: [-0.04, 0.08] },
+        variants: {
+            annoyed: { AU4: [0.24, 0.52], AU7: [0.12, 0.3], AU15: [0.16, 0.38], AU23: [0.08, 0.24] },
+            firm: { AU4: [0.42, 0.78], AU7: [0.22, 0.48], AU23: [0.2, 0.44], AU15: [0.22, 0.44] }
+        }
+    },
+    sad: {
+        base: { AU1: [0.18, 0.46], AU15: [0.3, 0.62], AU7: [0.06, 0.22], gazeY: [-0.34, -0.12], blush: [0, 0.08] },
+        variants: {
+            downcast: { AU1: [0.18, 0.4], AU15: [0.34, 0.66], gazeY: [-0.44, -0.2], AU7: [0.08, 0.24] },
+            teary: { AU1: [0.32, 0.62], AU15: [0.28, 0.58], AU6: [0.04, 0.16], gazeY: [-0.34, -0.12] }
+        }
+    },
+    shy: {
+        base: { AU12: [0.22, 0.48], AU6: [0.12, 0.34], AU1: [0.08, 0.24], gazeY: [-0.34, -0.1], gazeX: [-0.2, 0.2], blush: [0.32, 0.82] },
+        variants: {
+            bashful: { AU12: [0.28, 0.54], AU6: [0.18, 0.38], gazeY: [-0.42, -0.18], blush: [0.46, 0.92] },
+            embarrassed: { AU1: [0.14, 0.36], AU15: [0.04, 0.18], AU12: [0.14, 0.36], gazeY: [-0.5, -0.2], blush: [0.55, 1] }
+        }
+    },
+    neutral: {
+        base: { AU12: [0.06, 0.2], AU6: [0.02, 0.12], AU2: [0.02, 0.1], gazeY: [-0.04, 0.08], blush: [0, 0.08] },
+        variants: {
+            attentive: { AU12: [0.08, 0.22], AU2: [0.05, 0.16], gazeY: [0, 0.12] },
+            quiet: { AU12: [0.04, 0.16], AU6: [0.02, 0.1], gazeY: [-0.06, 0.04] }
+        }
+    }
+};
+
+function clamp(value, min, max) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return min;
+    return Math.max(min, Math.min(max, n));
+}
+
+function normalizeEmotion(emotion) {
+    const text = String(emotion || '').trim().toLowerCase();
+    if (!text) return 'neutral';
+    if (text.includes('happy') || text.includes('joy') || text.includes('开心') || text.includes('高兴') || text.includes('快乐')) return 'happy';
+    if (text.includes('playful') || text.includes('tease') || text.includes('俏皮') || text.includes('调皮') || text.includes('得意')) return 'playful';
+    if (text.includes('surpris') || text.includes('惊讶') || text.includes('惊喜') || text.includes('吃惊')) return 'surprised';
+    if (text.includes('angry') || text.includes('anger') || text.includes('生气') || text.includes('愤怒') || text.includes('恼火')) return 'angry';
+    if (text.includes('sad') || text.includes('down') || text.includes('难过') || text.includes('伤心') || text.includes('委屈')) return 'sad';
+    if (text.includes('shy') || text.includes('害羞') || text.includes('脸红')) return 'shy';
+    if (text.includes('excited')) return 'happy';
+    if (text.includes('calm')) return 'neutral';
+    return ARCHETYPES[text] ? text : 'neutral';
+}
+
+function seededRandom(seed) {
+    let state = Math.floor(Number(seed) || 0) >>> 0;
+    if (state === 0) state = 0x6d2b79f5;
+    return () => {
+        state = (state * 1664525 + 1013904223) >>> 0;
+        return state / 0x100000000;
+    };
+}
+
+function seedFromNow() {
+    return ((Date.now() & 0xffffffff) ^ Math.floor(Math.random() * 0xffffffff)) >>> 0;
+}
+
+function sampleRange(range, random) {
+    if (!Array.isArray(range)) return 0;
+    const min = Number(range[0]);
+    const max = Number(range[1]);
+    const lo = Number.isFinite(min) ? min : 0;
+    const hi = Number.isFinite(max) ? max : lo;
+    return lo + (hi - lo) * random();
+}
+
+function mergeRanges(base, variant) {
+    return { ...(base || {}), ...(variant || {}) };
+}
+
+function sample(emotion, intensity = 1, seed = null, variantName = null) {
+    const normalized = normalizeEmotion(emotion);
+    const archetype = ARCHETYPES[normalized] || ARCHETYPES.neutral;
+    const random = seededRandom(seed == null ? seedFromNow() : seed);
+    const variants = Object.keys(archetype.variants || {});
+    const pickedVariant = variantName && archetype.variants[variantName]
+        ? variantName
+        : variants[Math.floor(random() * variants.length)] || '';
+    const ranges = mergeRanges(archetype.base, archetype.variants[pickedVariant]);
+    const gain = clamp(intensity, 0, 1.5);
+    const auMap = {};
+
+    for (const [key, range] of Object.entries(ranges)) {
+        auMap[key] = sampleRange(range, random) * gain;
+    }
+
+    return {
+        emotion: normalized,
+        variant: pickedVariant,
+        auMap
+    };
+}
+
+// strict 模式下可直达的补充词表：这些预设被 normalizeEmotion 折叠（excited→happy、calm→neutral）
+// 或完全不识别（anxiety/tired → neutral），导致对应 VAD 预设永远取不到。
+// 仅「仅 AI 编舞」档的调用方传 { strict: true } 启用，blend 档行为不变。
+const STRICT_PRESET_ALIASES = {
+    '兴奋': 'excited', '激动': 'excited', 'hyped': 'excited',
+    '平静': 'calm', '冷静': 'calm', '淡定': 'calm', 'relaxed': 'calm',
+    '焦虑': 'anxiety', '紧张': 'anxiety', '不安': 'anxiety', 'anxious': 'anxiety', 'nervous': 'anxiety',
+    '疲惫': 'tired', '困倦': 'tired', '困': 'tired', '累': 'tired', 'sleepy': 'tired', 'exhausted': 'tired',
+    '温柔': 'affectionate', '亲昵': 'affectionate', '喜欢': 'affectionate',
+    '好奇': 'curious',
+    '担心': 'concerned', '担忧': 'concerned', 'worried': 'concerned',
+    '困惑': 'confused', '疑惑': 'confused', '迷茫': 'confused'
+};
+
+// 仅 strict 路径可达的扩展预设（对齐 soullink classifier 的 14 类情绪）。
+// 故意不并入 VAD_PRESETS：_nearestPreset 会遍历 VAD_PRESETS，
+// 并入会改变 blend 档的情绪反查结果，违反冻结要求。
+const STRICT_EXTRA_PRESETS = {
+    affectionate: { valence: 0.68, arousal: 0.18, dominance: 0.12 },
+    curious: { valence: 0.32, arousal: 0.38, dominance: 0.08 },
+    concerned: { valence: -0.34, arousal: 0.22, dominance: -0.12 },
+    confused: { valence: -0.12, arousal: 0.3, dominance: -0.18 }
+};
+
+function resolveStrictEmotionName(emotion) {
+    const raw = String(emotion || '').trim().toLowerCase();
+    if (!raw) return null;
+    if (VAD_PRESETS[raw] || STRICT_EXTRA_PRESETS[raw]) return raw;
+    const alias = STRICT_PRESET_ALIASES[raw];
+    if (alias && (VAD_PRESETS[alias] || STRICT_EXTRA_PRESETS[alias])) return alias;
+    return null;
+}
+
+function getVADPreset(emotion, options = null) {
+    if (options && options.strict) {
+        const name = resolveStrictEmotionName(emotion);
+        if (name) return { ...(VAD_PRESETS[name] || STRICT_EXTRA_PRESETS[name]) };
+        // strict 下无直配再走旧归一化，保证兜底
+    }
+    const normalized = normalizeEmotion(emotion);
+    return { ...(VAD_PRESETS[normalized] || VAD_PRESETS.neutral) };
+}
+
+module.exports = {
+    ARCHETYPES,
+    STRICT_EXTRA_PRESETS,
+    VAD_PRESETS,
+    getVADPreset,
+    normalizeEmotion,
+    resolveStrictEmotionName,
+    sample,
+    seededRandom
+};

--- a/live-2d/js/avatar/live2d/emotion-engine.js
+++ b/live-2d/js/avatar/live2d/emotion-engine.js
@@ -1,0 +1,809 @@
+// emotion-engine.js - 统一表情/动作引擎（合并旧 EmotionMotionMapper + EmotionExpressionMapper）
+// Adapted from Project-N-E-K-O/N.E.K.O (Apache-2.0): static/live2d-emotion.js 的
+// 初始参数记录 / 表情软重置 / 无动作时参数动画降级（playSimpleMotion）思路。
+//
+// 配置来源（优先级从高到低）：
+//   1. <模型目录>/emotion_mapping.json  —— per-model sidecar（可选）
+//      { "emotions": { "开心": { "motions": [..], "expressions": [..] } },
+//        "actions": { "动作1": [..] }, "idle": { "group": "Idle" } }
+//   2. 旧版中央配置 emotion_actions.json / emotion_expressions.json（按角色名键）
+//      —— WebUI 仍然直接编辑这两个文件，保持兼容（无 sidecar 时始终读它们）
+//
+// 对外暴露两个"门面"（兼容旧的双 Mapper 契约，避免 TTS 时间轴双份 marker 造成动作重复触发）：
+//   engine.motionFacade     -> 旧 global.emotionMapper 接口
+//   engine.expressionFacade -> 旧 global.expressionMapper 接口
+const fs = require('fs');
+const path = require('path');
+const { logToTerminal } = require('../../api-utils.js');
+const { shouldUseLegacyEmotionLogic } = require('../motion-mode.js');
+
+const APP_ROOT = path.join(__dirname, '..', '..', '..');
+const EMOTION_WHITELIST = ['开心', '生气', '难过', '惊讶', '害羞', '俏皮'];
+const SOFT_RESET_MS = 220;             // 表情软重置时长（N.E.K.O 同款节奏）
+const SIMPLE_MOTION_MS = 900;          // 无动作降级的参数动画时长
+
+// 表情/口型/头部角度参数：记录初始参数与软重置时跳过（口型归 lipsync，角度归视线跟随）
+const LIPSYNC_PARAMS = ['ParamMouthOpenY', 'PARAM_MOUTH_OPEN_Y', 'ParamMouthForm', 'ParamMouthOpen', 'ParamA', 'ParamI', 'ParamU', 'ParamE', 'ParamO'];
+const SKIP_PARAMS = ['ParamAngleX', 'ParamAngleY', 'ParamAngleZ', 'ParamEyeBallX', 'ParamEyeBallY', ...LIPSYNC_PARAMS];
+
+// 简易参数动画预设：六情绪各给一个"点头/摇头/侧身"式的小动作（无 motion 配置时的降级表现）
+const SIMPLE_MOTION_PRESETS = {
+    '开心': { ParamAngleZ: 12, ParamBodyAngleZ: 4 },
+    '生气': { ParamAngleX: -14, ParamBodyAngleX: -5 },
+    '难过': { ParamAngleY: -18, ParamBodyAngleY: -4 },
+    '惊讶': { ParamAngleY: 14, ParamBodyAngleY: 3 },
+    '害羞': { ParamAngleZ: -10, ParamAngleY: -8 },
+    '俏皮': { ParamAngleZ: 16, ParamAngleX: 8 }
+};
+
+function _readJson(filePath) {
+    try {
+        return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    } catch (_) {
+        return null;
+    }
+}
+
+function _writeJson(filePath, data) {
+    try {
+        fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf8');
+        return true;
+    } catch (e) {
+        console.error(`[EmotionEngine] 写入 ${filePath} 失败:`, e);
+        return false;
+    }
+}
+
+function _scanFiles(root, suffix) {
+    const result = [];
+    try {
+        if (!root || !fs.existsSync(root)) return result;
+        for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+            const fullPath = path.join(root, entry.name);
+            if (entry.isDirectory()) {
+                result.push(..._scanFiles(fullPath, suffix));
+            } else if (entry.isFile() && entry.name.toLowerCase().endsWith(suffix)) {
+                result.push(fullPath);
+            }
+        }
+    } catch (_) {}
+    return result;
+}
+
+// 解析 <标签>（与旧实现一致，含 <expression:xx> 之外的所有尖括号标签）
+function parseEmotionTagsWithPosition(text) {
+    const pattern = /<([^>]+)>/g;
+    const tags = [];
+    let match;
+    while ((match = pattern.exec(text)) !== null) {
+        tags.push({
+            emotion: match[1],
+            startIndex: match.index,
+            endIndex: match.index + match[0].length,
+            fullTag: match[0]
+        });
+    }
+    return tags;
+}
+
+// 移除标签并生成 { purifiedText, positions: [{ position, emotion }] }
+function stripTags(text) {
+    const tags = parseEmotionTagsWithPosition(text);
+    if (tags.length === 0) return { purifiedText: text, positions: [] };
+
+    let purifiedText = text;
+    for (let i = tags.length - 1; i >= 0; i--) {
+        const t = tags[i];
+        purifiedText = purifiedText.substring(0, t.startIndex) + purifiedText.substring(t.endIndex);
+    }
+
+    const positions = [];
+    let offset = 0;
+    for (const t of tags) {
+        positions.push({ position: t.startIndex - offset, emotion: t.emotion });
+        offset += t.endIndex - t.startIndex;
+    }
+    return { purifiedText, positions };
+}
+
+class EmotionEngine {
+    constructor(model, config = null) {
+        this.model = model;
+        this.config = config || {};
+        this.currentMotionGroup = 'TapBody';
+        this.idleGroup = 'Idle';
+        this.idleExpression = '';
+        this.defaultExpression = '默认表情';
+        this.currentCharacter = null;
+        this.modelDirName = null;
+
+        // 统一配置（motionConfig/expressionConfig 沿用旧字典结构：六情绪 + 动作N/表情N）
+        this.motionConfig = {};
+        this.expressionConfig = {};
+        this._sidecarPath = null;
+        this._usingSidecar = false;
+        this._expressionDefinitionsSynced = false;
+        this._lastAuTrigger = null;
+
+        // N.E.K.O 机制：初始参数快照 / 软重置 / 简易动画句柄
+        this.initialParameters = {};
+        this._softResetFrame = null;
+        this._simpleMotionFrame = null;
+
+        // 双门面（对外兼容旧 Mapper 契约）
+        this.motionFacade = this._createMotionFacade();
+        this.expressionFacade = this._createExpressionFacade();
+    }
+
+    static async create(model, config = null) {
+        const engine = new EmotionEngine(model, config);
+        await engine.loadConfig();
+        engine.recordInitialParameters();
+        engine._configureAuDriver();
+        return engine;
+    }
+
+    // ============ 配置加载 ============
+
+    _resolveCharacterName() {
+        try {
+            const modelPath = this.model?.internalModel?.settings?.url || '';
+            const match = decodeURIComponent(modelPath).match(/2D\/([^\/]+)\//);
+            if (match) return match[1];
+        } catch (_) {}
+        return '肥牛';
+    }
+
+    async loadConfig() {
+        this.currentCharacter = this._resolveCharacterName();
+        this.modelDirName = this.currentCharacter;
+        this._sidecarPath = path.join(APP_ROOT, '2D', this.modelDirName, 'emotion_mapping.json');
+
+        const emptyEmotions = () => Object.fromEntries(EMOTION_WHITELIST.map(e => [e, []]));
+        this.motionConfig = emptyEmotions();
+        this.expressionConfig = emptyEmotions();
+        this.idleGroup = 'Idle';
+        this.idleExpression = '';
+        this._usingSidecar = false;
+        this._expressionDefinitionsSynced = false;
+
+        // 1) sidecar 优先
+        const sidecar = _readJson(this._sidecarPath);
+        if (sidecar && typeof sidecar === 'object') {
+            this._usingSidecar = true;
+            const emotions = sidecar.emotions || {};
+            for (const [emotion, entry] of Object.entries(emotions)) {
+                if (Array.isArray(entry?.motions)) this.motionConfig[emotion] = entry.motions;
+                if (Array.isArray(entry?.expressions)) this.expressionConfig[emotion] = entry.expressions;
+            }
+            for (const [name, files] of Object.entries(sidecar.actions || {})) {
+                if (Array.isArray(files)) this.motionConfig[name] = files;
+            }
+            for (const [name, files] of Object.entries(sidecar.expressions_named || {})) {
+                if (Array.isArray(files)) this.expressionConfig[name] = files;
+            }
+            if (sidecar.idle && Object.prototype.hasOwnProperty.call(sidecar.idle, 'group')) {
+                this.idleGroup = sidecar.idle.group || '';
+            }
+            if (typeof sidecar.idle?.expression === 'string') this.idleExpression = sidecar.idle.expression;
+            if (sidecar.motion_group) this.currentMotionGroup = sidecar.motion_group;
+            logToTerminal('info', `[EmotionEngine] 使用 per-model 配置: ${this._sidecarPath}`);
+            return;
+        }
+
+        // 2) 旧版中央配置（WebUI 的编辑目标，保持兼容）
+        const legacyActions = _readJson(path.join(APP_ROOT, 'emotion_actions.json'));
+        const actionEntry = legacyActions?.[this.currentCharacter]?.emotion_actions;
+        if (actionEntry && typeof actionEntry === 'object') {
+            this.motionConfig = { ...emptyEmotions(), ...actionEntry };
+        }
+
+        const legacyExpr = _readJson(path.join(APP_ROOT, 'emotion_expressions.json'));
+        const exprEntry = legacyExpr?.[this.currentCharacter]?.emotion_expressions;
+        if (exprEntry && typeof exprEntry === 'object') {
+            this.expressionConfig = { ...emptyEmotions(), ...exprEntry };
+        }
+
+        const motionCount = Object.values(this.motionConfig).flat().length;
+        const exprCount = Object.values(this.expressionConfig).flat().length;
+        logToTerminal('info', `[EmotionEngine] 角色 "${this.currentCharacter}" 配置加载完成（legacy），动作文件 ${motionCount} 个 / 表情文件 ${exprCount} 个`);
+    }
+
+    async reloadConfig() {
+        await this.loadConfig();
+        this._configureAuDriver();
+    }
+
+    async getCurrentCharacterName() {
+        return this.currentCharacter || this._resolveCharacterName();
+    }
+
+    getModelAssetRoot() {
+        return this._modelAssetBase();
+    }
+
+    _runtimeConfig() {
+        return global.live2dRuntime?.config || this.config || {};
+    }
+
+    _isAuExpressionMode() {
+        const config = this._runtimeConfig();
+        return (
+            shouldUseLegacyEmotionLogic(config) &&
+            String(config?.ui?.expression_engine || 'au').toLowerCase() === 'au' &&
+            config?.expression_solver?.enabled !== false
+        );
+    }
+
+    _configureAuDriver() {
+        if (!this._isAuExpressionMode()) return false;
+        try {
+            return global.auDriver?.setEmotionEngine?.(this) === true;
+        } catch (error) {
+            logToTerminal('warn', `[EmotionEngine] 配置 AU 表情驱动失败: ${error?.stack || error?.message || error}`);
+            return false;
+        }
+    }
+
+    _tryPlayAuEmotion(emotion) {
+        if (!this._isAuExpressionMode() || !EMOTION_WHITELIST.includes(emotion)) return false;
+        try {
+            const handled = global.auDriver?.playEmotion?.(emotion) === true;
+            if (handled) {
+                this._lastAuTrigger = { emotion, at: Date.now() };
+            }
+            return handled;
+        } catch (error) {
+            console.warn('[EmotionEngine] AU 表情触发失败，回退预制动作:', error);
+            return false;
+        }
+    }
+
+    _wasJustHandledByAu(emotion) {
+        const marker = this._lastAuTrigger;
+        return Boolean(marker && marker.emotion === emotion && Date.now() - marker.at < 1000);
+    }
+
+    // ============ N.E.K.O 机制：初始参数记录 / 软重置 / 简易动画 ============
+
+    recordInitialParameters() {
+        this.initialParameters = {};
+        try {
+            const coreModel = this.model?.internalModel?.coreModel;
+            if (!coreModel || typeof coreModel.getParameterCount !== 'function') return;
+
+            const count = coreModel.getParameterCount();
+            for (let i = 0; i < count; i++) {
+                let paramId = null;
+                try { paramId = coreModel.getParameterId ? coreModel.getParameterId(i) : null; } catch (_) {}
+                if (paramId && SKIP_PARAMS.includes(paramId)) continue;
+                try {
+                    this.initialParameters[`#${i}`] = {
+                        id: paramId,
+                        index: i,
+                        value: coreModel.getParameterValueByIndex(i)
+                    };
+                } catch (_) {}
+            }
+        } catch (e) {
+            console.warn('[EmotionEngine] 记录初始参数失败:', e);
+        }
+    }
+
+    // 表情软重置：把（非口型/角度）参数在 SOFT_RESET_MS 内插值回初始快照
+    softResetToInitial() {
+        const coreModel = this.model?.internalModel?.coreModel;
+        if (!coreModel || Object.keys(this.initialParameters).length === 0) return;
+        if (this._softResetFrame) cancelAnimationFrame(this._softResetFrame);
+
+        const start = performance.now();
+        const from = {};
+        for (const key of Object.keys(this.initialParameters)) {
+            const p = this.initialParameters[key];
+            try { from[key] = coreModel.getParameterValueByIndex(p.index); } catch (_) {}
+        }
+
+        const step = (now) => {
+            const t = Math.min(1, (now - start) / SOFT_RESET_MS);
+            for (const key of Object.keys(this.initialParameters)) {
+                const p = this.initialParameters[key];
+                if (!(key in from)) continue;
+                const v = from[key] + (p.value - from[key]) * t;
+                try { coreModel.setParameterValueByIndex(p.index, v); } catch (_) {}
+            }
+            if (t < 1) {
+                this._softResetFrame = requestAnimationFrame(step);
+            } else {
+                this._softResetFrame = null;
+            }
+        };
+        this._softResetFrame = requestAnimationFrame(step);
+    }
+
+    // 无 motion 配置时的降级表现：短促的头部/身体参数动画（正弦进出）
+    playSimpleMotion(emotion) {
+        if (!shouldUseLegacyEmotionLogic()) return;
+        // 参数导演有编舞在进行时让位，避免双重驱动头部角度
+        if (global.paramDirector && global.paramDirector.isChoreographyActive()) return;
+        const preset = SIMPLE_MOTION_PRESETS[emotion];
+        const coreModel = this.model?.internalModel?.coreModel;
+        if (!preset || !coreModel || typeof coreModel.setParameterValueById !== 'function') return;
+        if (this._simpleMotionFrame) cancelAnimationFrame(this._simpleMotionFrame);
+
+        const start = performance.now();
+        const step = (now) => {
+            const t = Math.min(1, (now - start) / SIMPLE_MOTION_MS);
+            const wave = Math.sin(t * Math.PI); // 0 -> 1 -> 0
+            for (const [paramId, amp] of Object.entries(preset)) {
+                try { coreModel.setParameterValueById(paramId, amp * wave); } catch (_) {}
+            }
+            if (t < 1) {
+                this._simpleMotionFrame = requestAnimationFrame(step);
+            } else {
+                this._simpleMotionFrame = null;
+            }
+        };
+        this._simpleMotionFrame = requestAnimationFrame(step);
+        console.log(`[EmotionEngine] 情绪 "${emotion}" 无动作配置，使用参数动画降级`);
+    }
+
+    // ============ 动作 ============
+
+    playConfiguredEmotion(emotion) {
+        if (this._tryPlayAuEmotion(emotion)) return true;
+        return this._playConfiguredEmotionLegacy(emotion);
+    }
+
+    _playConfiguredEmotionLegacy(emotion) {
+        const files = this.motionConfig?.[emotion];
+        if (!files || files.length === 0) {
+            this.playSimpleMotion(emotion);
+            return false;
+        }
+        const selected = files[Math.floor(Math.random() * files.length)];
+        const index = this._findMotionIndexByFileName(selected);
+        if (index !== -1) {
+            this.playMotionByIndex(index);
+            console.log(`[EmotionEngine] 情绪动作: ${emotion} -> ${selected}`);
+            return true;
+        } else if (this.playNativeMotionFile(selected)) {
+            console.log(`[EmotionEngine] 情绪动作: ${emotion} -> ${selected}`);
+            return true;
+        } else {
+            console.warn(`[EmotionEngine] 未找到动作文件 "${selected}" 对应的索引，使用参数动画降级`);
+            this.playSimpleMotion(emotion);
+            return false;
+        }
+    }
+
+    _findMotionIndexByFileName(fileName) {
+        try {
+            const defs = this.model.internalModel.settings.motions[this.currentMotionGroup];
+            if (!defs) return -1;
+            return defs.findIndex(m => m.File === fileName);
+        } catch (_) {
+            return -1;
+        }
+    }
+
+    playMotionByIndex(index) {
+        return this._playMotionAt(this.currentMotionGroup, index);
+    }
+
+    _playMotionAt(group, index) {
+        if (!this.model) return;
+        try {
+            const defs = this.model.internalModel.settings.motions?.[group];
+            if (!defs || defs.length === 0) {
+                console.warn(`[EmotionEngine] 动作组 "${group}" 为空或不存在`);
+                return false;
+            }
+            const motionIndex = index % defs.length;
+            if (this.model.internalModel?.motionManager) {
+                this.model.internalModel.motionManager.stopAllMotions();
+            }
+            this.model.motion(group, motionIndex);
+            return true;
+        } catch (e) {
+            console.error('[EmotionEngine] 播放动作失败:', e);
+            return false;
+        }
+    }
+
+    playNativeMotionFile(fileName) {
+        const location = this._findOrRegisterMotionFile(fileName);
+        if (!location) {
+            console.warn(`[EmotionEngine] 原生动作文件不可用: ${fileName}`);
+            return false;
+        }
+        return this._playMotionAt(location.group, location.index);
+    }
+
+    stopNativeMotions() {
+        try {
+            const idleDefinitions = this.model?.internalModel?.settings?.motions?.[this.idleGroup];
+            if (this.idleGroup && Array.isArray(idleDefinitions) && idleDefinitions.length > 0) {
+                this.model.motion(this.idleGroup, 0);
+                return true;
+            }
+            this.model?.internalModel?.motionManager?.stopAllMotions?.();
+            return true;
+        } catch (_) {
+            return false;
+        }
+    }
+
+    _findOrRegisterMotionFile(fileName) {
+        const settings = this.model?.internalModel?.settings;
+        const motionManager = this.model?.internalModel?.motionManager;
+        if (!settings || !motionManager || !fileName) return null;
+        const normalized = String(fileName).replace(/\\/g, '/');
+        settings.motions = settings.motions || {};
+
+        for (const [group, definitions] of Object.entries(settings.motions)) {
+            if (!Array.isArray(definitions)) continue;
+            const index = definitions.findIndex(item => String(item?.File || '').replace(/\\/g, '/') === normalized);
+            if (index >= 0) return { group, index };
+        }
+
+        const group = this.currentMotionGroup || 'TapBody';
+        const definitions = settings.motions[group] || (settings.motions[group] = []);
+        definitions.push({ File: normalized });
+        motionManager.definitions = settings.motions;
+        motionManager.motionGroups = motionManager.motionGroups || {};
+        if (!Array.isArray(motionManager.motionGroups[group])) {
+            motionManager.motionGroups[group] = [];
+        }
+        return { group, index: definitions.length - 1 };
+    }
+
+    playDefaultMotion() {
+        try {
+            if (!this.idleGroup) {
+                this.model.internalModel?.motionManager?.stopAllMotions?.();
+            } else if (this.model.internalModel.settings.motions[this.idleGroup]) {
+                this.model.motion(this.idleGroup, 0);
+            } else {
+                this.model.motion(this.currentMotionGroup, 0);
+            }
+            if (this.idleExpression) {
+                this._playExpressionFile(this.idleExpression);
+            } else {
+                this.resetExpressionToNeutral();
+            }
+        } catch (e) {
+            console.error('[EmotionEngine] 播放默认动作失败:', e);
+        }
+    }
+
+    // ============ 表情 ============
+
+    triggerExpressionByEmotion(emotion) {
+        // TTS 同一标签会依次通知 motion/expression 两个旧门面。
+        // AU 成功处理过同一标签时，第二次通知在这里吞掉。
+        if (this._isAuExpressionMode() && EMOTION_WHITELIST.includes(emotion)) {
+            if (this._wasJustHandledByAu(emotion) || this._tryPlayAuEmotion(emotion)) {
+                return null;
+            }
+        }
+        const files = this.expressionConfig?.[emotion];
+        if (files && files.length > 0) {
+            const selected = files[Math.floor(Math.random() * files.length)];
+            this._playExpressionFile(selected);
+            return this._expressionNameFromPath(selected);
+        }
+        this.playDefaultExpression();
+        return null;
+    }
+
+    triggerExpression(expressionName) {
+        if (!expressionName || expressionName === '默认表情' || expressionName === this.defaultExpression) {
+            // 请求默认表情时，若存在配置则播放，否则软重置回初始状态
+            return this.playDefaultExpression();
+        }
+        const files = this.expressionConfig?.[expressionName];
+        if (!files || files.length === 0) {
+            console.warn(`[EmotionEngine] 表情 "${expressionName}" 未配置，使用默认表情`);
+            this.playDefaultExpression();
+            return false;
+        }
+        const selected = files[Math.floor(Math.random() * files.length)];
+        this._playExpressionFile(selected);
+        return true;
+    }
+
+    playDefaultExpression() {
+        // 显式配置了“默认表情”时才播放文件；否则回到模型中性表情。
+        for (const name of [this.defaultExpression, '默认表情']) {
+            const files = this.expressionConfig?.[name];
+            if (files && files.length > 0) {
+                this._playExpressionFile(files[0]);
+                return true;
+            }
+        }
+        return this.resetExpressionToNeutral();
+    }
+
+    _expressionNameFromPath(file) {
+        try {
+            let name = file.split('/').pop().replace('.exp3.json', '');
+            if (name.startsWith('expression')) {
+                const num = name.replace('expression', '');
+                if (!isNaN(parseInt(num))) name = `表情${num}`;
+            }
+            return name;
+        } catch (_) {
+            return '未知表情';
+        }
+    }
+
+    _modelAssetBase() {
+        try {
+            const rawUrl = String(this.model?.internalModel?.settings?.url || '');
+            const decoded = decodeURIComponent(rawUrl)
+                .replace(/^\/?live-2d\//, '')
+                .replace(/^\/+/, '');
+            const modelJsonPath = path.isAbsolute(decoded) ? decoded : path.join(APP_ROOT, decoded);
+            if (fs.existsSync(modelJsonPath)) return path.dirname(modelJsonPath);
+        } catch (_) {}
+        return path.join(APP_ROOT, '2D', this.modelDirName || this.currentCharacter || '');
+    }
+
+    _collectExpressionDefinitions() {
+        const settings = this.model?.internalModel?.settings;
+        const assetBase = this._modelAssetBase();
+        const modelRoot = path.join(APP_ROOT, '2D', this.modelDirName || this.currentCharacter || '');
+        const definitions = [];
+        const seenFiles = new Set();
+
+        const addDefinition = (name, file) => {
+            const normalized = String(file || '').replace(/\\/g, '/');
+            if (!normalized || seenFiles.has(normalized)) return;
+            seenFiles.add(normalized);
+            definitions.push({
+                Name: name || path.basename(normalized).replace(/\.exp3\.json$/i, ''),
+                File: normalized
+            });
+        };
+
+        for (const item of settings?.expressions || []) {
+            if (item?.File) addDefinition(item.Name, item.File);
+        }
+        for (const item of settings?.json?.FileReferences?.Expressions || []) {
+            if (item?.File) addDefinition(item.Name, item.File);
+        }
+
+        const configuredFiles = new Set([this.idleExpression]);
+        for (const files of Object.values(this.expressionConfig || {})) {
+            if (Array.isArray(files)) {
+                for (const file of files) configuredFiles.add(file);
+            }
+        }
+        for (const file of configuredFiles) {
+            if (!file) continue;
+            const absolute = path.join(assetBase, String(file).replace(/\//g, path.sep));
+            if (fs.existsSync(absolute)) addDefinition(null, file);
+        }
+
+        for (const expressionPath of _scanFiles(modelRoot, '.exp3.json')) {
+            const rel = path.relative(assetBase, expressionPath).replace(/\\/g, '/');
+            addDefinition(null, rel);
+        }
+        return definitions;
+    }
+
+    _ensureExpressionDefinitions() {
+        if (this._expressionDefinitionsSynced) return true;
+        const motionManager = this.model?.internalModel?.motionManager;
+        const settings = this.model?.internalModel?.settings;
+        const PixiLive2D = globalThis.PIXI?.live2d || globalThis.window?.PIXI?.live2d;
+        if (!motionManager || !settings || !PixiLive2D?.Cubism4ExpressionManager) {
+            return false;
+        }
+
+        const definitions = this._collectExpressionDefinitions();
+        if (!definitions.length) return false;
+
+        settings.expressions = definitions;
+        settings.resolveURL = settings.resolveURL || function(url) { return url; };
+
+        let expressionManager = motionManager.expressionManager;
+        if (!expressionManager) {
+            try {
+                expressionManager = new PixiLive2D.Cubism4ExpressionManager(settings, {
+                    autoFocus: false,
+                    autoHitTest: false
+                });
+                motionManager.expressionManager = expressionManager;
+            } catch (e) {
+                console.warn('[EmotionEngine] 创建表情管理器失败:', e);
+                return false;
+            }
+        }
+
+        expressionManager.definitions = definitions;
+        expressionManager.expressions = expressionManager.expressions || [];
+        this._expressionDefinitionsSynced = true;
+        return true;
+    }
+
+    resetExpressionToNeutral() {
+        try {
+            this._ensureExpressionDefinitions();
+            const expressionManager = this.model?.internalModel?.motionManager?.expressionManager;
+            if (expressionManager && typeof expressionManager.resetExpression === 'function') {
+                expressionManager.resetExpression();
+                return true;
+            }
+        } catch (e) {
+            console.warn('[EmotionEngine] 重置表情失败:', e);
+        }
+        this.softResetToInitial();
+        return false;
+    }
+
+    clearNativeExpressions() {
+        return this.resetExpressionToNeutral();
+    }
+
+    playNativeExpressionFile(expressionFile) {
+        return this._playExpressionFile(expressionFile);
+    }
+
+    _playExpressionFile(expressionFile) {
+        if (!this.model || typeof this.model.expression !== 'function') return false;
+        try {
+            this._ensureExpressionDefinitions();
+            const originalName = expressionFile.split('/').pop().replace('.exp3.json', '');
+            this.model.expression(originalName);
+            return true;
+        } catch (e) {
+            console.error('[EmotionEngine] 播放表情失败:', e);
+            return false;
+        }
+    }
+
+    // 表情绑定（WebUI /bind-expression 走这里）：更新内存 + 持久化
+    bindExpressionToEmotion(emotion, expressionName) {
+        if (!this.expressionConfig) return false;
+
+        let files = this.expressionConfig[expressionName];
+        if (!files || files.length === 0) {
+            const guessed = `expressions/${expressionName}.exp3.json`;
+            this.expressionConfig[expressionName] = [guessed];
+            files = this.expressionConfig[expressionName];
+        }
+        if (!this.expressionConfig[emotion]) this.expressionConfig[emotion] = [];
+        for (const f of files) {
+            if (!this.expressionConfig[emotion].includes(f)) {
+                this.expressionConfig[emotion].push(f);
+            }
+        }
+        this._persistExpressionConfig();
+        return true;
+    }
+
+    _persistExpressionConfig() {
+        if (this._usingSidecar) {
+            // 写回 sidecar
+            const sidecar = _readJson(this._sidecarPath) || {};
+            sidecar.emotions = sidecar.emotions || {};
+            for (const emotion of EMOTION_WHITELIST) {
+                sidecar.emotions[emotion] = sidecar.emotions[emotion] || {};
+                sidecar.emotions[emotion].expressions = this.expressionConfig[emotion] || [];
+            }
+            sidecar.expressions_named = {};
+            for (const [name, files] of Object.entries(this.expressionConfig)) {
+                if (!EMOTION_WHITELIST.includes(name)) sidecar.expressions_named[name] = files;
+            }
+            _writeJson(this._sidecarPath, sidecar);
+            return;
+        }
+        // 写回旧版中央配置（修复旧实现 fetch('/api/...') 必然失败的保存路径）
+        const legacyPath = path.join(APP_ROOT, 'emotion_expressions.json');
+        const legacy = _readJson(legacyPath) || {};
+        if (!legacy[this.currentCharacter]) legacy[this.currentCharacter] = {};
+        legacy[this.currentCharacter].emotion_expressions = this.expressionConfig;
+        _writeJson(legacyPath, legacy);
+    }
+
+    // ============ TTS 时间轴 ============
+
+    // kind: 'motion' | 'expression' —— 门面各取所需，marker 结构与旧实现一致
+    prepareTextForTTS(text, kind) {
+        const { purifiedText, positions } = stripTags(text);
+        const config = kind === 'expression' ? this.expressionConfig : this.motionConfig;
+        const fileKey = kind === 'expression' ? 'expressionFiles' : 'motionFiles';
+
+        const emotionMarkers = [];
+        for (const p of positions) {
+            if (config && config[p.emotion]) {
+                emotionMarkers.push({
+                    position: p.position,
+                    emotion: p.emotion,
+                    [fileKey]: config[p.emotion]
+                });
+            }
+        }
+        return { text: purifiedText, emotionMarkers };
+    }
+
+    triggerEmotionByTextPosition(position, textLength, markers, kind) {
+        if (!markers || markers.length === 0) return;
+        const fire = (emotion) => {
+            if (kind === 'expression') {
+                this.triggerExpressionByEmotion(emotion);
+            } else {
+                this.playConfiguredEmotion(emotion);
+            }
+        };
+
+        for (let i = markers.length - 1; i >= 0; i--) {
+            const marker = markers[i];
+            if (position >= marker.position && position <= marker.position + 2) {
+                fire(marker.emotion);
+                markers.splice(i, 1);
+                break;
+            }
+        }
+        if (position >= textLength - 1 && markers.length > 0) {
+            for (const marker of markers) fire(marker.emotion);
+            markers.length = 0;
+        }
+    }
+
+    // ============ 门面（兼容旧双 Mapper 契约） ============
+
+    _createMotionFacade() {
+        const engine = this;
+        return {
+            get model() { return engine.model; },
+            get currentCharacter() { return engine.currentCharacter; },
+            getCurrentCharacterName: () => engine.getCurrentCharacterName(),
+            playConfiguredEmotion: (emotion) => engine.playConfiguredEmotion(emotion),
+            playMotion: (index) => engine.playMotionByIndex(index),
+            playDefaultMotion: () => engine.playDefaultMotion(),
+            prepareTextForTTS: (text) => engine.prepareTextForTTS(text, 'motion'),
+            triggerEmotionByTextPosition: (pos, len, markers) => engine.triggerEmotionByTextPosition(pos, len, markers, 'motion'),
+            reloadConfig: () => engine.reloadConfig(),
+            // 旧接口兼容（无外部消费者，保守保留）
+            triggerMotionByEmotion: (text) => {
+                const m = text.match(/<([^>]+)>/);
+                if (m && m[1]) engine.playConfiguredEmotion(m[1]);
+                return text.replace(/<[^>]+>/g, '').trim();
+            },
+            _engine: engine
+        };
+    }
+
+    _createExpressionFacade() {
+        const engine = this;
+        return {
+            get model() { return engine.model; },
+            get currentCharacter() { return engine.currentCharacter; },
+            get defaultExpression() { return engine.defaultExpression; },
+            set defaultExpression(v) { engine.defaultExpression = v; },
+            getCurrentCharacterName: () => engine.getCurrentCharacterName(),
+            setEmotionMapper: () => {},   // 旧接口，双 Mapper 互联已不需要
+            prepareTextForTTS: (text) => engine.prepareTextForTTS(text, 'expression'),
+            triggerEmotionByTextPosition: (pos, len, markers) => engine.triggerEmotionByTextPosition(pos, len, markers, 'expression'),
+            triggerExpressionByEmotion: (emotion) => engine.triggerExpressionByEmotion(emotion),
+            triggerExpression: (name) => engine.triggerExpression(name),
+            playExpression: (name) => engine.triggerExpression(name),
+            playDefaultExpression: () => engine.playDefaultExpression(),
+            bindExpressionToEmotion: (emotion, name) => engine.bindExpressionToEmotion(emotion, name),
+            reloadConfig: () => engine.reloadConfig(),
+            _engine: engine
+        };
+    }
+
+    destroy() {
+        if (this._softResetFrame) cancelAnimationFrame(this._softResetFrame);
+        if (this._simpleMotionFrame) cancelAnimationFrame(this._simpleMotionFrame);
+        this._softResetFrame = null;
+        this._simpleMotionFrame = null;
+        this.model = null;
+    }
+}
+
+module.exports = { EmotionEngine, LIPSYNC_PARAMS, EMOTION_WHITELIST };

--- a/live-2d/js/avatar/live2d/expression/au-driver.js
+++ b/live-2d/js/avatar/live2d/expression/au-driver.js
@@ -1,0 +1,415 @@
+'use strict';
+
+const { eventBus } = require('../../../core/event-bus.js');
+const { Events } = require('../../../core/events.js');
+const { logToTerminal } = require('../../../api-utils.js');
+const {
+    Live2DSemanticAdapter,
+    LIVE2D_MOUTH_OPEN_PARAMS,
+    LIVE2D_MOUTH_FALLBACK_PARAMS
+} = require('./semantic-actions.js');
+const {
+    EmotionKind,
+    emotionKindFromTag,
+    buildExpressionRuntime
+} = require('./expression-units.js');
+const { ExpressionHistory, ExpressionSolver } = require('./expression-solver.js');
+
+const EYE_LID_PARAM_PATTERN = /(?:ParamEye[LR]Open|PARAM_EYE_[LR]_OPEN|ParamEyeWide[LR]?|ParamEye[LR]Wide|PARAM_EYE_[LR]_WIDE|Eye[LR]_Squint|EyeWide)/;
+const MOUTH_OPEN_PARAM_IDS = new Set([
+    ...LIVE2D_MOUTH_OPEN_PARAMS,
+    ...LIVE2D_MOUTH_FALLBACK_PARAMS
+]);
+const EXTERNAL_DRIVE_EPSILON = 1e-4;
+
+class AuDriver {
+    constructor(model, config = {}) {
+        this.model = model;
+        this.coreModel = model?.internalModel?.coreModel || null;
+        this.config = config || {};
+        this.adapter = new Live2DSemanticAdapter(this.model, this.coreModel);
+        this.solver = null;
+        this.expressionRuntime = null;
+        this.emotionEngine = null;
+        this.states = new Map();
+        this.activeNative = { expression: [], motion: [] };
+        this._triggeredAt = 0;
+        this._releaseTimer = null;
+        this._eventsAttached = false;
+        this._boundRelease = () => this.release();
+        this._attachEvents();
+    }
+
+    setEmotionEngine(emotionEngine) {
+        this.emotionEngine = emotionEngine || null;
+        if (!this.emotionEngine || !this.coreModel) return false;
+
+        const runtime = buildExpressionRuntime({
+            modelDir: this.emotionEngine.getModelAssetRoot?.(),
+            motionConfig: this.emotionEngine.motionConfig,
+            expressionConfig: this.emotionEngine.expressionConfig,
+            logger: {
+                info: message => logToTerminal('info', message),
+                warn: message => logToTerminal('warn', message)
+            }
+        });
+        this.expressionRuntime = runtime;
+        this.adapter.updateBindings(runtime.profile.bindings);
+
+        const units = runtime.units.filter(unit => {
+            if (unit.kind !== 'semantic') return unit.enabled !== false;
+            const unresolved = unit.targets
+                .map(target => target.action)
+                .filter(action => !this.adapter.canResolve(action));
+            if (unresolved.length > 0) {
+                logToTerminal('info', `[AuDriver] 跳过不可映射 AU "${unit.id}": ${unresolved.join(', ')}`);
+                return false;
+            }
+            return unit.enabled !== false;
+        });
+
+        const solverConfig = getSolverConfig(this.config);
+        this.solver = new ExpressionSolver(units, runtime.rules, {
+            history: new ExpressionHistory(20),
+            topCandidates: 14,
+            typicalityFloor: solverConfig.typicalityFloor,
+            typicalityPower: solverConfig.typicalityPower
+        });
+        logToTerminal(
+            'info',
+            `[AuDriver] 已就绪: 可用 AU=${units.length}, 原生=${units.filter(unit => unit.kind === 'native').length}, 参数绑定=${this.adapter.bindings.size}`
+        );
+        return true;
+    }
+
+    refreshExpressionRuntime() {
+        return this.setEmotionEngine(this.emotionEngine);
+    }
+
+    updateConfig(config) {
+        this.config = config || {};
+        if (this.emotionEngine) this.refreshExpressionRuntime();
+    }
+
+    playEmotion(tag, options = {}) {
+        const emotion = emotionKindFromTag(tag) || coerceEmotion(tag);
+        if (!emotion || !this.solver || !this.isEnabled()) return false;
+
+        const solverConfig = getSolverConfig(this.config);
+        const selected = this.solver.solve({
+            emotion,
+            intensity: clamp(options.intensity ?? 1, 0, 1),
+            randomness: solverConfig.randomness,
+            diversity: solverConfig.diversity,
+            historyAvoidance: solverConfig.historyAvoidance,
+            maxUnits: solverConfig.maxUnits,
+            coreScore: 0.65
+        });
+        if (selected.units.length === 0) {
+            logToTerminal('warn', `[AuDriver] "${tag}" 没有可用的 AU，回退旧表情逻辑`);
+            return false;
+        }
+
+        const now = nowMs();
+        const transitionMs = nonNegative(options.transitionMs ?? options.transition_ms, solverConfig.transitionMs);
+        const platformTargets = this._resolvePlatformTargets(selected.semanticTargets);
+
+        this._clearReleaseTimer();
+        this._triggeredAt = now;
+        this._clearNative();
+        this._playNativeTriggers(selected.nativeTriggers);
+        this._transitionTo(platformTargets, now, transitionMs, solverConfig.neutralMs);
+        logToTerminal(
+            'info',
+            `[AuDriver] 解算 ${tag}: ${selected.units.map(unit => unit.id).join(' + ') || '中性'}`
+        );
+        return true;
+    }
+
+    release() {
+        if (this.states.size === 0 && this.activeNative.expression.length === 0 && this.activeNative.motion.length === 0) {
+            return;
+        }
+        const now = nowMs();
+        const solverConfig = getSolverConfig(this.config);
+        const remainingHoldMs = Math.max(0, solverConfig.minHoldMs - (now - this._triggeredAt));
+        if (remainingHoldMs > 0) {
+            if (!this._releaseTimer) {
+                this._releaseTimer = setTimeout(() => {
+                    this._releaseTimer = null;
+                    this._releaseNow();
+                }, remainingHoldMs);
+                this._releaseTimer.unref?.();
+            }
+            return;
+        }
+        this._releaseNow(now, solverConfig.neutralMs);
+    }
+
+    _releaseNow(now = nowMs(), neutralMs = getSolverConfig(this.config).neutralMs) {
+        this._clearReleaseTimer();
+        for (const state of this.states.values()) {
+            this._startRelease(state, now, neutralMs);
+        }
+        this._clearNative();
+    }
+
+    applyFrame(coreModel = this.coreModel, now = nowMs()) {
+        if (!coreModel || this.states.size === 0) return;
+
+        for (const [id, state] of [...this.states.entries()]) {
+            const current = readParameter(coreModel, state.info);
+            if (state.phase === 'transition') {
+                const progress = state.durationMs <= 0
+                    ? 1
+                    : clamp((now - state.startedAt) / state.durationMs, 0, 1);
+                const eased = ease(state.easing, progress);
+                state.value = lerp(state.from, state.target, eased);
+                state.weight = eased;
+                writeStateParameter(coreModel, state, state.value);
+                if (progress >= 1) {
+                    state.phase = 'hold';
+                    state.value = state.target;
+                    state.weight = 1;
+                }
+                continue;
+            }
+
+            if (state.phase === 'hold') {
+                state.value = state.target;
+                state.weight = 1;
+                writeStateParameter(coreModel, state, state.target);
+                continue;
+            }
+
+            const progress = state.releaseMs <= 0
+                ? 1
+                : clamp((now - state.releaseStartedAt) / state.releaseMs, 0, 1);
+            const hasExternalDrive = Number.isFinite(state.lastWritten)
+                && Math.abs(current - state.lastWritten) > EXTERNAL_DRIVE_EPSILON;
+            if (progress >= 1) {
+                state.weight = 0;
+                if (!hasExternalDrive) {
+                    state.value = state.neutral;
+                    writeStateParameter(coreModel, state, state.neutral);
+                }
+                this.states.delete(id);
+                continue;
+            }
+
+            const releaseValue = lerp(state.releaseFrom, state.neutral, ease('in_out_sine', progress));
+            state.value = hasExternalDrive
+                ? lerp(releaseValue, current, progress)
+                : releaseValue;
+            state.weight = 1 - progress;
+            writeStateParameter(coreModel, state, state.value);
+        }
+    }
+
+    activeWeightForParam(paramId) {
+        return clamp(this.states.get(paramId)?.weight || 0, 0, 1);
+    }
+
+    isEyeControlled() {
+        for (const [id, state] of this.states) {
+            if (state.weight > 0.01 && EYE_LID_PARAM_PATTERN.test(id)) return true;
+        }
+        return false;
+    }
+
+    isMouthControlled() {
+        for (const [id, state] of this.states) {
+            if (state.weight > 0.01 && MOUTH_OPEN_PARAM_IDS.has(id)) return true;
+        }
+        return false;
+    }
+
+    isEnabled() {
+        return this.config?.expression_solver?.enabled !== false;
+    }
+
+    destroy() {
+        this._clearReleaseTimer();
+        this._clearNative();
+        this.states.clear();
+        this.solver = null;
+        this._detachEvents();
+        this.emotionEngine = null;
+        this.coreModel = null;
+        this.model = null;
+    }
+
+    _resolvePlatformTargets(semanticTargets) {
+        const targets = new Map();
+        for (const semanticTarget of semanticTargets || []) {
+            for (const platformTarget of this.adapter.toPlatformTargets(semanticTarget.action, semanticTarget.value)) {
+                if (targets.has(platformTarget.id)) continue;
+                targets.set(platformTarget.id, {
+                    ...platformTarget,
+                    easing: semanticTarget.easing
+                });
+            }
+        }
+        return targets;
+    }
+
+    _transitionTo(nextTargets, now, transitionMs, neutralMs) {
+        for (const [id, state] of this.states) {
+            if (!nextTargets.has(id)) this._startRelease(state, now, neutralMs);
+        }
+
+        for (const [id, next] of nextTargets) {
+            const existing = this.states.get(id);
+            const from = existing ? existing.value : readParameter(this.coreModel, next);
+            this.states.set(id, {
+                info: next,
+                from,
+                target: next.value,
+                neutral: next.neutral,
+                value: from,
+                weight: existing?.weight || 0,
+                phase: transitionMs <= 0 ? 'hold' : 'transition',
+                startedAt: now,
+                durationMs: transitionMs,
+                easing: next.easing || 'in_out_sine',
+                releaseFrom: from,
+                releaseStartedAt: 0,
+                releaseMs: neutralMs,
+                lastWritten: existing?.lastWritten
+            });
+            if (transitionMs <= 0) {
+                const state = this.states.get(id);
+                state.value = next.value;
+                state.weight = 1;
+            }
+        }
+    }
+
+    _startRelease(state, now, releaseMs) {
+        if (state.phase === 'release') return;
+        state.releaseFrom = state.value;
+        state.releaseStartedAt = now;
+        state.releaseMs = releaseMs;
+        state.phase = 'release';
+        state.weight = 1;
+    }
+
+    _playNativeTriggers(triggers) {
+        const seenTypes = new Set();
+        for (const trigger of triggers || []) {
+            const nativeType = trigger?.nativeType;
+            if (seenTypes.has(nativeType)) continue;
+            let played = false;
+            if (nativeType === 'expression') {
+                played = this.emotionEngine?.playNativeExpressionFile?.(trigger.nativeRef) === true;
+            } else if (nativeType === 'motion') {
+                played = this.emotionEngine?.playNativeMotionFile?.(trigger.nativeRef) === true;
+            }
+            if (played) {
+                seenTypes.add(nativeType);
+                this.activeNative[nativeType].push(trigger.nativeRef);
+            }
+        }
+    }
+
+    _clearNative() {
+        if (this.activeNative.expression.length > 0) {
+            try { this.emotionEngine?.clearNativeExpressions?.(); } catch (_) {}
+        }
+        if (this.activeNative.motion.length > 0) {
+            try { this.emotionEngine?.stopNativeMotions?.(); } catch (_) {}
+        }
+        this.activeNative = { expression: [], motion: [] };
+    }
+
+    _clearReleaseTimer() {
+        if (!this._releaseTimer) return;
+        clearTimeout(this._releaseTimer);
+        this._releaseTimer = null;
+    }
+
+    _attachEvents() {
+        if (this._eventsAttached) return;
+        eventBus.on(Events.TTS_END, this._boundRelease);
+        eventBus.on(Events.TTS_INTERRUPTED, this._boundRelease);
+        this._eventsAttached = true;
+    }
+
+    _detachEvents() {
+        if (!this._eventsAttached) return;
+        eventBus.off(Events.TTS_END, this._boundRelease);
+        eventBus.off(Events.TTS_INTERRUPTED, this._boundRelease);
+        this._eventsAttached = false;
+    }
+}
+
+function getSolverConfig(config) {
+    const raw = config?.expression_solver || {};
+    return {
+        transitionMs: nonNegative(raw.transition_ms, 600),
+        neutralMs: nonNegative(raw.neutral_ms, 600),
+        minHoldMs: nonNegative(raw.min_hold_ms, 1500),
+        randomness: clamp(raw.randomness ?? 0.5, 0, 1),
+        diversity: clamp(raw.diversity ?? 0.6, 0, 1),
+        historyAvoidance: clamp(raw.history_avoidance ?? 0.7, 0, 1),
+        maxUnits: Math.max(1, Math.floor(Number(raw.max_units) || 5)),
+        typicalityFloor: clamp(raw.typicality_floor ?? 0.3, 0, 1),
+        typicalityPower: nonNegative(raw.typicality_power, 0.5)
+    };
+}
+
+function coerceEmotion(value) {
+    const emotion = String(value || '').trim();
+    return Object.values(EmotionKind).includes(emotion) ? emotion : null;
+}
+
+function readParameter(coreModel, info) {
+    try {
+        return Number(coreModel.getParameterValueByIndex(info.index));
+    } catch (_) {
+        return Number(info.defaultValue) || 0;
+    }
+}
+
+function writeParameter(coreModel, info, value) {
+    const written = clamp(value, info.minimum, info.maximum);
+    try {
+        coreModel.setParameterValueByIndex(info.index, written);
+        return written;
+    } catch (_) {
+        return NaN;
+    }
+}
+
+function writeStateParameter(coreModel, state, value) {
+    const written = writeParameter(coreModel, state.info, value);
+    if (Number.isFinite(written)) state.lastWritten = written;
+}
+
+function nowMs() {
+    return globalThis.performance?.now?.() ?? Date.now();
+}
+
+function ease(name, progress) {
+    const t = clamp(progress, 0, 1);
+    if (name === 'linear') return t;
+    if (name === 'out_cubic') return 1 - Math.pow(1 - t, 3);
+    return -(Math.cos(Math.PI * t) - 1) / 2;
+}
+
+function lerp(from, to, progress) {
+    return from + (to - from) * progress;
+}
+
+function nonNegative(value, fallback) {
+    const number = Number(value);
+    return Number.isFinite(number) && number >= 0 ? number : fallback;
+}
+
+function clamp(value, minimum, maximum) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return minimum;
+    return Math.max(minimum, Math.min(maximum, number));
+}
+
+module.exports = { AuDriver, getSolverConfig };

--- a/live-2d/js/avatar/live2d/expression/expression-solver.js
+++ b/live-2d/js/avatar/live2d/expression/expression-solver.js
@@ -1,0 +1,394 @@
+'use strict';
+
+const {
+    FacialRegion,
+    clampSemanticValue,
+    neutralValue,
+    semanticActionsOverlap
+} = require('./semantic-actions.js');
+
+const REGION_DIVERSITY_BONUS = 0.12;
+
+class ExpressionHistory {
+    constructor(capacity = 20) {
+        this.capacity = Math.max(1, Number(capacity) || 20);
+        this.queue = [];
+    }
+
+    recent() {
+        return this.queue.map(item => ({
+            unitIds: new Set(item.unitIds),
+            emotion: item.emotion
+        }));
+    }
+
+    record(signature) {
+        this.queue.unshift({
+            unitIds: new Set(signature.unitIds || []),
+            emotion: signature.emotion
+        });
+        if (this.queue.length > this.capacity) this.queue.length = this.capacity;
+    }
+
+    penalty(candidate, historyAvoidance) {
+        const avoidance = Math.max(0, Number(historyAvoidance) || 0);
+        if (this.queue.length === 0 || avoidance <= 0) return 0;
+
+        const candidateIds = new Set(candidate.unitIds || []);
+        let maxWeighted = 0;
+        for (let index = 0; index < this.queue.length; index++) {
+            const historical = this.queue[index];
+            const union = new Set([...candidateIds, ...historical.unitIds]);
+            const unitJaccard = union.size === 0
+                ? 1
+                : intersectionSize(candidateIds, historical.unitIds) / union.size;
+            const emotionMatch = candidate.emotion === historical.emotion ? 1 : 0;
+            const similarity = Math.pow(unitJaccard * 0.65 + emotionMatch * 0.35, 2);
+            const recencyWeight = Math.max(0, 1 - index / this.capacity);
+            maxWeighted = Math.max(maxWeighted, similarity * recencyWeight);
+        }
+        return maxWeighted * avoidance;
+    }
+
+    snapshot() {
+        return this.recent();
+    }
+
+    restore(snapshot) {
+        this.queue = Array.isArray(snapshot)
+            ? snapshot.slice(0, this.capacity).map(item => ({
+                unitIds: new Set(item.unitIds || []),
+                emotion: item.emotion
+            }))
+            : [];
+    }
+
+    get recentUnitIds() {
+        return new Set(this.queue.flatMap(item => [...item.unitIds]));
+    }
+
+    get length() {
+        return this.queue.length;
+    }
+}
+
+class ExpressionSolver {
+    constructor(units = [], rules = [], options = {}) {
+        this.units = Array.isArray(units) ? units : [];
+        this.rules = Array.isArray(rules) ? rules : [];
+        this.history = options.history || new ExpressionHistory(options.historyCapacity || 20);
+        this.topCandidates = Math.max(1, Number(options.topCandidates) || 14);
+        this.typicalityFloor = clamp(options.typicalityFloor ?? 0.3, 0, 1);
+        const typicalityPower = Number(options.typicalityPower);
+        this.typicalityPower = Number.isFinite(typicalityPower)
+            ? Math.max(0, typicalityPower)
+            : 0.5;
+        this.random = typeof options.random === 'function' ? options.random : Math.random;
+    }
+
+    solve(request) {
+        const result = this._run(normalizeRequest(request));
+        this.history.record({
+            unitIds: result.units.map(unit => unit.id),
+            emotion: result.emotion
+        });
+        return result;
+    }
+
+    preview(request) {
+        return this._run(normalizeRequest(request));
+    }
+
+    _run(request) {
+        const candidates = this._scoreUnits(request, this.history.recentUnitIds);
+        if (candidates.length === 0) return emptyResult(request.emotion);
+
+        const ranked = candidates
+            .map(candidate => ({ candidate, rank: this._rank(candidate, request) }))
+            .sort((left, right) => right.rank - left.rank)
+            .map(item => item.candidate);
+        return this._makeResult(this._buildCombo(ranked, request), request);
+    }
+
+    _resolveCorrelation(unit, emotion) {
+        if (Object.prototype.hasOwnProperty.call(unit.emotions || {}, emotion)) {
+            return {
+                correlation: Number(unit.emotions[emotion]) || 0,
+                viaBaseline: false
+            };
+        }
+        const baseline = Number(unit.baseline) || 0;
+        return { correlation: baseline, viaBaseline: baseline > 0 };
+    }
+
+    _peakCorrelation(unit) {
+        return Math.max(
+            Number(unit.baseline) || 0,
+            ...Object.values(unit.emotions || {}).map(value => Number(value) || 0)
+        );
+    }
+
+    _scoreUnits(request, recentIds) {
+        const scored = [];
+        for (const unit of this.units) {
+            if (!unit || unit.enabled === false) continue;
+            const { correlation, viaBaseline } = this._resolveCorrelation(unit, request.emotion);
+            if (correlation <= 0) continue;
+            const peak = this._peakCorrelation(unit);
+            const typicality = peak > 0 ? correlation / peak : 0;
+            if (typicality < this.typicalityFloor) continue;
+            const novelty = recentIds.has(unit.id) ? 0.35 : 1;
+            // 跨区域加分只给语义复合 AU：原生单元的多区域是定义使然，
+            // 吃加分会让预制文件（exp3 固定 3 区域 +0.24）系统性霸榜。
+            const regionBonus = unit.kind === 'semantic'
+                ? Math.max(0, new Set(unit.regions || []).size - 1) * REGION_DIVERSITY_BONUS
+                : 0;
+            scored.push({
+                unit,
+                score: correlation * 0.8 + novelty * 0.2 + regionBonus,
+                correlation,
+                typicality,
+                viaBaseline
+            });
+        }
+        return scored
+            .sort((left, right) => right.score - left.score)
+            .slice(0, this.topCandidates);
+    }
+
+    _rank(scored, request) {
+        if (request.randomness <= 0) return scored.score;
+        return scored.score + this._uniform(-1, 1) * request.randomness * request.diversity * 0.3;
+    }
+
+    _selectionDecision(scored, request) {
+        if (request.randomness <= 0) return true;
+        let base;
+        if (scored.score >= request.coreScore || scored.correlation >= 0.8) {
+            base = 1;
+        } else {
+            base = Math.min(
+                1,
+                Math.max(0.05, scored.score) * (0.55 + request.diversity * 0.55) + scored.correlation * 0.2
+            );
+        }
+        const probability = base * Math.pow(scored.typicality, this.typicalityPower);
+        return this._random() <= probability;
+    }
+
+    _buildCombo(ranked, request) {
+        const combo = [];
+        let unmet = 1;
+
+        for (const candidate of ranked) {
+            if (combo.length >= request.maxUnits) break;
+            if (candidate.viaBaseline && combo.length === 0) continue;
+            if (!this._selectionDecision(candidate, request)) continue;
+
+            const conflicts = this._findConflicts(candidate, combo, request.emotion);
+            if (conflicts.length > 0) {
+                if (candidate.viaBaseline) continue;
+                const strongest = Math.max(...conflicts.map(item => item.score));
+                const strongestWeight = Math.max(...conflicts.map(item => unitControlWeight(item.unit)));
+                const replaceMargin = 0.03 + Math.max(0, strongestWeight - unitControlWeight(candidate.unit)) * 0.08;
+                if (candidate.score <= strongest + replaceMargin) continue;
+                for (const conflict of conflicts) {
+                    const index = combo.indexOf(conflict);
+                    if (index >= 0) combo.splice(index, 1);
+                }
+            }
+
+            combo.push(candidate);
+            unmet *= 1 - clamp(candidate.correlation, 0, 1);
+            const coveredRegions = new Set(combo.flatMap(item => item.unit.regions || []));
+            if (
+                request.randomness > 0 &&
+                1 - unmet >= 0.9 &&
+                coveredRegions.size >= 2 &&
+                this._random() > request.diversity
+            ) {
+                break;
+            }
+        }
+        return combo;
+    }
+
+    _findConflicts(candidate, combo, emotion) {
+        const conflicts = [];
+        const candidateActions = candidate.unit.kind === 'semantic'
+            ? new Set(candidate.unit.targets.map(item => item.action))
+            : new Set();
+        const mutualExclusionIds = new Set();
+
+        for (const rule of this.rules) {
+            if (rule?.kind !== 'mutual_exclusion') continue;
+            if (Array.isArray(rule.emotions) && rule.emotions.length > 0 && !rule.emotions.includes(emotion)) continue;
+            const ids = Array.isArray(rule.unitIds) ? rule.unitIds : [];
+            if (ids.includes(candidate.unit.id)) {
+                for (const id of ids) mutualExclusionIds.add(id);
+            }
+        }
+
+        for (const existing of combo) {
+            if (mutualExclusionIds.has(existing.unit.id)) {
+                conflicts.push(existing);
+                continue;
+            }
+            if (
+                candidateActions.size > 0 &&
+                existing.unit.kind === 'semantic' &&
+                actionsOverlap(candidateActions, new Set(existing.unit.targets.map(item => item.action)))
+            ) {
+                conflicts.push(existing);
+            }
+        }
+        return conflicts;
+    }
+
+    _makeResult(combo, request) {
+        const units = combo.map(item => item.unit);
+        const semanticTargets = [];
+        const nativeTriggers = [];
+        const unitsByRegion = {};
+
+        for (const scored of combo) {
+            const unit = scored.unit;
+            for (const region of unit.regions || []) {
+                (unitsByRegion[region] ||= []).push(unit);
+            }
+            if (unit.kind === 'semantic') {
+                const linkedProgress = unit.linkedSampling ? this._random() : null;
+                for (const item of unit.targets) {
+                    const sampled = linkedProgress === null
+                        ? this._uniform(item.minValue, item.maxValue)
+                        : this._uniformAt(item.minValue, item.maxValue, linkedProgress);
+                    const neutral = neutralValue(item.action);
+                    semanticTargets.push({
+                        action: item.action,
+                        value: clampSemanticValue(
+                            item.action,
+                            neutral + (sampled - neutral) * request.intensity
+                        ),
+                        easing: unit.easing || 'out_cubic'
+                    });
+                }
+            } else if (unit.kind === 'native') {
+                nativeTriggers.push({
+                    nativeType: unit.nativeType,
+                    nativeRef: unit.nativeRef
+                });
+            }
+        }
+
+        return {
+            units,
+            emotion: request.emotion,
+            score: this._comboScore(combo, request),
+            semanticTargets,
+            nativeTriggers,
+            unitsByRegion
+        };
+    }
+
+    _comboScore(combo, request) {
+        if (combo.length === 0) return 0;
+        const unitIds = new Set(combo.map(item => item.unit.id));
+        const regions = new Set(combo.flatMap(item => item.unit.regions || []));
+        let unmet = 1;
+        for (const item of combo) unmet *= 1 - clamp(item.correlation, 0, 1);
+        const fulfillment = 1 - unmet;
+        const typicalityAverage = combo.reduce((sum, item) => sum + item.typicality, 0) / combo.length;
+        const regionSteps = Math.max(0, regions.size - 1);
+        const variety = regionSteps > 0
+            ? Math.log1p(regionSteps) / Math.log(Object.keys(FacialRegion).length) * 0.22 * typicalityAverage
+            : 0;
+        const sizePenalty = Math.max(0, combo.length - 1) * 0.04;
+        const historyPenalty = this.history.penalty({
+            unitIds,
+            emotion: request.emotion
+        }, request.historyAvoidance);
+        return fulfillment + variety - sizePenalty + this._ruleScore(unitIds, request.emotion) - historyPenalty;
+    }
+
+    _ruleScore(comboIds, emotion) {
+        let score = 0;
+        for (const rule of this.rules) {
+            if (rule?.kind !== 'bonus') continue;
+            if (Array.isArray(rule.emotions) && rule.emotions.length > 0 && !rule.emotions.includes(emotion)) continue;
+            const unitIds = Array.isArray(rule.unitIds) ? rule.unitIds : [];
+            if (unitIds.every(id => comboIds.has(id))) score += Number(rule.value) || 0;
+        }
+        return score;
+    }
+
+    _random() {
+        return clamp(Number(this.random()), 0, 1);
+    }
+
+    _uniform(minimum, maximum) {
+        return this._uniformAt(minimum, maximum, this._random());
+    }
+
+    _uniformAt(minimum, maximum, progress) {
+        const min = Number(minimum) || 0;
+        const max = Number(maximum) || 0;
+        return min + (max - min) * clamp(progress, 0, 1);
+    }
+}
+
+function normalizeRequest(request = {}) {
+    return {
+        emotion: String(request.emotion || ''),
+        intensity: clamp(request.intensity ?? 1, 0, 1),
+        randomness: clamp(request.randomness ?? 0.5, 0, 1),
+        diversity: clamp(request.diversity ?? 0.6, 0, 1),
+        historyAvoidance: clamp(request.historyAvoidance ?? request.history_avoidance ?? 0.7, 0, 1),
+        maxUnits: Math.max(1, Math.floor(Number(request.maxUnits ?? request.max_units) || 5)),
+        coreScore: clamp(request.coreScore ?? request.core_score ?? 0.65, 0, 1)
+    };
+}
+
+function emptyResult(emotion) {
+    return {
+        units: [],
+        emotion,
+        score: 0,
+        semanticTargets: [],
+        nativeTriggers: [],
+        unitsByRegion: {}
+    };
+}
+
+function actionsOverlap(left, right) {
+    for (const leftAction of left) {
+        for (const rightAction of right) {
+            if (semanticActionsOverlap(leftAction, rightAction)) return true;
+        }
+    }
+    return false;
+}
+
+function unitControlWeight(unit) {
+    return unit?.kind === 'semantic'
+        ? Math.max(1, unit.targets?.length || 0)
+        : Math.max(1, unit?.regions?.length || 0);
+}
+
+function intersectionSize(left, right) {
+    let count = 0;
+    for (const item of left) {
+        if (right.has(item)) count++;
+    }
+    return count;
+}
+
+function clamp(value, minimum, maximum) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return minimum;
+    return Math.max(minimum, Math.min(maximum, number));
+}
+
+module.exports = {
+    ExpressionHistory,
+    ExpressionSolver
+};

--- a/live-2d/js/avatar/live2d/expression/expression-units.js
+++ b/live-2d/js/avatar/live2d/expression/expression-units.js
@@ -1,0 +1,523 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+    FacialRegion,
+    SemanticAction,
+    semanticActionRegion
+} = require('./semantic-actions.js');
+
+const EmotionKind = Object.freeze({
+    JOY: 'joy',
+    SADNESS: 'sadness',
+    ANGER: 'anger',
+    SURPRISE: 'surprise',
+    PLAYFUL: 'playful',
+    SMUG: 'smug',
+    WRY: 'wry',
+    SHY: 'shy'
+});
+
+const EMOTION_KIND_BY_TAG = Object.freeze({
+    开心: EmotionKind.JOY,
+    生气: EmotionKind.ANGER,
+    难过: EmotionKind.SADNESS,
+    惊讶: EmotionKind.SURPRISE,
+    害羞: EmotionKind.SHY,
+    俏皮: EmotionKind.PLAYFUL
+});
+
+const PROFILE_FILE_NAME = 'expression_profile.json';
+const NATIVE_SCORE = 0.85;
+
+function target(action, minValue, maxValue) {
+    return { action, minValue, maxValue };
+}
+
+function semanticUnit(id, targets, emotions, options = {}) {
+    return {
+        id,
+        kind: 'semantic',
+        enabled: options.enabled !== false,
+        targets,
+        emotions: { ...emotions },
+        baseline: Number(options.baseline) || 0,
+        easing: typeof options.easing === 'string' ? options.easing : 'in_out_sine',
+        linkedSampling: options.linkedSampling === true,
+        regions: [...new Set(targets.map(item => semanticActionRegion(item.action)).filter(Boolean))]
+    };
+}
+
+function nativeUnit(id, nativeType, nativeRef, regions, emotions, options = {}) {
+    return {
+        id,
+        kind: 'native',
+        enabled: options.enabled !== false,
+        nativeType,
+        nativeRef,
+        regions: [...new Set(regions)],
+        emotions: { ...emotions },
+        baseline: Number(options.baseline) || 0
+    };
+}
+
+function defaultSemanticUnits() {
+    const E = EmotionKind;
+    const A = SemanticAction;
+    return [
+        semanticUnit('皱眉', [target(A.BROW_HEIGHT, 0, 0.1)], {
+            [E.ANGER]: 1,
+            [E.SADNESS]: 1,
+            [E.WRY]: 1
+        }),
+        semanticUnit('轻微抬眉', [target(A.BROW_HEIGHT, 0.5, 0.7)], {
+            [E.JOY]: 0.58,
+            [E.PLAYFUL]: 0.45,
+            [E.SMUG]: 0.5
+        }),
+        semanticUnit('抬眉', [target(A.BROW_HEIGHT, 0.7, 1)], {
+            [E.JOY]: 0.69,
+            [E.SURPRISE]: 1
+        }),
+        semanticUnit('闭眼', [target(A.EYE_OPEN, 0, 0)], {
+            [E.SADNESS]: 0.23,
+            [E.WRY]: 0.34,
+            [E.SHY]: 0.3
+        }),
+        semanticUnit('眯眼', [target(A.EYE_OPEN, 0.2, 0.4)], {
+            [E.JOY]: 0.76,
+            [E.ANGER]: 0.88,
+            [E.SADNESS]: 0.79,
+            [E.SMUG]: 0.7
+        }),
+        semanticUnit('睁眼', [target(A.EYE_OPEN, 0.75, 1)], {
+            [E.JOY]: 0.2,
+            [E.SURPRISE]: 1
+        }),
+        semanticUnit('瞪眼', [target(A.EYE_WIDE, 0.5, 1)], {
+            [E.SURPRISE]: 1,
+            [E.ANGER]: 0.4
+        }),
+        semanticUnit('wink 左眼', [
+            target(A.EYE_OPEN_LEFT, 0, 0),
+            target(A.EYE_OPEN_RIGHT, 0.75, 1)
+        ], {
+            [E.JOY]: 0.58,
+            [E.PLAYFUL]: 1
+        }),
+        semanticUnit('wink 右眼', [
+            target(A.EYE_OPEN_LEFT, 0.75, 1),
+            target(A.EYE_OPEN_RIGHT, 0, 0)
+        ], {
+            [E.JOY]: 0.58,
+            [E.PLAYFUL]: 1
+        }),
+        semanticUnit('目移', [target(A.EYE_GAZE_X, -1, 1)], {
+            [E.SADNESS]: 0.72,
+            [E.SHY]: 0.7,
+            [E.WRY]: 0.8
+        }),
+        semanticUnit('眼睛下看', [target(A.EYE_GAZE_Y, -1, -0.7)], {
+            [E.SADNESS]: 0.8,
+            [E.WRY]: 0.8,
+            [E.SHY]: 0.4
+        }),
+        semanticUnit('眼睛上看', [target(A.EYE_GAZE_Y, 0.7, 1)], {}),
+        semanticUnit('嘴角上扬', [target(A.MOUTH_SMILE, 0.6, 1)], {
+            [E.JOY]: 0.82,
+            [E.PLAYFUL]: 0.9,
+            [E.SMUG]: 0.65,
+            [E.WRY]: 0.7,
+            [E.SHY]: 0.45
+        }),
+        semanticUnit('嘴角下撇', [target(A.MOUTH_SMILE, 0, 0.4)], {
+            [E.SADNESS]: 0.92,
+            [E.ANGER]: 0.44,
+            [E.SMUG]: 0.45,
+            [E.SURPRISE]: 1
+        }),
+        semanticUnit('闭嘴', [target(A.MOUTH_OPEN, 0, 0.1)], {
+            [E.ANGER]: 0.3,
+            [E.SADNESS]: 0.25,
+            [E.SURPRISE]: 0.7
+        }),
+        semanticUnit('嘴巴微张', [target(A.MOUTH_OPEN, 0.15, 0.2)], {
+            [E.JOY]: 0.76,
+            [E.SADNESS]: 0.16,
+            [E.SURPRISE]: 0.6,
+            [E.PLAYFUL]: 0.4,
+            [E.SMUG]: 0.8
+        }),
+        semanticUnit('嘴巴张大', [target(A.MOUTH_OPEN, 0.6, 1)], {
+            [E.JOY]: 0.25,
+            [E.SURPRISE]: 0.8
+        }),
+        semanticUnit('下颌张开', [target(A.MOUTH_JAW_OPEN, 0.5, 1)], {
+            [E.SURPRISE]: 1,
+            [E.JOY]: 0.3
+        }),
+        semanticUnit('抿嘴', [
+            target(A.MOUTH_SMILE, 0.4, 0.4),
+            target(A.MOUTH_OPEN, 0, 0)
+        ], {
+            [E.ANGER]: 0.86,
+            [E.SADNESS]: 0.34
+        }),
+        semanticUnit('拢嘴', [target(A.MOUTH_FUNNEL, 0.5, 1)], {
+            [E.SMUG]: 0.4
+        }),
+        semanticUnit('撅嘴', [target(A.MOUTH_PUCKER, 0.4, 1)], {
+            [E.SHY]: 0.55,
+            [E.SADNESS]: 0.3,
+            [E.WRY]: 0.6
+        }),
+        semanticUnit('咧嘴', [target(A.MOUTH_PUCKER, -1, -0.4)], {
+            [E.JOY]: 0.4,
+            [E.SMUG]: 0.35,
+            [E.WRY]: 0.6
+        }),
+        semanticUnit('耸嘴', [target(A.MOUTH_SHRUG, 0.4, 1)], {
+            [E.WRY]: 0.62,
+            [E.ANGER]: 0.35,
+            [E.SADNESS]: 0.28,
+            [E.SMUG]: 0.3
+        }),
+        semanticUnit('鼓腮', [target(A.MOUTH_CHEEK_PUFF, 0.5, 1)], {
+            [E.SHY]: 0.7,
+            [E.ANGER]: 0.9
+        }),
+        semanticUnit('微微吐舌', [target(A.MOUTH_TONGUE_OUT, 0.3, 0.6)], {
+            [E.PLAYFUL]: 0.9,
+            [E.SMUG]: 0.45,
+            [E.JOY]: 0.35,
+            [E.SHY]: 0.25
+        }),
+        semanticUnit('嘴移', [target(A.MOUTH_X, -1, 1)], {
+            [E.ANGER]: 0.6,
+            [E.PLAYFUL]: 0.7,
+            [E.SMUG]: 0.6,
+            [E.SURPRISE]: 0.5
+        }),
+        semanticUnit('嘴部居中', [target(A.MOUTH_X, 0, 0)], {
+            [E.SADNESS]: 0.24
+        }),
+        semanticUnit('抬头', [target(A.HEAD_PITCH, 0.3, 0.7)], {}, {
+            baseline: 0.05
+        }),
+        semanticUnit('低头', [target(A.HEAD_PITCH, -0.7, -0.3)], {
+            [E.SADNESS]: 0.8,
+            [E.ANGER]: 0.8,
+            [E.SHY]: 0.55,
+            [E.WRY]: 0.8
+        }),
+        semanticUnit('歪头', [target(A.HEAD_ROLL, -0.5, 0.5)], {
+            [E.JOY]: 0.45,
+            [E.PLAYFUL]: 0.8,
+            [E.SMUG]: 0.55,
+            [E.SHY]: 0.5
+        }, {
+            baseline: 0.25
+        }),
+        semanticUnit('转头', [target(A.HEAD_YAW, -0.5, 0.5)], {}, {
+            baseline: 0.2
+        }),
+        semanticUnit('阴险抬眼', [
+            target(A.HEAD_PITCH, -0.6, -0.3),
+            target(A.EYE_GAZE_Y, 0.6, 1)
+        ], {
+            [E.SMUG]: 0.8,
+            [E.ANGER]: 0.65
+        }),
+        semanticUnit('身体前倾', [target(A.BODY_ANGLE_Y, 0.45, 0.75)], {
+            [E.JOY]: 0.75,
+            [E.ANGER]: 0.85,
+            [E.PLAYFUL]: 0.8
+        }),
+        semanticUnit('垂头含胸', [
+            target(A.HEAD_PITCH, -0.6, -0.3),
+            target(A.BODY_ANGLE_Y, -0.65, -0.35)
+        ], {
+            [E.SADNESS]: 0.75,
+            [E.WRY]: 0.7,
+            [E.SHY]: 0.5
+        }),
+        semanticUnit('惊讶后仰', [
+            target(A.BODY_ANGLE_Y, -0.75, -0.45),
+            target(A.HEAD_PITCH, 0.2, 0.5)
+        ], {
+            [E.SURPRISE]: 0.9
+        }),
+        semanticUnit('身体侧摆', [target(A.BODY_ANGLE_Z, -0.55, 0.55)], {}, {
+            baseline: 0.25
+        }),
+        semanticUnit('扭身避视', [
+            target(A.BODY_ANGLE_X, -0.65, 0.65),
+            target(A.EYE_GAZE_X, -1, 1)
+        ], {
+            [E.SHY]: 0.6,
+            [E.WRY]: 0.5
+        }, {
+            linkedSampling: true
+        })
+    ];
+}
+
+function defaultRules() {
+    return [];
+}
+
+function emotionKindFromTag(tag) {
+    return EMOTION_KIND_BY_TAG[String(tag || '').trim()] || null;
+}
+
+function buildNativeExpressionUnits(motionConfig = {}, expressionConfig = {}) {
+    const unitsByKey = new Map();
+
+    const add = (config, nativeType) => {
+        for (const [tag, files] of Object.entries(config || {})) {
+            const emotion = emotionKindFromTag(tag);
+            if (!emotion || !Array.isArray(files)) continue;
+            for (const rawFile of files) {
+                const nativeRef = normalizeFileRef(rawFile);
+                if (!nativeRef) continue;
+                const key = `${nativeType}:${nativeRef.toLowerCase()}`;
+                let unit = unitsByKey.get(key);
+                if (!unit) {
+                    unit = nativeUnit(
+                        `原生${nativeType === 'motion' ? '动作' : '表情'}:${nativeRef}`,
+                        nativeType,
+                        nativeRef,
+                        nativeType === 'motion'
+                            ? [FacialRegion.HEAD, FacialRegion.BODY]
+                            : [FacialRegion.BROW, FacialRegion.EYE, FacialRegion.MOUTH],
+                        {}
+                    );
+                    unitsByKey.set(key, unit);
+                }
+                unit.emotions[emotion] = Math.max(Number(unit.emotions[emotion]) || 0, NATIVE_SCORE);
+            }
+        }
+    };
+
+    add(motionConfig, 'motion');
+    add(expressionConfig, 'expression');
+    return [...unitsByKey.values()];
+}
+
+function nativeExclusionRules(nativeUnits) {
+    const rules = [];
+    for (const nativeType of ['motion', 'expression']) {
+        const ids = nativeUnits
+            .filter(unit => unit.nativeType === nativeType)
+            .map(unit => unit.id);
+        if (ids.length > 1) {
+            rules.push({
+                kind: 'mutual_exclusion',
+                id: `native-${nativeType}-exclusive`,
+                unitIds: ids,
+                emotions: []
+            });
+        }
+    }
+    return rules;
+}
+
+function createExpressionProfileSeed() {
+    const units = {};
+    for (const unit of defaultSemanticUnits()) {
+        units[unit.id] = {
+            enabled: unit.enabled !== false,
+            emotions: { ...unit.emotions },
+            baseline: unit.baseline,
+            easing: unit.easing
+        };
+    }
+    return {
+        version: 1,
+        bindings: {},
+        units,
+        rules: []
+    };
+}
+
+function loadExpressionProfile(modelDir, logger = console) {
+    const seed = createExpressionProfileSeed();
+    if (!modelDir) return { profile: seed, path: null, seeded: false };
+    const filePath = path.join(modelDir, PROFILE_FILE_NAME);
+    if (!fs.existsSync(filePath)) {
+        logger?.info?.(`[AuDriver] 未找到模型 AU 配置，使用内置默认值: ${filePath}`);
+        return { profile: seed, path: filePath, seeded: false };
+    }
+
+    try {
+        const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        return {
+            profile: normalizeProfile(parsed, seed),
+            path: filePath,
+            seeded: false
+        };
+    } catch (error) {
+        logger?.warn?.(`[AuDriver] 读取模型 AU 配置失败，使用内置默认值: ${error.message}`);
+        return { profile: seed, path: filePath, seeded: false };
+    }
+}
+
+function buildExpressionRuntime({ modelDir, motionConfig, expressionConfig, logger = console } = {}) {
+    const loaded = loadExpressionProfile(modelDir, logger);
+    const semanticUnits = applyUnitOverrides(defaultSemanticUnits(), loaded.profile.units);
+    const nativeUnits = [
+        ...buildNativeExpressionUnits(motionConfig, expressionConfig),
+        ...normalizeCustomNativeUnits(loaded.profile.native_units)
+    ];
+    const rules = [
+        ...defaultRules(),
+        ...nativeExclusionRules(nativeUnits),
+        ...normalizeRules(loaded.profile.rules)
+    ];
+    return {
+        profile: loaded.profile,
+        profilePath: loaded.path,
+        seeded: loaded.seeded,
+        units: [...semanticUnits, ...nativeUnits],
+        rules
+    };
+}
+
+function normalizeProfile(raw, fallback) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return fallback;
+    return {
+        version: Number(raw.version) || fallback.version,
+        bindings: isPlainObject(raw.bindings) ? raw.bindings : {},
+        units: isPlainObject(raw.units) ? raw.units : fallback.units,
+        native_units: Array.isArray(raw.native_units) ? raw.native_units : [],
+        rules: Array.isArray(raw.rules) ? raw.rules : []
+    };
+}
+
+function applyUnitOverrides(units, overrides) {
+    return units.map(unit => {
+        const override = overrides?.[unit.id];
+        if (!isPlainObject(override)) return unit;
+        const targets = Array.isArray(override.targets)
+            ? normalizeTargets(override.targets, unit.targets)
+            : unit.targets;
+        return {
+            ...unit,
+            enabled: typeof override.enabled === 'boolean' ? override.enabled : unit.enabled,
+            targets,
+            emotions: isPlainObject(override.emotions)
+                ? { ...unit.emotions, ...normalizeEmotionScores(override.emotions) }
+                : unit.emotions,
+            baseline: Number.isFinite(Number(override.baseline)) ? Number(override.baseline) : unit.baseline,
+            easing: typeof override.easing === 'string' && override.easing ? override.easing : unit.easing,
+            regions: [...new Set(targets.map(item => semanticActionRegion(item.action)).filter(Boolean))]
+        };
+    });
+}
+
+function normalizeTargets(rawTargets, fallback) {
+    const targets = rawTargets
+        .map(item => {
+            if (!isPlainObject(item) || !semanticActionRegion(item.action)) return null;
+            const minValue = Number(item.min_value ?? item.minValue);
+            const maxValue = Number(item.max_value ?? item.maxValue);
+            if (!Number.isFinite(minValue) || !Number.isFinite(maxValue)) return null;
+            return target(item.action, minValue, maxValue);
+        })
+        .filter(Boolean);
+    return targets.length > 0 ? targets : fallback;
+}
+
+function normalizeCustomNativeUnits(rawUnits) {
+    return (Array.isArray(rawUnits) ? rawUnits : [])
+        .map(item => {
+            if (!isPlainObject(item) || !item.id || !item.native_ref || !item.native_type) return null;
+            const nativeType = item.native_type === 'motion' ? 'motion' : item.native_type === 'expression' ? 'expression' : null;
+            if (!nativeType) return null;
+            const regions = Array.isArray(item.regions)
+                ? item.regions.filter(region => Object.values(FacialRegion).includes(region))
+                : nativeType === 'motion'
+                    ? [FacialRegion.HEAD, FacialRegion.BODY]
+                    : [FacialRegion.BROW, FacialRegion.EYE, FacialRegion.MOUTH];
+            return nativeUnit(
+                String(item.id),
+                nativeType,
+                normalizeFileRef(item.native_ref),
+                regions,
+                normalizeEmotionScores(item.emotions),
+                {
+                    enabled: item.enabled !== false,
+                    baseline: item.baseline
+                }
+            );
+        })
+        .filter(Boolean);
+}
+
+function normalizeRules(rawRules) {
+    return rawRules
+        .map(rule => {
+            if (!isPlainObject(rule) || !rule.id) return null;
+            const kind = rule.kind;
+            const unitIds = Array.isArray(rule.unit_ids ?? rule.unitIds)
+                ? [...new Set((rule.unit_ids ?? rule.unitIds).map(String).filter(Boolean))]
+                : [];
+            if (kind === 'mutual_exclusion' && unitIds.length > 1) {
+                return {
+                    kind,
+                    id: String(rule.id),
+                    unitIds,
+                    emotions: normalizeEmotionList(rule.emotions)
+                };
+            }
+            if (kind === 'bonus' && unitIds.length > 0 && Number.isFinite(Number(rule.value))) {
+                return {
+                    kind,
+                    id: String(rule.id),
+                    unitIds,
+                    value: Number(rule.value),
+                    emotions: normalizeEmotionList(rule.emotions)
+                };
+            }
+            return null;
+        })
+        .filter(Boolean);
+}
+
+function normalizeEmotionScores(raw) {
+    const result = {};
+    for (const [emotion, score] of Object.entries(raw || {})) {
+        if (!Object.values(EmotionKind).includes(emotion)) continue;
+        const value = Number(score);
+        if (Number.isFinite(value)) result[emotion] = value;
+    }
+    return result;
+}
+
+function normalizeEmotionList(raw) {
+    return Array.isArray(raw)
+        ? [...new Set(raw.filter(emotion => Object.values(EmotionKind).includes(emotion)))]
+        : [];
+}
+
+function normalizeFileRef(value) {
+    return typeof value === 'string' ? value.replace(/\\/g, '/').trim() : '';
+}
+
+function isPlainObject(value) {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+module.exports = {
+    EmotionKind,
+    EMOTION_KIND_BY_TAG,
+    PROFILE_FILE_NAME,
+    emotionKindFromTag,
+    defaultSemanticUnits,
+    defaultRules,
+    buildNativeExpressionUnits,
+    createExpressionProfileSeed,
+    loadExpressionProfile,
+    buildExpressionRuntime
+};

--- a/live-2d/js/avatar/live2d/expression/semantic-actions.js
+++ b/live-2d/js/avatar/live2d/expression/semantic-actions.js
@@ -1,0 +1,420 @@
+'use strict';
+
+const FacialRegion = Object.freeze({
+    BROW: 'brow',
+    EYE: 'eye',
+    MOUTH: 'mouth',
+    HEAD: 'head',
+    BODY: 'body'
+});
+
+const LIVE2D_MOUTH_OPEN_PARAMS = Object.freeze([
+    'ParamMouthOpenY',
+    'PARAM_MOUTH_OPEN_Y',
+    'ParamMouthOpen'
+]);
+const LIVE2D_MOUTH_FALLBACK_PARAMS = Object.freeze(['ParamA']);
+
+const SemanticAction = Object.freeze({
+    BROW_HEIGHT: 'brow.height',
+    BROW_HEIGHT_LEFT: 'brow.height.left',
+    BROW_HEIGHT_RIGHT: 'brow.height.right',
+    EYE_OPEN: 'eye.open',
+    EYE_OPEN_LEFT: 'eye.open.left',
+    EYE_OPEN_RIGHT: 'eye.open.right',
+    EYE_GAZE_X: 'eye.gaze.x',
+    EYE_GAZE_Y: 'eye.gaze.y',
+    EYE_WIDE: 'eye.wide',
+    MOUTH_OPEN: 'mouth.open',
+    MOUTH_SMILE: 'mouth.smile',
+    MOUTH_X: 'mouth.x',
+    MOUTH_JAW_OPEN: 'mouth.jaw.open',
+    MOUTH_FUNNEL: 'mouth.funnel',
+    MOUTH_PUCKER: 'mouth.pucker',
+    MOUTH_SHRUG: 'mouth.shrug',
+    MOUTH_CHEEK_PUFF: 'mouth.cheek.puff',
+    MOUTH_TONGUE_OUT: 'mouth.tongue.out',
+    HEAD_YAW: 'head.yaw',
+    HEAD_PITCH: 'head.pitch',
+    HEAD_ROLL: 'head.roll',
+    BODY_ANGLE_X: 'body.angle.x',
+    BODY_ANGLE_Y: 'body.angle.y',
+    BODY_ANGLE_Z: 'body.angle.z'
+});
+
+const DEFAULT_SEMANTIC_ACTION_SPECS = Object.freeze([
+    spec(SemanticAction.BROW_HEIGHT, 0, 1, FacialRegion.BROW, 0.5, [
+        SemanticAction.BROW_HEIGHT_LEFT,
+        SemanticAction.BROW_HEIGHT_RIGHT
+    ]),
+    spec(SemanticAction.BROW_HEIGHT_LEFT, 0, 1, FacialRegion.BROW, 0.5, [SemanticAction.BROW_HEIGHT]),
+    spec(SemanticAction.BROW_HEIGHT_RIGHT, 0, 1, FacialRegion.BROW, 0.5, [SemanticAction.BROW_HEIGHT]),
+    spec(SemanticAction.EYE_OPEN, 0, 1, FacialRegion.EYE, 0.8, [
+        SemanticAction.EYE_OPEN_LEFT,
+        SemanticAction.EYE_OPEN_RIGHT
+    ]),
+    spec(SemanticAction.EYE_OPEN_LEFT, 0, 1, FacialRegion.EYE, 0.8, [SemanticAction.EYE_OPEN]),
+    spec(SemanticAction.EYE_OPEN_RIGHT, 0, 1, FacialRegion.EYE, 0.8, [SemanticAction.EYE_OPEN]),
+    spec(SemanticAction.EYE_GAZE_X, -1, 1, FacialRegion.EYE),
+    spec(SemanticAction.EYE_GAZE_Y, -1, 1, FacialRegion.EYE),
+    spec(SemanticAction.EYE_WIDE, 0, 1, FacialRegion.EYE),
+    spec(SemanticAction.MOUTH_OPEN, 0, 1, FacialRegion.MOUTH),
+    spec(SemanticAction.MOUTH_SMILE, 0, 1, FacialRegion.MOUTH, 0.5),
+    spec(SemanticAction.MOUTH_X, -1, 1, FacialRegion.MOUTH),
+    spec(SemanticAction.MOUTH_JAW_OPEN, 0, 1, FacialRegion.MOUTH),
+    spec(SemanticAction.MOUTH_FUNNEL, 0, 1, FacialRegion.MOUTH),
+    spec(SemanticAction.MOUTH_PUCKER, -1, 1, FacialRegion.MOUTH),
+    spec(SemanticAction.MOUTH_SHRUG, 0, 1, FacialRegion.MOUTH),
+    spec(SemanticAction.MOUTH_CHEEK_PUFF, 0, 1, FacialRegion.MOUTH),
+    spec(SemanticAction.MOUTH_TONGUE_OUT, 0, 1, FacialRegion.MOUTH),
+    spec(SemanticAction.HEAD_YAW, -1, 1, FacialRegion.HEAD),
+    spec(SemanticAction.HEAD_PITCH, -1, 1, FacialRegion.HEAD),
+    spec(SemanticAction.HEAD_ROLL, -1, 1, FacialRegion.HEAD),
+    spec(SemanticAction.BODY_ANGLE_X, -1, 1, FacialRegion.BODY),
+    spec(SemanticAction.BODY_ANGLE_Y, -1, 1, FacialRegion.BODY),
+    spec(SemanticAction.BODY_ANGLE_Z, -1, 1, FacialRegion.BODY)
+]);
+
+const SPEC_BY_ACTION = new Map(DEFAULT_SEMANTIC_ACTION_SPECS.map(item => [item.id, item]));
+
+// Each inner array describes one compatible parameter layout. The resolver
+// prefers a complete layout and falls back to any usable partial layout.
+const DEFAULT_LIVE2D_BINDINGS = Object.freeze({
+    [SemanticAction.BROW_HEIGHT]: [
+        ['ParamBrowLY', 'ParamBrowRY'],
+        ['PARAM_BROW_L_Y', 'PARAM_BROW_R_Y']
+    ],
+    [SemanticAction.BROW_HEIGHT_LEFT]: [
+        ['ParamBrowLY'],
+        ['PARAM_BROW_L_Y']
+    ],
+    [SemanticAction.BROW_HEIGHT_RIGHT]: [
+        ['ParamBrowRY'],
+        ['PARAM_BROW_R_Y']
+    ],
+    [SemanticAction.EYE_OPEN]: [
+        ['ParamEyeLOpen', 'ParamEyeROpen'],
+        ['PARAM_EYE_L_OPEN', 'PARAM_EYE_R_OPEN']
+    ],
+    [SemanticAction.EYE_OPEN_LEFT]: [
+        ['ParamEyeLOpen'],
+        ['PARAM_EYE_L_OPEN']
+    ],
+    [SemanticAction.EYE_OPEN_RIGHT]: [
+        ['ParamEyeROpen'],
+        ['PARAM_EYE_R_OPEN']
+    ],
+    [SemanticAction.EYE_GAZE_X]: [
+        ['ParamEyeBallX'],
+        ['PARAM_EYE_BALL_X']
+    ],
+    [SemanticAction.EYE_GAZE_Y]: [
+        ['ParamEyeBallY'],
+        ['PARAM_EYE_BALL_Y']
+    ],
+    [SemanticAction.EYE_WIDE]: [
+        ['ParamEyeWideL', 'ParamEyeWideR'],
+        ['ParamEyeLWide', 'ParamEyeRWide'],
+        ['PARAM_EYE_L_WIDE', 'PARAM_EYE_R_WIDE'],
+        ['ParamEyeWide']
+    ],
+    [SemanticAction.MOUTH_OPEN]: [
+        ...LIVE2D_MOUTH_OPEN_PARAMS.map(id => [id]),
+        ...LIVE2D_MOUTH_FALLBACK_PARAMS.map(id => [id])
+    ],
+    [SemanticAction.MOUTH_SMILE]: [
+        ['ParamMouthForm'],
+        ['PARAM_MOUTH_FORM']
+    ],
+    [SemanticAction.MOUTH_X]: [
+        ['ParamMouthX'],
+        ['PARAM_MOUTH_X']
+    ],
+    [SemanticAction.MOUTH_JAW_OPEN]: [
+        ['ParamJawOpen'],
+        ['PARAM_JAW_OPEN']
+    ],
+    [SemanticAction.MOUTH_FUNNEL]: [
+        ['ParamMouthFunnel'],
+        ['PARAM_MOUTH_FUNNEL']
+    ],
+    [SemanticAction.MOUTH_PUCKER]: [
+        ['ParamMouthPuckerWiden'],
+        ['PARAM_MOUTH_PUCKER_WIDEN']
+    ],
+    [SemanticAction.MOUTH_SHRUG]: [
+        ['ParamMouthShrug'],
+        ['PARAM_MOUTH_SHRUG']
+    ],
+    [SemanticAction.MOUTH_CHEEK_PUFF]: [
+        ['ParamCheeckPuff'],
+        ['ParamCheekPuff'],
+        ['ParamCheek']
+    ],
+    [SemanticAction.MOUTH_TONGUE_OUT]: [
+        ['ParamTongueOut'],
+        ['PARAM_TONGUE_OUT']
+    ],
+    [SemanticAction.HEAD_YAW]: [
+        ['ParamAngleX'],
+        ['PARAM_ANGLE_X']
+    ],
+    [SemanticAction.HEAD_PITCH]: [
+        ['ParamAngleY'],
+        ['PARAM_ANGLE_Y']
+    ],
+    [SemanticAction.HEAD_ROLL]: [
+        ['ParamAngleZ'],
+        ['PARAM_ANGLE_Z']
+    ],
+    [SemanticAction.BODY_ANGLE_X]: [
+        ['ParamBodyAngleX'],
+        ['PARAM_BODY_ANGLE_X']
+    ],
+    [SemanticAction.BODY_ANGLE_Y]: [
+        ['ParamBodyAngleY'],
+        ['PARAM_BODY_ANGLE_Y']
+    ],
+    [SemanticAction.BODY_ANGLE_Z]: [
+        ['ParamBodyAngleZ'],
+        ['PARAM_BODY_ANGLE_Z']
+    ]
+});
+
+function spec(id, minimum, maximum, region, neutral = 0, overlaps = []) {
+    return Object.freeze({
+        id,
+        minimum,
+        maximum,
+        neutral,
+        region,
+        overlaps: Object.freeze([...overlaps])
+    });
+}
+
+function clamp(value, minimum, maximum) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return minimum;
+    return Math.max(minimum, Math.min(maximum, number));
+}
+
+function semanticActionsOverlap(left, right) {
+    if (left === right) return true;
+    const leftSpec = SPEC_BY_ACTION.get(left);
+    const rightSpec = SPEC_BY_ACTION.get(right);
+    return Boolean(leftSpec?.overlaps.includes(right) || rightSpec?.overlaps.includes(left));
+}
+
+function clampSemanticValue(action, value) {
+    const actionSpec = SPEC_BY_ACTION.get(action);
+    if (!actionSpec) return clamp(value, -1, 1);
+    return clamp(value, actionSpec.minimum, actionSpec.maximum);
+}
+
+function neutralValue(action) {
+    return SPEC_BY_ACTION.get(action)?.neutral ?? 0;
+}
+
+function semanticActionRegion(action) {
+    return SPEC_BY_ACTION.get(action)?.region || null;
+}
+
+function buildLive2DParameterCatalog(model, coreModel) {
+    const catalog = new Map();
+    if (!coreModel || typeof coreModel.getParameterCount !== 'function') return catalog;
+
+    const displayNames = readDisplayNames(model);
+    const count = coreModel.getParameterCount();
+    for (let index = 0; index < count; index++) {
+        const id = getParameterId(coreModel, index);
+        if (!id) continue;
+        let minimum = getParameterBound(coreModel, index, 'min');
+        let maximum = getParameterBound(coreModel, index, 'max');
+        const defaultValue = getParameterBound(coreModel, index, 'default');
+        if (!Number.isFinite(minimum)) minimum = -30;
+        if (!Number.isFinite(maximum)) maximum = 30;
+        if (maximum < minimum) [minimum, maximum] = [maximum, minimum];
+
+        catalog.set(id, {
+            id,
+            index,
+            minimum,
+            maximum,
+            defaultValue: Number.isFinite(defaultValue) ? defaultValue : (minimum + maximum) / 2,
+            name: displayNames[id] || ''
+        });
+    }
+    return catalog;
+}
+
+function readDisplayNames(model) {
+    const result = {};
+    try {
+        const entries = model?.internalModel?.settings?.json?.FileReferences?.DisplayInfo
+            || model?.internalModel?.settings?.FileReferences?.DisplayInfo;
+        if (!entries || typeof require !== 'function') return result;
+        const fs = require('fs');
+        const path = require('path');
+        const rawUrl = String(model?.internalModel?.settings?.url || '');
+        const decoded = decodeURIComponent(rawUrl).replace(/^\/?live-2d\//, '').replace(/^\/+/, '');
+        const root = path.join(__dirname, '..', '..', '..', '..');
+        const modelPath = path.isAbsolute(decoded) ? decoded : path.join(root, decoded);
+        const displayInfoPath = path.join(path.dirname(modelPath), String(entries).replace(/\//g, path.sep));
+        if (!fs.existsSync(displayInfoPath)) return result;
+        const json = JSON.parse(fs.readFileSync(displayInfoPath, 'utf8'));
+        for (const item of Array.isArray(json?.Parameters) ? json.Parameters : []) {
+            if (item?.Id && item?.Name) result[item.Id] = item.Name;
+        }
+    } catch (_) {}
+    return result;
+}
+
+function getParameterId(coreModel, index) {
+    try {
+        if (typeof coreModel.getParameterId === 'function') return coreModel.getParameterId(index);
+    } catch (_) {}
+    try {
+        return coreModel?._model?.parameters?.ids?.[index] || null;
+    } catch (_) {
+        return null;
+    }
+}
+
+function getParameterBound(coreModel, index, kind) {
+    const field = kind === 'min'
+        ? 'minimumValues'
+        : kind === 'max'
+            ? 'maximumValues'
+            : 'defaultValues';
+    try {
+        const value = Number(coreModel?._model?.parameters?.[field]?.[index]);
+        if (Number.isFinite(value)) return value;
+    } catch (_) {}
+
+    const method = kind === 'min'
+        ? 'getParameterMinimumValue'
+        : kind === 'max'
+            ? 'getParameterMaximumValue'
+            : 'getParameterDefaultValue';
+    try {
+        const value = Number(coreModel?.[method]?.(index));
+        if (Number.isFinite(value)) return value;
+    } catch (_) {}
+    return NaN;
+}
+
+class Live2DSemanticAdapter {
+    constructor(model, coreModel, bindingOverrides = {}) {
+        this.model = model;
+        this.coreModel = coreModel;
+        this.catalog = buildLive2DParameterCatalog(model, coreModel);
+        this.bindings = new Map();
+        this.updateBindings(bindingOverrides);
+    }
+
+    updateBindings(bindingOverrides = {}) {
+        this.bindings.clear();
+        for (const action of Object.values(SemanticAction)) {
+            const configured = Object.prototype.hasOwnProperty.call(bindingOverrides || {}, action)
+                ? bindingOverrides[action]
+                : DEFAULT_LIVE2D_BINDINGS[action];
+            const parameters = resolveBindingGroup(this.catalog, configured);
+            if (parameters.length > 0) this.bindings.set(action, parameters);
+        }
+    }
+
+    canResolve(action) {
+        return (this.bindings.get(action) || []).length > 0;
+    }
+
+    resolve(action) {
+        return [...(this.bindings.get(action) || [])];
+    }
+
+    toPlatformTargets(action, semanticValue) {
+        return this.resolve(action).map(info => ({
+            ...info,
+            action,
+            value: semanticToPlatform(semanticValue, info, action),
+            neutral: semanticToPlatform(neutralValue(action), info, action)
+        }));
+    }
+}
+
+function resolveBindingGroup(catalog, rawBinding) {
+    const groups = normalizeBindingGroups(rawBinding);
+    let partial = [];
+    for (const group of groups) {
+        const resolved = group
+            .map(id => catalog.get(id))
+            .filter(Boolean);
+        if (resolved.length === group.length && resolved.length > 0) return resolved;
+        if (partial.length === 0 && resolved.length > 0) partial = resolved;
+    }
+    return partial;
+}
+
+function normalizeBindingGroups(rawBinding) {
+    if (typeof rawBinding === 'string') return [[rawBinding]];
+    if (!Array.isArray(rawBinding)) return [];
+    if (rawBinding.every(value => typeof value === 'string')) return [rawBinding];
+    return rawBinding
+        .filter(Array.isArray)
+        .map(group => group.filter(value => typeof value === 'string' && value));
+}
+
+function semanticToPlatform(semanticValue, platformSpec, action) {
+    const actionSpec = SPEC_BY_ACTION.get(action);
+    if (!actionSpec) {
+        const midpoint = (platformSpec.minimum + platformSpec.maximum) / 2;
+        const normalized = clamp(semanticValue, -1, 1);
+        const value = normalized >= 0
+            ? midpoint + normalized * (platformSpec.maximum - midpoint)
+            : midpoint + normalized * (midpoint - platformSpec.minimum);
+        return clamp(value, platformSpec.minimum, platformSpec.maximum);
+    }
+
+    const clamped = clampSemanticValue(action, semanticValue);
+    const span = actionSpec.maximum - actionSpec.minimum;
+    const ratio = span <= 0 ? 0 : (clamped - actionSpec.minimum) / span;
+    return clamp(
+        platformSpec.minimum + ratio * (platformSpec.maximum - platformSpec.minimum),
+        platformSpec.minimum,
+        platformSpec.maximum
+    );
+}
+
+function platformToSemantic(platformValue, platformSpec, action) {
+    const actionSpec = SPEC_BY_ACTION.get(action);
+    const value = clamp(platformValue, platformSpec.minimum, platformSpec.maximum);
+    if (!actionSpec) {
+        const midpoint = (platformSpec.minimum + platformSpec.maximum) / 2;
+        if (value >= midpoint) {
+            const span = platformSpec.maximum - midpoint;
+            return span <= 0 ? 0 : (value - midpoint) / span;
+        }
+        const span = midpoint - platformSpec.minimum;
+        return span <= 0 ? 0 : -(midpoint - value) / span;
+    }
+
+    const span = platformSpec.maximum - platformSpec.minimum;
+    const ratio = span <= 0 ? 0 : (value - platformSpec.minimum) / span;
+    return actionSpec.minimum + ratio * (actionSpec.maximum - actionSpec.minimum);
+}
+
+module.exports = {
+    FacialRegion,
+    SemanticAction,
+    LIVE2D_MOUTH_OPEN_PARAMS,
+    LIVE2D_MOUTH_FALLBACK_PARAMS,
+    DEFAULT_SEMANTIC_ACTION_SPECS,
+    DEFAULT_LIVE2D_BINDINGS,
+    Live2DSemanticAdapter,
+    buildLive2DParameterCatalog,
+    clampSemanticValue,
+    neutralValue,
+    semanticActionRegion,
+    semanticActionsOverlap,
+    semanticToPlatform,
+    platformToSemantic
+};

--- a/live-2d/js/avatar/live2d/face-micro-motion.js
+++ b/live-2d/js/avatar/live2d/face-micro-motion.js
@@ -1,0 +1,243 @@
+'use strict';
+
+const facsMapper = require('./facs-mapper.js');
+
+const BLOCKED_PARAMS = new Set(['ParamEyeLOpen', 'ParamEyeROpen', 'ParamMouthOpenY']);
+
+function clamp(value, min, max) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return min;
+    return Math.max(min, Math.min(max, n));
+}
+
+function normalizeCatalog(catalogById) {
+    if (!catalogById) return new Map();
+    if (catalogById instanceof Map) return catalogById;
+    if (Array.isArray(catalogById)) return new Map(catalogById.map(item => [item.id, item]));
+    return new Map(Object.entries(catalogById));
+}
+
+function deltaMagnitude(vector) {
+    return Math.abs(vector.valence) + Math.abs(vector.arousal) * 0.82 + Math.abs(vector.dominance) * 0.62;
+}
+
+function seededRandom(seed) {
+    let state = Math.floor(Number(seed) || 0) >>> 0;
+    if (state === 0) state = 0x9e3779b9;
+    return () => {
+        state = (state * 1664525 + 1013904223) >>> 0;
+        return state / 0x100000000;
+    };
+}
+
+class FaceMicroMotion {
+    constructor() {
+        this.previous = null;
+        this.pulse = null;
+        this.random = seededRandom(4421);
+        this.nextAllowedPulseAt = 0;
+        this.nextGazeAt = 0;
+        this.gaze = { x: 0, y: 0, startedAt: 0, duration: 1 };
+    }
+
+    reset() {
+        this.previous = null;
+        this.pulse = null;
+        this.nextAllowedPulseAt = 0;
+        this.nextGazeAt = 0;
+        this.gaze = { x: 0, y: 0, startedAt: 0, duration: 1 };
+    }
+
+    compute(options = {}) {
+        const catalog = normalizeCatalog(options.catalogById);
+        const state = options.vadState || {};
+        const vad = state.current || state;
+        const timeSeconds = Number(options.timeSeconds) || 0;
+        const speaking = options.speaking === true;
+        const intensity = clamp(options.intensity ?? 1, 0, 2);
+        const activeWeight = typeof options.activeWeight === 'function' ? options.activeWeight : () => 0;
+        // 以下两项仅「仅 AI 编舞」档的调用方传入；未传（undefined）= 行为与旧版完全一致
+        const mouthFormScale = Number.isFinite(Number(options.mouthFormScale)) ? clamp(Number(options.mouthFormScale), 0, 1) : null;
+        this._gazeStability = Number.isFinite(Number(options.gazeStability)) ? clamp(Number(options.gazeStability), 0, 1) : null;
+        if (!vad || typeof vad !== 'object' || intensity <= 0) return {};
+
+        const focus = speaking ? 0.72 : 0;
+        const toneWeight = speaking ? 0.4 : 1;
+        const delta = this._getDelta(vad);
+        this._maybeStartPulse(timeSeconds, delta, focus);
+        this.previous = { ...vad };
+
+        const offsets = {};
+        this._addOffsets(offsets, this._toneLayer(vad, catalog, toneWeight));
+        this._addOffsets(offsets, this._continuousLayer(timeSeconds, vad, focus, catalog));
+        this._addOffsets(offsets, this._pulseLayer(timeSeconds, focus, catalog));
+
+        const result = {};
+        for (const [id, rawOffset] of Object.entries(offsets)) {
+            if (BLOCKED_PARAMS.has(id) || !catalog.has(id)) continue;
+            const remaining = 1 - clamp(activeWeight(id), 0, 1);
+            let offset = rawOffset * intensity * remaining;
+            // 口型仲裁（仅 director 档生效）：说话期微表情对 ParamMouthForm 的写入让位 lipsync
+            if (mouthFormScale !== null && speaking && id === 'ParamMouthForm') offset *= mouthFormScale;
+            if (Math.abs(offset) < 0.0001) continue;
+            result[id] = offset;
+        }
+        return result;
+    }
+
+    _toneLayer(vad, catalog, weight) {
+        const positive = Math.max(0, vad.valence || 0);
+        const negative = Math.max(0, -(vad.valence || 0));
+        const aroused = Math.max(0, vad.arousal || 0);
+        const calm = Math.max(0, -(vad.arousal || 0));
+        const submissive = Math.max(0, -(vad.dominance || 0));
+        const dominant = Math.max(0, vad.dominance || 0);
+
+        const au = {
+            AU12: (positive * 0.15 + calm * positive * 0.06) * weight,
+            AU6: (positive * 0.1 + calm * positive * 0.04) * weight,
+            AU15: (negative * 0.12 + calm * negative * 0.05) * weight,
+            AU1: (negative * 0.09 + submissive * 0.06) * weight,
+            AU2: (aroused * 0.09 + positive * aroused * 0.04) * weight,
+            AU4: dominant * negative * 0.11 * weight,
+            AU7: (negative * dominant * 0.08 + calm * 0.035) * weight,
+            blush: positive * submissive * 0.18 * weight,
+            gazeY: (-submissive * 0.06 + dominant * 0.03) * weight
+        };
+
+        const offsets = facsMapper.expandToOffsets(au, catalog);
+        delete offsets.ParamEyeLOpen;
+        delete offsets.ParamEyeROpen;
+        return offsets;
+    }
+
+    _continuousLayer(timeSeconds, vad, focus, catalog) {
+        const magnitude = clamp(deltaMagnitude(vad) * 0.85, 0, 0.1);
+        if (magnitude < 0.003) return {};
+
+        const idleWeight = 1 - focus * 0.56;
+        const slow = Math.sin(timeSeconds * 0.86 + (vad.valence || 0) * 9.2);
+        const mid = Math.sin(timeSeconds * 1.34 + (vad.arousal || 0) * 7.6 + 1.7);
+        const side = Math.sin(timeSeconds * 0.47 + (vad.dominance || 0) * 5.1);
+        const positive = Math.max(0, vad.valence || 0);
+        const negative = Math.max(0, -(vad.valence || 0));
+        const aroused = Math.max(0, vad.arousal || 0);
+        const calm = Math.max(0, -(vad.arousal || 0));
+        const submissive = Math.max(0, -(vad.dominance || 0));
+
+        const result = {
+            ParamMouthForm: positive * 0.026 * (0.7 + slow * 0.3) * idleWeight - negative * 0.018 * (0.75 + mid * 0.25) * idleWeight,
+            ParamBrowLY: (negative * 0.024 + submissive * 0.012 + aroused * 0.012) * (0.74 + slow * 0.22) * idleWeight,
+            ParamBrowRY: (negative * 0.024 + submissive * 0.012 + aroused * 0.012) * (0.74 + slow * 0.22) * idleWeight,
+            ParamEyeLSmile: positive * 0.02 * (0.75 + slow * 0.2) * idleWeight,
+            ParamEyeRSmile: positive * 0.02 * (0.75 + slow * 0.2) * idleWeight,
+            EyeL_Squint: (negative * 0.014 + calm * 0.01) * (0.75 + mid * 0.2) * idleWeight,
+            EyeR_Squint: (negative * 0.014 + calm * 0.01) * (0.75 + mid * 0.2) * idleWeight,
+            ParamEyeBallY: (Math.max(0, vad.dominance || 0) * 0.008 - submissive * 0.014 + calm * -0.006) * idleWeight,
+            ParamAngleZ: ((vad.valence || 0) * submissive * -0.28 + (vad.dominance || 0) * 0.15 + side * magnitude * 0.5) * idleWeight
+        };
+
+        const gaze = this._gazeSweep(timeSeconds, vad);
+        result.ParamEyeBallX = gaze.x + side * magnitude * 0.18;
+        result.ParamEyeBallY += gaze.y;
+
+        return this._filterExisting(result, catalog);
+    }
+
+    _pulseLayer(timeSeconds, focus, catalog) {
+        if (!this.pulse) return {};
+        const progress = (timeSeconds - this.pulse.startedAt) / this.pulse.duration;
+        if (progress >= 1) {
+            this.pulse = null;
+            return {};
+        }
+
+        const envelope = Math.sin(Math.PI * clamp(progress, 0, 1));
+        const amplitude = this.pulse.amplitude * envelope * (1 - focus * 0.34);
+        const vector = this.pulse.vector;
+        const positive = Math.max(0, vector.valence);
+        const negative = Math.max(0, -vector.valence);
+        const aroused = Math.max(0, vector.arousal);
+        const submissive = Math.max(0, -vector.dominance);
+        const dominant = Math.max(0, vector.dominance);
+
+        return this._filterExisting({
+            ParamMouthForm: positive * amplitude * 1.1 - negative * amplitude * 0.9,
+            ParamBrowLY: (negative * 0.9 + submissive * 0.45 + aroused * 0.5) * amplitude,
+            ParamBrowRY: (negative * 0.9 + submissive * 0.45 + aroused * 0.5) * amplitude,
+            ParamBrowLAngle: dominant * negative * amplitude * -0.9,
+            ParamBrowRAngle: dominant * negative * amplitude * 0.9,
+            ParamEyeLSmile: positive * amplitude * 0.65,
+            ParamEyeRSmile: positive * amplitude * 0.65,
+            EyeL_Squint: (negative * dominant) * amplitude * 0.7,
+            EyeR_Squint: (negative * dominant) * amplitude * 0.7,
+            ParamJawOpen: aroused * amplitude * 0.34,
+            ParamAngleZ: this.pulse.side * amplitude * 2.6
+        }, catalog);
+    }
+
+    _gazeSweep(timeSeconds, vad) {
+        if (timeSeconds >= this.nextGazeAt) {
+            // gazeStability 仅 director 档传入：稳定度越高，扫视间隔越长、幅度越小（对齐 SDK gazeStability）
+            const stability = this._gazeStability;
+            const spanScale = stability == null ? 1 : (0.6 + stability * 1.6);
+            const ampScale = stability == null ? 1 : (1.25 - stability * 0.7);
+            const span = (2 + this.random() * 4) * spanScale;
+            this.gaze = {
+                x: (this.random() - 0.5) * 0.11 * ampScale * (1 + Math.max(0, vad.arousal || 0)),
+                y: (this.random() - 0.5) * 0.08 * ampScale,
+                startedAt: timeSeconds,
+                duration: 0.45 + this.random() * 0.6
+            };
+            this.nextGazeAt = timeSeconds + span;
+        }
+        const progress = (timeSeconds - this.gaze.startedAt) / Math.max(0.001, this.gaze.duration);
+        const envelope = progress >= 1 ? 0 : Math.sin(Math.PI * clamp(progress, 0, 1));
+        return { x: this.gaze.x * envelope, y: this.gaze.y * envelope };
+    }
+
+    _getDelta(vad) {
+        const previous = this.previous || { valence: 0, arousal: 0, dominance: 0 };
+        return {
+            valence: (vad.valence || 0) - previous.valence,
+            arousal: (vad.arousal || 0) - previous.arousal,
+            dominance: (vad.dominance || 0) - previous.dominance
+        };
+    }
+
+    _maybeStartPulse(timeSeconds, delta, focus) {
+        const magnitude = deltaMagnitude(delta);
+        const threshold = focus > 0.5 ? 0.012 : 0.0048;
+        if (magnitude < threshold || timeSeconds < this.nextAllowedPulseAt) return;
+        this.pulse = {
+            startedAt: timeSeconds,
+            duration: 0.42 + this.random() * 0.38,
+            vector: delta,
+            amplitude: clamp(magnitude * 2.7, 0.018, 0.12) * (1 - focus * 0.48),
+            side: this.random() < 0.5 ? -1 : 1
+        };
+        this.nextAllowedPulseAt = timeSeconds + 0.42 + this.random() * 0.7;
+    }
+
+    _addOffsets(target, source) {
+        for (const [id, value] of Object.entries(source || {})) {
+            if (!Number.isFinite(Number(value))) continue;
+            target[id] = (target[id] || 0) + Number(value);
+        }
+    }
+
+    _filterExisting(source, catalog) {
+        const result = {};
+        for (const [id, value] of Object.entries(source || {})) {
+            if (BLOCKED_PARAMS.has(id) || !catalog.has(id)) continue;
+            if (Math.abs(Number(value) || 0) < 0.0001) continue;
+            result[id] = Number(value);
+        }
+        return result;
+    }
+}
+
+module.exports = {
+    BLOCKED_PARAMS,
+    FaceMicroMotion
+};

--- a/live-2d/js/avatar/live2d/facs-mapper.js
+++ b/live-2d/js/avatar/live2d/facs-mapper.js
@@ -1,0 +1,326 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const MOUTH_OPEN_PARAMS = new Set(['ParamMouthOpenY']);
+const MAX_SQUINT = 0.45;
+
+const FACE_PARAM_WHITELIST = new Set([
+    'ParamBrowLY', 'ParamBrowRY', 'ParamBrowLX', 'ParamBrowRX',
+    'ParamBrowLAngle', 'ParamBrowRAngle', 'ParamBrowLForm', 'ParamBrowRForm',
+    'ParamEyeLOpen', 'ParamEyeROpen', 'ParamEyeLSmile', 'ParamEyeRSmile',
+    'EyeL_Squint', 'EyeR_Squint', 'ParamEyeBallX', 'ParamEyeBallY',
+    'ParamMouthForm', 'ParamMouthX', 'ParamMouthFunnel', 'ParamMouthPressLipOpen',
+    'ParamMouthShrug', 'ParamMouthPuckerWiden', 'ParamJawOpen',
+    'Param100', 'ParamCheek', 'ParamCheeckPuff',
+    'Param74'
+]);
+
+const DEFAULT_AU_MAP = {
+    AU1: {
+        ParamBrowLY: 0.42,
+        ParamBrowRY: 0.42,
+        ParamBrowLAngle: -0.18,
+        ParamBrowRAngle: 0.18
+    },
+    AU2: {
+        ParamBrowLY: 0.24,
+        ParamBrowRY: 0.24,
+        ParamBrowLX: -0.16,
+        ParamBrowRX: 0.16
+    },
+    AU4: {
+        ParamBrowLY: -0.45,
+        ParamBrowRY: -0.45,
+        ParamBrowLAngle: -0.42,
+        ParamBrowRAngle: 0.42,
+        ParamBrowLForm: -0.18,
+        ParamBrowRForm: -0.18
+    },
+    AU5: {
+        ParamEyeLOpen: 0.22,
+        ParamEyeROpen: 0.22,
+        ParamBrowLY: 0.12,
+        ParamBrowRY: 0.12
+    },
+    AU6: {
+        ParamEyeLSmile: 1,
+        ParamEyeRSmile: 1,
+        EyeL_Squint: 0.44,
+        EyeR_Squint: 0.44,
+        ParamCheek: 0.56,
+        ParamCheeckPuff: 0.22
+    },
+    AU7: {
+        EyeL_Squint: 0.85,
+        EyeR_Squint: 0.85,
+        ParamEyeLOpen: -0.16,
+        ParamEyeROpen: -0.16
+    },
+    AU12: {
+        ParamMouthForm: 0.78,
+        ParamMouthPuckerWiden: 0.26,
+        ParamEyeLSmile: 0.62,
+        ParamEyeRSmile: 0.62,
+        ParamCheek: 0.5
+    },
+    AU15: {
+        ParamMouthForm: -0.86,
+        ParamMouthShrug: -0.24,
+        ParamBrowLY: -0.08,
+        ParamBrowRY: -0.08
+    },
+    AU18: {
+        ParamMouthFunnel: 0.9,
+        ParamMouthPuckerWiden: -0.34,
+        ParamMouthX: 0.08
+    },
+    AU23: {
+        ParamMouthPressLipOpen: 0.58,
+        ParamMouthForm: -0.18,
+        ParamJawOpen: -0.12
+    },
+    AU25: {
+        ParamJawOpen: 0.28,
+        ParamMouthFunnel: 0.12
+    },
+    AU26: {
+        ParamJawOpen: 0.72,
+        ParamMouthFunnel: 0.2,
+        ParamMouthForm: 0.08
+    },
+    AU43: {
+        ParamEyeLOpen: -0.95,
+        ParamEyeROpen: -0.95,
+        EyeL_Squint: 0.22,
+        EyeR_Squint: 0.22
+    },
+    blush: {
+        ParamCheek: 1,
+        Param100: 0.7,
+        Param74: 1
+    },
+    gazeX: {
+        ParamEyeBallX: 1
+    },
+    gazeY: {
+        ParamEyeBallY: 1
+    }
+};
+
+function clamp(value, min, max) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return min;
+    return Math.max(min, Math.min(max, n));
+}
+
+function normalizeAUKey(key) {
+    const raw = String(key || '').trim();
+    if (!raw) return '';
+    const lower = raw.toLowerCase();
+    const aliases = {
+        blush: 'blush',
+        gazex: 'gazeX',
+        gazey: 'gazeY'
+    };
+    const compact = lower.replace(/[\s_-]+/g, '');
+    if (aliases[compact]) {
+        return aliases[compact];
+    }
+    const numeric = lower.replace(/^au/, '').replace(/^0+/, '');
+    if (/^\d+$/.test(numeric)) return `AU${Number(numeric)}`;
+    return raw.toUpperCase();
+}
+
+function normalizeCatalog(catalogById) {
+    if (!catalogById) return new Map();
+    if (catalogById instanceof Map) return catalogById;
+    if (Array.isArray(catalogById)) return new Map(catalogById.map(item => [item.id, item]));
+    if (typeof catalogById === 'object') return new Map(Object.entries(catalogById));
+    return new Map();
+}
+
+function defaultFor(info) {
+    const value = Number(info?.default);
+    return Number.isFinite(value) ? value : 0;
+}
+
+function deltaForParam(id, info, coeff) {
+    const min = Number.isFinite(Number(info?.min)) ? Number(info.min) : -1;
+    const max = Number.isFinite(Number(info?.max)) ? Number(info.max) : 1;
+    const span = Math.max(0.001, max - min);
+    const absMax = Math.max(Math.abs(min), Math.abs(max), 0.001);
+
+    if (id === 'ParamEyeBallX' || id === 'ParamEyeBallY') return coeff * Math.min(absMax, span * 0.5);
+    if (id === 'ParamEyeLOpen' || id === 'ParamEyeROpen') return coeff * span * 0.46;
+    if (id === 'ParamEyeLSmile' || id === 'ParamEyeRSmile') return coeff * span * 0.92;
+    if (id === 'EyeL_Squint' || id === 'EyeR_Squint') return Math.sign(coeff) * Math.min(MAX_SQUINT, Math.abs(coeff) * span);
+    if (id === 'ParamJawOpen') return coeff * span * 0.42;
+    if (id === 'ParamCheek' || id === 'ParamCheeckPuff' || id === 'Param100') return coeff * span * 0.86;
+    if (id === 'Param74') return coeff * span;
+    return coeff * span * 0.45;
+}
+
+function readOverrideFileUncached(modelDir) {
+    if (!modelDir) return null;
+    const filePath = path.join(modelDir, 'facs_map.json');
+    try {
+        if (!fs.existsSync(filePath)) return null;
+        const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        return parsed && typeof parsed === 'object' ? parsed : null;
+    } catch (_) {
+        return null;
+    }
+}
+
+// facs_map.json 读盘缓存（纯性能优化，输出与逐次读盘完全一致）：
+// 旧实现每个关键帧都 existsSync + readFileSync + JSON.parse，一轮对话 20~40 次同步 IO 在渲染进程主线程上。
+// 现在按 modelDir 缓存，2 秒内直接复用；超过 2 秒重新 stat mtime，文件没变继续复用，变了才重读。
+// 校准面板保存 facs_map.json 后可调 clearOverrideCache() 立即失效。
+const OVERRIDE_CACHE_STAT_INTERVAL_MS = 2000;
+const overrideCache = new Map(); // modelDir -> { checkedAt, mtimeMs, override }
+
+function readOverrideFile(modelDir) {
+    if (!modelDir) return null;
+    const now = Date.now();
+    const cached = overrideCache.get(modelDir);
+    if (cached && (now - cached.checkedAt) < OVERRIDE_CACHE_STAT_INTERVAL_MS) {
+        return cached.override;
+    }
+    let mtimeMs = -1;
+    try {
+        const stat = fs.statSync(path.join(modelDir, 'facs_map.json'));
+        mtimeMs = stat.mtimeMs;
+    } catch (_) {
+        mtimeMs = -1; // 文件不存在
+    }
+    if (cached && cached.mtimeMs === mtimeMs) {
+        cached.checkedAt = now;
+        return cached.override;
+    }
+    const override = mtimeMs === -1 ? null : readOverrideFileUncached(modelDir);
+    overrideCache.set(modelDir, { checkedAt: now, mtimeMs, override });
+    return override;
+}
+
+function clearOverrideCache(modelDir = null) {
+    if (modelDir) overrideCache.delete(modelDir);
+    else overrideCache.clear();
+}
+
+// 读取 facs_map.json 里的声明式情绪规则（profile-generator 产出，仅 director 档消费）。
+// 规则形如 { id, trigger: { emotion: [..] | vad_window: {axis:[min,max]} }, targets: {param: value},
+//            intensity, priority, exclusive_group }
+function getModelRules(modelDir) {
+    const override = readOverrideFile(modelDir);
+    const rules = override?.rules;
+    if (!Array.isArray(rules)) return [];
+    return rules.filter(rule =>
+        rule && typeof rule === 'object' &&
+        rule.targets && typeof rule.targets === 'object' &&
+        rule.trigger && typeof rule.trigger === 'object'
+    );
+}
+
+function mergeMappings(base, override) {
+    const result = {};
+    for (const [au, mapping] of Object.entries(base || {})) {
+        result[normalizeAUKey(au)] = { ...(mapping || {}) };
+    }
+    const source = override?.mappings || override?.au_map || override;
+    if (!source || typeof source !== 'object') return result;
+    for (const [au, mapping] of Object.entries(source)) {
+        if (!mapping || typeof mapping !== 'object') continue;
+        const key = normalizeAUKey(au);
+        result[key] = { ...(result[key] || {}), ...mapping };
+    }
+    return result;
+}
+
+class FACSMapper {
+    constructor(mapping = DEFAULT_AU_MAP) {
+        this.mapping = mergeMappings(mapping, null);
+    }
+
+    loadModelOverride(modelDir) {
+        const override = readOverrideFile(modelDir);
+        if (!override) return false;
+        this.mapping = mergeMappings(this.mapping, override);
+        return true;
+    }
+
+    expand(auMap, catalogById, options = {}) {
+        const catalog = normalizeCatalog(catalogById);
+        const offsets = this.expandToOffsets(auMap, catalog, options);
+        const result = {};
+        for (const [id, offset] of Object.entries(offsets)) {
+            const info = catalog.get(id);
+            if (!info) continue;
+            const value = defaultFor(info) + offset;
+            result[id] = clampParam(id, value, info);
+        }
+        return result;
+    }
+
+    expandToOffsets(auMap, catalogById, options = {}) {
+        const catalog = normalizeCatalog(catalogById);
+        const modelOverride = options.modelDir ? readOverrideFile(options.modelDir) : null;
+        const mapping = modelOverride ? mergeMappings(this.mapping, modelOverride) : this.mapping;
+        const result = {};
+        const source = auMap && typeof auMap === 'object' ? auMap : {};
+
+        for (const [rawKey, rawIntensity] of Object.entries(source)) {
+            const auKey = normalizeAUKey(rawKey);
+            const intensity = clamp(rawIntensity, -1, 1);
+            if (!intensity) continue;
+            const auMapping = mapping[auKey];
+            if (!auMapping) continue;
+
+            for (const [id, coeff] of Object.entries(auMapping)) {
+                if (MOUTH_OPEN_PARAMS.has(id) || !FACE_PARAM_WHITELIST.has(id)) continue;
+                const info = catalog.get(id);
+                if (!info) continue;
+                let delta = deltaForParam(id, info, Number(coeff) || 0) * intensity;
+                // 口型仲裁（仅 director 档调用方传入）：说话期 ParamMouthForm 让位 lipsync，
+                // 避免微笑口型与嘴形动画抢同一参数产生抖动。mouthFormScale 缺省 undefined = 行为不变。
+                if (id === 'ParamMouthForm' && Number.isFinite(options.mouthFormScale)) {
+                    delta *= clamp(options.mouthFormScale, 0, 1);
+                }
+                if (!Number.isFinite(delta) || delta === 0) continue;
+                result[id] = (result[id] || 0) + delta;
+            }
+        }
+
+        for (const id of ['EyeL_Squint', 'EyeR_Squint']) {
+            const info = catalog.get(id);
+            if (!info || result[id] === undefined) continue;
+            const target = clamp(defaultFor(info) + result[id], info.min, Math.min(info.max, MAX_SQUINT));
+            result[id] = target - defaultFor(info);
+        }
+
+        return result;
+    }
+}
+
+function clampParam(id, value, info) {
+    const min = Number.isFinite(Number(info?.min)) ? Number(info.min) : -1;
+    const max = Number.isFinite(Number(info?.max)) ? Number(info.max) : 1;
+    const effectiveMax = (id === 'EyeL_Squint' || id === 'EyeR_Squint') ? Math.min(max, MAX_SQUINT) : max;
+    return clamp(value, min, effectiveMax);
+}
+
+const defaultMapper = new FACSMapper();
+
+module.exports = {
+    AU_VOCABULARY: Object.keys(DEFAULT_AU_MAP),
+    DEFAULT_AU_MAP,
+    FACSMapper,
+    clamp,
+    clearOverrideCache,
+    getModelRules,
+    expand: (...args) => defaultMapper.expand(...args),
+    expandToOffsets: (...args) => defaultMapper.expandToOffsets(...args),
+    loadModelOverride: (...args) => defaultMapper.loadModelOverride(...args),
+    normalizeAUKey
+};

--- a/live-2d/js/avatar/live2d/idle-action-scheduler.js
+++ b/live-2d/js/avatar/live2d/idle-action-scheduler.js
@@ -1,0 +1,283 @@
+'use strict';
+
+// idle-action-scheduler.js - 离散待机动作调度器
+// 对齐 soullink-emotion-sdk engine 的 idle action system：非周期的小动作（点头/歪头/侧目/
+// 重心转移/前倾/后撤/叹气/慢眨眼），按 VAD 状态 + 风格权重挑选，带防重复窗口，说话立即打断。
+//
+// 范围铁律：本模块仅由 ParamDirector 在「仅 AI 编舞」档（director）驱动，blend / legacy 档不会
+// 实例化调用。动作只产出关键帧，经 ParamDirector 的 'idle' 通道走既有 transition/hold/release
+// 状态机落地——不直写任何 Live2D 参数。
+
+const { seededRandom } = require('./emotion-archetypes.js');
+const { normalizeDuration } = require('./duration-utils.js');
+
+function clamp(value, min, max) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return min;
+    return Math.max(min, Math.min(max, n));
+}
+
+// 每个动作：
+//   id            动作名（防重复窗口按 id+direction 记账）
+//   base          基础权重
+//   affinity      VAD 亲和度：score = base + valence*v + arousal*a + dominance*d
+//   requires(vad) 可选硬门槛
+//   directional   是否有左右方向
+//   cooldownSec   自身冷却
+//   build(ctx)    产出 [{ delayMs, frame }]，frame 为 ParamDirector 时间轴帧格式
+const ACTIONS = [
+    {
+        id: 'slow_nod', base: 1.0, affinity: { valence: 0.3, arousal: 0.2 }, cooldownSec: 14,
+        build(ctx) {
+            const depth = -(3.2 + ctx.random() * 2.4) * ctx.gain;
+            return [
+                { delayMs: 0, frame: ctx.frame({ ParamAngleY: depth, Param5: depth }, 620, 260, 900) },
+                { delayMs: 950, frame: ctx.frame({ ParamAngleY: depth * -0.35, Param5: depth * -0.35 }, 540, 160, 1100) }
+            ];
+        }
+    },
+    {
+        id: 'head_tilt', base: 1.0, affinity: { valence: 0.2 }, directional: true, cooldownSec: 16,
+        build(ctx) {
+            const z = (3 + ctx.random() * 2.2) * ctx.direction * ctx.gain;
+            return [
+                { delayMs: 0, frame: ctx.frame({ ParamAngleZ: z, Param4: z, ParamBodyAngleZ: -z * 0.24 }, 760, 1250, 1500) }
+            ];
+        }
+    },
+    {
+        id: 'glance_side', base: 0.9, affinity: { arousal: 0.4 }, directional: true, cooldownSec: 10,
+        build(ctx) {
+            const x = (0.45 + ctx.random() * 0.3) * ctx.direction;
+            const z = 1.6 * ctx.direction * ctx.gain;
+            return [
+                { delayMs: 0, frame: ctx.frame({ ParamEyeBallX: x, ParamAngleZ: z, Param4: z }, 420, 700, 800) },
+                { delayMs: 1300, frame: ctx.frame({ ParamEyeBallX: 0, ParamAngleZ: 0, Param4: 0 }, 520, 120, 900) }
+            ];
+        }
+    },
+    {
+        id: 'weight_shift', base: 1.0, affinity: { arousal: -0.3 }, directional: true, cooldownSec: 18,
+        build(ctx) {
+            const bx = (2.2 + ctx.random() * 1.4) * ctx.direction * ctx.gain;
+            const hx = bx * 0.6;
+            return [
+                { delayMs: 0, frame: ctx.frame({ ParamBodyAngleX: bx, ParamAngleX: hx, Param3: hx }, 950, 1500, 1500) }
+            ];
+        }
+    },
+    {
+        id: 'lean_in', base: 0.8, affinity: { valence: 0.4, dominance: 0.2 }, cooldownSec: 20,
+        build(ctx) {
+            const y = (3 + ctx.random() * 1.6) * ctx.gain;
+            return [
+                { delayMs: 0, frame: ctx.frame({ ParamAngleY: y, Param5: y, ParamBodyAngleY: y * 0.35 }, 820, 1100, 1400) }
+            ];
+        }
+    },
+    {
+        id: 'settle_back', base: 0.8, affinity: { arousal: -0.4, valence: -0.1 }, cooldownSec: 20,
+        build(ctx) {
+            const y = -(2.4 + ctx.random() * 1.4) * ctx.gain;
+            return [
+                { delayMs: 0, frame: ctx.frame({ ParamAngleY: y, Param5: y, ParamBodyAngleY: y * 0.3 }, 1050, 1300, 1600) }
+            ];
+        }
+    },
+    {
+        id: 'sigh', base: 0.7, affinity: { valence: -0.5, arousal: -0.2 }, cooldownSec: 26,
+        requires: (vad) => (vad.valence || 0) < 0.08,
+        build(ctx) {
+            const y = -(3.4 + ctx.random() * 1.8) * ctx.gain;
+            return [
+                { delayMs: 0, frame: ctx.frame({ ParamAngleY: y * 0.4, Param5: y * 0.4 }, 480, 220, 500) },
+                {
+                    delayMs: 760,
+                    frame: ctx.frame({
+                        ParamAngleY: y, Param5: y, ParamBodyAngleY: y * 0.3,
+                        ParamBrowLY: -0.12, ParamBrowRY: -0.12
+                    }, 700, 520, 1700)
+                }
+            ];
+        }
+    },
+    {
+        id: 'slow_blink', base: 1.0, affinity: { arousal: -0.2 }, cooldownSec: 9,
+        build(ctx) {
+            const frame = ctx.frame({ ParamEyeLOpen: 0, ParamEyeROpen: 0, EyeL_Squint: 0.3, EyeR_Squint: 0.3 }, 150, 130, 280);
+            frame.release_params = ['ParamEyeLOpen', 'ParamEyeROpen', 'EyeL_Squint', 'EyeR_Squint'];
+            return [{ delayMs: 0, frame }];
+        }
+    }
+];
+
+const DEFAULT_OPTIONS = {
+    spontaneity: 1,
+    gain: 1,
+    avoid_repeat_window: 4,
+    min_interval_seconds: 7,
+    max_interval_seconds: 19,
+    slow_blink_weight: 1,
+    gaze_down_bias: 0
+};
+
+class IdleActionScheduler {
+    constructor() {
+        this.options = { ...DEFAULT_OPTIONS };
+        this.random = Math.random;
+        this._seed = null;
+        this._recent = [];            // [{id, direction}]，防重复窗口
+        this._cooldownUntil = new Map(); // actionId -> ms 时间戳
+        this._pendingSteps = [];      // [{fireAt, frame}]
+        this._nextActionAt = 0;
+        this._suspended = true;
+    }
+
+    configure(options = {}, seed = null) {
+        const merged = { ...DEFAULT_OPTIONS };
+        for (const key of Object.keys(DEFAULT_OPTIONS)) {
+            const value = Number(options[key]);
+            if (Number.isFinite(value)) merged[key] = value;
+        }
+        merged.spontaneity = clamp(merged.spontaneity, 0, 3);
+        merged.gain = clamp(merged.gain, 0, 2.5);
+        merged.avoid_repeat_window = clamp(Math.floor(merged.avoid_repeat_window), 0, 12);
+        merged.min_interval_seconds = clamp(merged.min_interval_seconds, 1.5, 120);
+        merged.max_interval_seconds = clamp(Math.max(merged.max_interval_seconds, merged.min_interval_seconds), 2, 180);
+        this.options = merged;
+        const normalizedSeed = Number.isFinite(Number(seed)) ? Math.floor(Number(seed)) : null;
+        if (normalizedSeed !== this._seed) {
+            this._seed = normalizedSeed;
+            this.random = normalizedSeed === null ? Math.random : seededRandom(normalizedSeed);
+        }
+    }
+
+    // 说话/编舞/交互开始时调用：清空未发帧，动作由 ParamDirector 侧淡出
+    interrupt(nowMs) {
+        this._pendingSteps = [];
+        this._suspended = true;
+        this._nextActionAt = (nowMs || 0) + this._intervalMs() * 0.6;
+    }
+
+    // 每渲染帧由 ParamDirector 调用。active=false 表示当前不允许待机动作（说话中等）。
+    // fire(frame) 由调用方提供，负责把帧送进 'idle' 通道。
+    tick(nowMs, { active, vad, fire }) {
+        if (!active) {
+            if (!this._suspended) this.interrupt(nowMs);
+            return;
+        }
+        if (this._suspended) {
+            this._suspended = false;
+            if (this._nextActionAt < nowMs) this._nextActionAt = nowMs + this._intervalMs() * (0.4 + this.random() * 0.6);
+        }
+
+        // 先发到期的后续步骤
+        if (this._pendingSteps.length > 0) {
+            const due = [];
+            this._pendingSteps = this._pendingSteps.filter(step => {
+                if (step.fireAt <= nowMs) {
+                    due.push(step);
+                    return false;
+                }
+                return true;
+            });
+            for (const step of due) {
+                try { fire(step.frame); } catch (_) {}
+            }
+        }
+
+        if (this.options.spontaneity <= 0 || this.options.gain <= 0) return;
+        if (nowMs < this._nextActionAt || this._pendingSteps.length > 0) return;
+
+        const action = this._pickAction(nowMs, vad || {});
+        this._nextActionAt = nowMs + this._intervalMs();
+        if (!action) return;
+
+        const direction = action.def.directional ? action.direction : 0;
+        const ctx = this._buildCtx(direction);
+        let steps = [];
+        try {
+            steps = action.def.build(ctx) || [];
+        } catch (_) {
+            return;
+        }
+        this._cooldownUntil.set(action.def.id, nowMs + (action.def.cooldownSec || 12) * 1000);
+        this._recent.push({ id: action.def.id, direction });
+        const windowSize = Math.max(1, this.options.avoid_repeat_window);
+        while (this._recent.length > windowSize) this._recent.shift();
+
+        for (const step of steps) {
+            if (!step || !step.frame) continue;
+            const delay = Math.max(0, Number(step.delayMs) || 0);
+            if (delay === 0) {
+                try { fire(step.frame); } catch (_) {}
+            } else {
+                this._pendingSteps.push({ fireAt: nowMs + delay, frame: step.frame });
+            }
+        }
+    }
+
+    _intervalMs() {
+        const { min_interval_seconds, max_interval_seconds, spontaneity } = this.options;
+        const span = min_interval_seconds + this.random() * Math.max(0.1, max_interval_seconds - min_interval_seconds);
+        return (span / Math.max(0.2, spontaneity)) * 1000;
+    }
+
+    _pickAction(nowMs, vadInput) {
+        const vad = vadInput.current || vadInput;
+        const candidates = [];
+        for (const def of ACTIONS) {
+            if ((this._cooldownUntil.get(def.id) || 0) > nowMs) continue;
+            if (typeof def.requires === 'function' && !def.requires(vad)) continue;
+            const weightScale = def.id === 'slow_blink' ? this.options.slow_blink_weight : 1;
+            const affinity = def.affinity || {};
+            const score = (def.base
+                + (Number(vad.valence) || 0) * (affinity.valence || 0)
+                + (Number(vad.arousal) || 0) * (affinity.arousal || 0)
+                + (Number(vad.dominance) || 0) * (affinity.dominance || 0)) * weightScale;
+            if (score <= 0.02) continue;
+            const directions = def.directional ? [-1, 1] : [0];
+            for (const direction of directions) {
+                if (this._recent.some(item => item.id === def.id && item.direction === direction)) continue;
+                candidates.push({ def, direction, score });
+            }
+        }
+        if (candidates.length === 0) return null;
+        let total = 0;
+        for (const item of candidates) total += item.score;
+        let roll = this.random() * total;
+        for (const item of candidates) {
+            roll -= item.score;
+            if (roll <= 0) return item;
+        }
+        return candidates[candidates.length - 1];
+    }
+
+    _buildCtx(direction) {
+        const gain = this.options.gain;
+        const random = this.random;
+        const gazeDownBias = clamp(this.options.gaze_down_bias, 0, 1);
+        return {
+            direction,
+            gain,
+            random,
+            frame(params, transitionMs, holdMs, releaseMs) {
+                const finalParams = { ...params };
+                // 害羞风格：视线类动作附带向下偏置
+                if (gazeDownBias > 0 && finalParams.ParamEyeBallX !== undefined && finalParams.ParamEyeBallY === undefined) {
+                    finalParams.ParamEyeBallY = -0.18 * gazeDownBias;
+                }
+                return {
+                    at: 0,
+                    params: finalParams,
+                    transition_ms: normalizeDuration(transitionMs, 500),
+                    hold_ms: normalizeDuration(holdMs, 400),
+                    release_ms: normalizeDuration(releaseMs, 900),
+                    sticky: false
+                };
+            }
+        };
+    }
+}
+
+module.exports = { IdleActionScheduler, IDLE_ACTIONS: ACTIONS };

--- a/live-2d/js/avatar/live2d/interaction.js
+++ b/live-2d/js/avatar/live2d/interaction.js
@@ -1,0 +1,402 @@
+// interaction.js - Live2D 交互控制器（兼容上游 PIXI 6 运行时）
+// Adapted from Project-N-E-K-O/N.E.K.O (Apache-2.0): static/live2d-interaction.js 的
+// 指针拖拽 / 鼠标锚点缩放思路。
+//
+// 对外契约（不可破坏，消费者：app.js / TTSFactory / music-player / http-server / avatar-drop）：
+//   init(model, app, config)          - 初始化
+//   setupInitialModelProperties(s)    - 兼容旧接口（变换已由 loader 应用，此处仅刷新交互区）
+//   setMouthOpenY(v)                  - 口型驱动（Phase 4 升级为 override 机制）
+//   updateInteractionArea()           - 刷新交互区缓存
+//   interactionX/Y/Width/Height       - 交互区（CSS 像素）
+//   saveModelPosition()               - 持久化位置/缩放（存储用 legacy 语义）
+//   resetModelPosition()              - 复位（供 HTTP /reset-model-position）
+//   isPointOverInteractive(x, y)      - 供 ui-controller 鼠标穿透判定（client 坐标）
+const { ipcRenderer } = require('electron');
+const { LEGACY_SCALE_RATIO } = require('./core.js');
+let _logToTerminal;
+try { ({ logToTerminal: _logToTerminal } = require('../../api-utils.js')); } catch (_) { _logToTerminal = (lvl, msg) => console.log(`[${lvl}]`, msg); }
+
+const WHEEL_ZOOM_STEP = 0.08;      // 每档滚轮的缩放比例
+const DRAG_SAVE_DEBOUNCE_MS = 300;
+
+class Live2DInteractionController {
+    constructor() {
+        this.model = null;
+        this.app = null;
+        this.config = null;
+        this.stage = null;   // Live2DStage（可选，用于 notifyActivity）
+
+        this.interactionWidth = 0;
+        this.interactionHeight = 0;
+        this.interactionX = 0;
+        this.interactionY = 0;
+
+        this.isDragging = false;
+        this.isDraggingChat = false;
+        this.dragOffset = { x: 0, y: 0 };
+        this.chatDragOffset = { x: 0, y: 0 };
+
+        this._scaleMin = 0.005;
+        this._scaleMax = 4;
+        this._saveTimer = null;
+        this._listeners = [];   // [{target, type, handler, options}]
+        // 口型参数 setter（Phase 4 由 lipsync 模块注入；默认直接写常见参数 ID）
+        this._mouthSetter = null;
+    }
+
+    init(model, app, config = null, extras = {}) {
+        this.model = model;
+        this.app = app;
+        this.config = config;
+        this.stage = extras.stage || this.stage;
+
+        // 缩放钳制范围基于初始应用缩放推导
+        const s = model?.scale?.x || 0.1;
+        this._scaleMin = s * 0.15;
+        this._scaleMax = s * 8;
+
+        this.updateInteractionArea();
+        this._teardownListeners();
+        this._setupPointerEvents();
+        this._setupChatDrag();
+        this._setupWindowEvents();
+    }
+
+    // ============ 交互区 ============
+
+    updateInteractionArea() {
+        if (!this.model) return;
+        // 与旧实现一致：取模型中间 1/3 宽、70% 高作为可交互区（避免透明边缘拦截鼠标）
+        this.interactionWidth = this.model.width / 3;
+        this.interactionHeight = this.model.height * 0.7;
+        this.interactionX = this.model.x + (this.model.width - this.interactionWidth) / 2;
+        this.interactionY = this.model.y + (this.model.height - this.interactionHeight) / 2;
+    }
+
+    // client 坐标（CSS px）是否落在模型交互区
+    isPointOverModel(clientX, clientY) {
+        if (!this.model) return false;
+        return clientX >= this.interactionX &&
+            clientX <= this.interactionX + this.interactionWidth &&
+            clientY >= this.interactionY &&
+            clientY <= this.interactionY + this.interactionHeight;
+    }
+
+    // 模型交互区 或 聊天框（窗口穿透判定用；聊天框可见时悬停其上不能穿透）
+    isPointOverInteractive(clientX, clientY) {
+        if (this.isPointOverModel(clientX, clientY)) return true;
+        const chat = document.getElementById('text-chat-container');
+        if (chat && chat.style.display !== 'none' && chat.offsetParent !== null) {
+            const r = chat.getBoundingClientRect();
+            if (clientX >= r.left && clientX <= r.right && clientY >= r.top && clientY <= r.bottom) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // ============ 事件 ============
+
+    _on(target, type, handler, options) {
+        target.addEventListener(type, handler, options);
+        this._listeners.push({ target, type, handler, options });
+    }
+
+    _teardownListeners() {
+        for (const { target, type, handler, options } of this._listeners) {
+            try { target.removeEventListener(type, handler, options); } catch (_) {}
+        }
+        this._listeners = [];
+    }
+
+    _setupPointerEvents() {
+        // 拖拽起点只认 canvas（DOM 浮层如聊天框/棋盘的点击不应拖动模型）
+        const isCanvasTarget = (e) => e.target && e.target.tagName === 'CANVAS';
+
+        this._on(window, 'pointerdown', (e) => {
+            if (e.button !== 0) return;
+            if (!isCanvasTarget(e)) return;
+            if (!this.isPointOverModel(e.clientX, e.clientY)) return;
+            this.isDragging = true;
+            this.dragOffset.x = e.clientX - this.model.x;
+            this.dragOffset.y = e.clientY - this.model.y;
+            this._pressStart = { x: e.clientX, y: e.clientY, t: performance.now() };
+            this._setPassthrough(false);
+            this._notifyActivity();
+        });
+
+        this._on(window, 'pointermove', (e) => {
+            if (!this.isDragging || !this.model) return;
+            let newX = e.clientX - this.dragOffset.x;
+            let newY = e.clientY - this.dragOffset.y;
+
+            // 多屏限制（与旧实现一致）：左扩展模式下限制 x >= 0
+            const extend = this.config?.ui?.screen_extend;
+            if (extend?.extend && extend?.left && newX < 0) newX = 0;
+
+            this.model.position.set(newX, newY);
+            this.updateInteractionArea();
+            this._notifyActivity();
+        });
+
+        this._on(window, 'pointerup', (e) => {
+            if (!this.isDragging) return;
+            this.isDragging = false;
+            this.saveModelPosition();
+
+            // 点击判定：位移小且时间短 -> 触发 Tap 动作（旧实现因拖拽误触被整段禁用，
+            // 这里用位移阈值解决误触问题后恢复该交互）
+            const press = this._pressStart;
+            this._pressStart = null;
+            if (press) {
+                const moved = Math.hypot(e.clientX - press.x, e.clientY - press.y);
+                const elapsed = performance.now() - press.t;
+                if (moved < 6 && elapsed < 350) {
+                    this._onModelTap();
+                }
+            }
+
+            // 松手后若指针不在交互区上则恢复穿透
+            setTimeout(() => {
+                if (!this.isDragging && !this.isPointOverInteractive(e.clientX, e.clientY)) {
+                    this._setPassthrough(true);
+                }
+            }, 100);
+        });
+
+        // 滚轮缩放：以鼠标位置为锚点（N.E.K.O 算法），只在模型交互区内生效
+        this._on(window, 'wheel', (e) => {
+            if (!this.model) return;
+            if (!(e.target && e.target.tagName === 'CANVAS')) return;
+            if (!this.isPointOverModel(e.clientX, e.clientY)) return;
+            e.preventDefault();
+
+            const absDelta = Math.abs(e.deltaY);
+            const zoomStep = Math.min(absDelta / 1000, WHEEL_ZOOM_STEP);
+            const factor = 1 + zoomStep;
+            const oldScale = this.model.scale.x;
+            let newScale = e.deltaY < 0 ? oldScale * factor : oldScale / factor;
+            newScale = Math.max(this._scaleMin, Math.min(this._scaleMax, newScale));
+            if (newScale === oldScale) return;
+
+            // 锚点缩放：保持鼠标下的点不动
+            const ratio = newScale / oldScale;
+            this.model.x = e.clientX - (e.clientX - this.model.x) * ratio;
+            this.model.y = e.clientY - (e.clientY - this.model.y) * ratio;
+            this.model.scale.set(newScale);
+
+            this.updateInteractionArea();
+            this._scheduleSave();
+            this._notifyActivity();
+        }, { passive: false });
+
+        this._on(window, 'pointercancel', () => {
+            this.isDragging = false;
+            this._pressStart = null;
+        });
+        this._on(window, 'blur', () => {
+            this.isDragging = false;
+            this._pressStart = null;
+        });
+
+        // 禁用右键菜单（与旧实现一致）
+        this._on(window, 'contextmenu', (e) => {
+            e.preventDefault();
+            return false;
+        });
+    }
+
+    // 聊天框拖拽（保持旧行为：按住聊天框背景/消息区可拖动聊天框）
+    _setupChatDrag() {
+        const chatContainer = document.getElementById('text-chat-container');
+        if (!chatContainer) return;
+
+        this._on(chatContainer, 'mousedown', (e) => {
+            if (e.target === chatContainer || e.target.id === 'chat-messages') {
+                this.isDraggingChat = true;
+                const rect = chatContainer.getBoundingClientRect();
+                this.chatDragOffset.x = e.clientX - rect.left;
+                this.chatDragOffset.y = e.clientY - rect.top;
+                e.preventDefault();
+                this._setPassthrough(false);
+            }
+        });
+
+        this._on(document, 'mousemove', (e) => {
+            if (!this.isDraggingChat) return;
+            chatContainer.style.setProperty('left', `${e.clientX - this.chatDragOffset.x}px`, 'important');
+            chatContainer.style.setProperty('top', `${e.clientY - this.chatDragOffset.y}px`, 'important');
+            chatContainer.style.setProperty('bottom', 'auto', 'important');
+        });
+
+        this._on(document, 'mouseup', (e) => {
+            if (!this.isDraggingChat) return;
+            this.isDraggingChat = false;
+            setTimeout(() => {
+                if (!this.isPointOverInteractive(e.clientX, e.clientY)) {
+                    this._setPassthrough(true);
+                }
+            }, 100);
+        });
+    }
+
+    _setupWindowEvents() {
+        this._on(window, 'resize', () => {
+            this.updateInteractionArea();
+        });
+    }
+
+    _setPassthrough(ignore) {
+        ipcRenderer.send('set-ignore-mouse-events', ignore
+            ? { ignore: true, options: { forward: true } }
+            : { ignore: false });
+    }
+
+    _notifyActivity() {
+        if (this.stage && typeof this.stage.notifyActivity === 'function') {
+            this.stage.notifyActivity();
+        }
+    }
+
+    // 单击模型：播放随机 Tap 动作（若模型定义了对应动作组）
+    _onModelTap() {
+        const m = this.model;
+        if (!m || !m.internalModel?.settings) return;
+        try {
+            const motions = m.internalModel.settings.motions || {};
+            const group = ['Tap', 'TapBody', 'tap_body', 'Tap@Body'].find(
+                g => Array.isArray(motions[g]) && motions[g].length > 0
+            );
+            if (group) {
+                // 不传 index 时 pixi-live2d-display 会在组内随机挑选
+                m.motion(group);
+                this._notifyActivity();
+            }
+        } catch (_) {}
+    }
+
+    // ============ 口型 ============
+
+    // Phase 4 的 lipsync 模块通过此方法接管口型写入
+    setMouthSetter(fn) {
+        this._mouthSetter = typeof fn === 'function' ? fn : null;
+    }
+
+    setMouthOpenY(v) {
+        if (!this.model) return;
+        v = Math.max(0, Math.min(Number(v) || 0, 3.0));
+        if (this._mouthSetter) {
+            this._mouthSetter(v);
+            return;
+        }
+        // 基础实现：直接写常见嘴部参数（Phase 4 替换为缓存 index + override）
+        try {
+            const coreModel = this.model.internalModel?.coreModel;
+            if (!coreModel || typeof coreModel.setParameterValueById !== 'function') return;
+            try { coreModel.setParameterValueById('ParamMouthOpenY', v); } catch (_) {}
+            try { coreModel.setParameterValueById('PARAM_MOUTH_OPEN_Y', v); } catch (_) {}
+        } catch (_) {}
+    }
+
+    // ============ 变换持久化 ============
+
+    // 兼容旧接口：变换已由 model-loader 应用，这里只刷新交互区
+    setupInitialModelProperties() {
+        this.updateInteractionArea();
+    }
+
+    _scheduleSave() {
+        if (this._saveTimer) clearTimeout(this._saveTimer);
+        this._saveTimer = setTimeout(() => {
+            this._saveTimer = null;
+            this.saveModelPosition();
+        }, DRAG_SAVE_DEBOUNCE_MS);
+    }
+
+    saveModelPosition() {
+        if (!this.model || !this.config) return;
+        if (!this.config.ui?.model_position?.remember_position) return;
+
+        const stageW = window.innerWidth || 1;
+        const stageH = window.innerHeight || 1;
+        const relativeX = this.model.x / stageW;
+        const relativeY = this.model.y / stageH;
+        const isDualRight = window.innerWidth > window.screen.width * 1.2 && this.config?.ui?.screen_extend?.right;
+        // 存储用 legacy 语义（兼容 WebUI 直接读写 config.ui.model_scale）
+        const legacyScale = this.model.scale.x * LEGACY_SCALE_RATIO;
+
+        if (isDualRight) {
+            this.config.ui.model_position.x_dual = relativeX;
+            this.config.ui.model_position.y_dual = relativeY;
+        } else {
+            this.config.ui.model_position.x = relativeX;
+            this.config.ui.model_position.y = relativeY;
+        }
+        this.config.ui.model_scale = legacyScale;
+
+        ipcRenderer.send('save-model-position', {
+            x: relativeX,
+            y: relativeY,
+            scale: legacyScale,
+            dual: isDualRight,
+            modelName: this._currentModelName()
+        });
+
+        console.log('[Live2DInteraction] 保存模型位置:', {
+            rel: { x: relativeX.toFixed(4), y: relativeY.toFixed(4) },
+            legacyScale: legacyScale.toFixed(4),
+            dual: isDualRight
+        });
+    }
+
+    _currentModelName() {
+        try {
+            const url = this.model?.internalModel?.settings?.url || '';
+            const m = url.match(/2D\/([^\/]+)\//);
+            return m ? decodeURIComponent(m[1]) : null;
+        } catch (_) {
+            return null;
+        }
+    }
+
+    // 复位到默认位置与缩放（供 HTTP /reset-model-position）
+    resetModelPosition() {
+        if (!this.model) return { success: false };
+        const isDualRight = window.innerWidth > window.screen.width * 1.2 && this.config?.ui?.screen_extend?.right;
+        const relX = isDualRight ? 0.825 : 0.65;
+        const relY = 0.38;
+        const legacyScale = 0.65;
+
+        this.model.x = relX * window.innerWidth;
+        this.model.y = relY * window.innerHeight;
+        this.model.scale.set(legacyScale / LEGACY_SCALE_RATIO);
+        this.updateInteractionArea();
+
+        ipcRenderer.send('save-model-position', {
+            x: relX, y: relY, scale: legacyScale, dual: isDualRight,
+            modelName: this._currentModelName()
+        });
+        return { success: true };
+    }
+
+    // 模型热切换时重绑定
+    rebind(model) {
+        this.model = model;
+        const s = model?.scale?.x || 0.1;
+        this._scaleMin = s * 0.15;
+        this._scaleMax = s * 8;
+        this.updateInteractionArea();
+    }
+
+    destroy() {
+        this._teardownListeners();
+        if (this._saveTimer) {
+            clearTimeout(this._saveTimer);
+            this._saveTimer = null;
+        }
+        this.model = null;
+        this.app = null;
+    }
+}
+
+module.exports = { Live2DInteractionController };

--- a/live-2d/js/avatar/live2d/model-loader.js
+++ b/live-2d/js/avatar/live2d/model-loader.js
@@ -1,0 +1,156 @@
+// model-loader.js - Live2D 模型加载器
+// Adapted from Project-N-E-K-O/N.E.K.O (Apache-2.0): static/live2d-model.js 的
+// loadModel 加载锁 / load token / 失败回退 / 资源销毁 思路。
+const { logToTerminal } = require('../../api-utils.js');
+const { LEGACY_SCALE_RATIO } = require('./core.js');
+
+class Live2DModelLoader {
+    constructor(stage) {
+        this.stage = stage;          // Live2DStage 实例
+        this.currentModel = null;
+        this.currentModelPath = null;
+        this._isLoading = false;
+        this._loadToken = 0;
+        // 模型加载/卸载后的通知（供 facade 更新 global 引用等）
+        this.onModelLoaded = null;   // (model, modelPath) => void
+        this.onModelRemoved = null;  // () => void
+    }
+
+    isLoading() {
+        return this._isLoading;
+    }
+
+    /**
+     * 加载 Live2D 模型（带加载锁与并发 token）
+     * @param {string} modelPath 相对 live-2d 目录的路径，如 "2D/肥牛/肥牛.model3.json"
+     * @param {object} options { config, preferences, fallbackPath, notifyLoaded }
+     *   - config: 全局 config（读取 ui.model_scale / ui.model_position 作为回退）
+     *   - preferences: 该模型的持久化偏好 { position: {x,y,x_dual,y_dual}, scale }（legacy 语义）
+     *   - fallbackPath: 加载失败时回退的模型路径
+     */
+    async loadModel(modelPath, options = {}) {
+        if (this._isLoading) {
+            throw new Error(`模型正在加载中，忽略重复请求: ${modelPath}`);
+        }
+        this._isLoading = true;
+        const token = ++this._loadToken;
+        const previousModel = this.currentModel;
+        const previousModelPath = this.currentModelPath;
+        let candidate = null;
+
+        try {
+            console.log(`[Live2DLoader] 开始加载模型: ${modelPath}`);
+            logToTerminal('info', `[Live2DLoader] 开始加载模型: ${modelPath}`);
+
+            candidate = await PIXI.live2d.Live2DModel.from(modelPath, { autoFocus: false, autoInteract: false });
+
+            // token 过期（加载期间被新的加载请求取代）则丢弃本次结果
+            if (token !== this._loadToken) {
+                await this._destroyModel(candidate);
+                candidate = null;
+                throw new Error('模型加载已被更新的请求取代');
+            }
+
+            this.stage.app.stage.addChild(candidate);
+            this.currentModel = candidate;
+            this.currentModelPath = modelPath;
+
+            this._applyTransform(candidate, options);
+
+            const showModel = options.config?.ui?.show_model !== false;
+            candidate.visible = showModel;
+
+            if (options.notifyLoaded !== false && typeof this.onModelLoaded === 'function') {
+                await this.onModelLoaded(candidate, modelPath);
+            }
+
+            // Keep the old model alive until loading and renderer-side wiring
+            // have succeeded. Replacing it here makes hot-switch failures
+            // recoverable instead of leaving an empty stage.
+            if (previousModel && previousModel !== candidate) {
+                await this._destroyModel(previousModel);
+            }
+
+            console.log(`[Live2DLoader] 模型加载完成: ${modelPath}, 位置(${candidate.x.toFixed(0)}, ${candidate.y.toFixed(0)}), 缩放${candidate.scale.x.toFixed(3)}, 可见=${showModel}`);
+            logToTerminal('info', `[Live2DLoader] 模型加载完成: ${modelPath}`);
+            return candidate;
+        } catch (error) {
+            const failedCandidate = candidate;
+            if (candidate) {
+                await this._destroyModel(candidate);
+                candidate = null;
+            }
+            if (this.currentModel === failedCandidate ||
+                this.currentModel === previousModel ||
+                this.currentModel === null) {
+                this.currentModel = previousModel;
+                this.currentModelPath = previousModelPath;
+            }
+
+            console.error(`[Live2DLoader] 模型加载失败: ${modelPath}`, error);
+            logToTerminal('error', `[Live2DLoader] 模型加载失败: ${modelPath} - ${error.message}`);
+
+            // 失败回退：加载 fallbackPath（只回退一次，避免死循环）
+            const fallback = options.fallbackPath;
+            if (fallback && fallback !== modelPath) {
+                console.warn(`[Live2DLoader] 回退到默认模型: ${fallback}`);
+                this._isLoading = false;
+                return this.loadModel(fallback, { ...options, fallbackPath: null });
+            }
+            throw error;
+        } finally {
+            this._isLoading = false;
+        }
+    }
+
+    async _destroyModel(model) {
+        if (!model) return;
+        try {
+            if (model.parent) model.parent.removeChild(model);
+            model.destroy({ children: true, texture: true, baseTexture: true });
+        } catch (e) {
+            console.warn('[Live2DLoader] 卸载模型时出现警告:', e);
+        }
+    }
+
+    // 应用初始位置与缩放（CSS 像素坐标系；存储值为 legacy 语义，除以 LEGACY_SCALE_RATIO）
+    _applyTransform(model, options = {}) {
+        const config = options.config || {};
+        const prefs = options.preferences || null;
+
+        const stageW = this.stage.width;
+        const stageH = this.stage.height;
+
+        // 缩放：优先 per-model 偏好，回退全局 config
+        const legacyScale = Number(prefs?.scale) > 0
+            ? Number(prefs.scale)
+            : (Number(config.ui?.model_scale) > 0 ? Number(config.ui.model_scale) : 0.24);
+        model.scale.set(legacyScale / LEGACY_SCALE_RATIO);
+
+        // 位置：0~1 相对值（与旧实现语义一致），双屏右扩展时用 x_dual/y_dual
+        const isDualRight = window.innerWidth > window.screen.width * 1.2 && config.ui?.screen_extend?.right;
+        const pos = prefs?.position || config.ui?.model_position || {};
+        const relX = isDualRight ? (pos.x_dual ?? 0.825) : (pos.x ?? 0.65);
+        const relY = isDualRight ? (pos.y_dual ?? 0.38) : (pos.y ?? 0.38);
+        model.x = relX * stageW;
+        model.y = relY * stageH;
+
+        const diag = `[Live2DLoader] transform: stage=${stageW}x${stageH}, rel=(${relX.toFixed(3)}, ${relY.toFixed(3)}), legacyScale=${legacyScale.toFixed(4)}, appliedScale=${(legacyScale / LEGACY_SCALE_RATIO).toFixed(4)}, dual=${isDualRight}`;
+        console.log(diag);
+        logToTerminal('info', diag);
+    }
+
+    // 卸载当前模型并释放纹理
+    async removeModel() {
+        if (!this.currentModel) return;
+        const model = this.currentModel;
+        this.currentModel = null;
+        this.currentModelPath = null;
+        await this._destroyModel(model);
+        if (typeof this.onModelRemoved === 'function') {
+            try { this.onModelRemoved(); } catch (_) {}
+        }
+    }
+}
+
+module.exports = { Live2DModelLoader };

--- a/live-2d/js/avatar/live2d/motion-style-presets.js
+++ b/live-2d/js/avatar/live2d/motion-style-presets.js
@@ -1,0 +1,137 @@
+'use strict';
+
+// motion-style-presets.js - 动作风格预设（对齐 soullink-emotion-sdk engine 的 motionStyle presets）
+// 仅「仅 AI 编舞」档（avatar_motion_mode: 'director'）消费；blend / legacy 档完全不读本文件。
+// 配置入口：config.motion_director.style = 'natural' | 'lively' | 'calm' | 'shy'
+// 可选覆盖：config.motion_director.style_overrides = { vad: {...}, idle: {...}, gaze: {...}, sway: {...}, face_micro: {...} }
+// 可选固定随机序列：config.motion_director.style_seed = <整数>（用于录制回归对比）
+
+const MOTION_STYLE_PRESETS = {
+    // 自然：接近现有默认手感，作为基准档
+    natural: {
+        vad: {
+            baseline: { valence: 0.1, arousal: 0, dominance: 0.05 },
+            reactivity: 1,
+            decay_rate: 0.018,
+            hold_seconds: 18,
+            ambient_drift_strength: 0.034
+        },
+        idle: {
+            spontaneity: 1,
+            gain: 1,
+            avoid_repeat_window: 4,
+            min_interval_seconds: 7,
+            max_interval_seconds: 19,
+            slow_blink_weight: 1,
+            gaze_down_bias: 0
+        },
+        gaze: { stability: 0.55 },
+        sway: { amplitude_scale: 1 },
+        face_micro: { intensity: 1 }
+    },
+    // 活泼：更高唤醒基线、更频繁的自发动作、更游移的视线、更大的动作幅度
+    lively: {
+        vad: {
+            baseline: { valence: 0.22, arousal: 0.18, dominance: 0.12 },
+            reactivity: 1.35,
+            decay_rate: 0.014,
+            hold_seconds: 22,
+            ambient_drift_strength: 0.05
+        },
+        idle: {
+            spontaneity: 1.5,
+            gain: 1.15,
+            avoid_repeat_window: 3,
+            min_interval_seconds: 4.5,
+            max_interval_seconds: 12,
+            slow_blink_weight: 0.7,
+            gaze_down_bias: 0
+        },
+        gaze: { stability: 0.35 },
+        sway: { amplitude_scale: 1.2 },
+        face_micro: { intensity: 1.2 }
+    },
+    // 沉静：低唤醒、动作稀疏而缓慢、视线稳定、慢眨眼偏多
+    calm: {
+        vad: {
+            baseline: { valence: 0.12, arousal: -0.18, dominance: 0.1 },
+            reactivity: 0.75,
+            decay_rate: 0.024,
+            hold_seconds: 14,
+            ambient_drift_strength: 0.02
+        },
+        idle: {
+            spontaneity: 0.6,
+            gain: 0.8,
+            avoid_repeat_window: 5,
+            min_interval_seconds: 10,
+            max_interval_seconds: 26,
+            slow_blink_weight: 1.4,
+            gaze_down_bias: 0
+        },
+        gaze: { stability: 0.8 },
+        sway: { amplitude_scale: 0.75 },
+        face_micro: { intensity: 0.8 }
+    },
+    // 害羞：低支配基线、幅度收敛、视线稳定但偏下、脸红类情绪反应更强
+    shy: {
+        vad: {
+            baseline: { valence: 0.08, arousal: 0.05, dominance: -0.22 },
+            reactivity: 1.1,
+            decay_rate: 0.02,
+            hold_seconds: 20,
+            ambient_drift_strength: 0.03,
+            emotionBias: { shy: 1.25, happy: 1.05 }
+        },
+        idle: {
+            spontaneity: 0.85,
+            gain: 0.7,
+            avoid_repeat_window: 4,
+            min_interval_seconds: 6,
+            max_interval_seconds: 16,
+            slow_blink_weight: 1.2,
+            gaze_down_bias: 0.3
+        },
+        gaze: { stability: 0.7, down_bias: 0.25 },
+        sway: { amplitude_scale: 0.7 },
+        face_micro: { intensity: 1.05 }
+    }
+};
+
+function isPlainObject(value) {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function mergeSection(base, override) {
+    if (!isPlainObject(override)) return { ...(base || {}) };
+    const result = { ...(base || {}) };
+    for (const [key, value] of Object.entries(override)) {
+        if (isPlainObject(value) && isPlainObject(result[key])) result[key] = { ...result[key], ...value };
+        else result[key] = value;
+    }
+    return result;
+}
+
+// 从 config 解析生效的风格预设。未配置 / 配置无效 / 非 director 调用方 → 返回 null（调用方走旧散配置路径）。
+function resolveMotionStyle(config) {
+    const motion = config?.motion_director || {};
+    const rawName = typeof motion.style === 'string' ? motion.style.trim().toLowerCase() : '';
+    if (!rawName || !MOTION_STYLE_PRESETS[rawName]) return null;
+    const base = MOTION_STYLE_PRESETS[rawName];
+    const overrides = isPlainObject(motion.style_overrides) ? motion.style_overrides : {};
+    const seedRaw = Number(motion.style_seed);
+    return {
+        name: rawName,
+        seed: Number.isFinite(seedRaw) ? Math.floor(seedRaw) : null,
+        vad: mergeSection(base.vad, overrides.vad),
+        idle: mergeSection(base.idle, overrides.idle),
+        gaze: mergeSection(base.gaze, overrides.gaze),
+        sway: mergeSection(base.sway, overrides.sway),
+        face_micro: mergeSection(base.face_micro, overrides.face_micro)
+    };
+}
+
+module.exports = {
+    MOTION_STYLE_PRESETS,
+    resolveMotionStyle
+};

--- a/live-2d/js/avatar/live2d/param-director.js
+++ b/live-2d/js/avatar/live2d/param-director.js
@@ -1,0 +1,948 @@
+// param-director.js - Live2D 参数导演（待机微动 + 说话摇摆 + 关键帧编舞）
+const fs = require('fs');
+const path = require('path');
+const { eventBus } = require('../../core/event-bus.js');
+const { Events } = require('../../core/events.js');
+const { logToTerminal } = require('../../api-utils.js');
+const { getAvatarMotionMode, shouldUseParamDirector } = require('../motion-mode.js');
+const { vadState } = require('./vad-state.js');
+const { FaceMicroMotion } = require('./face-micro-motion.js');
+const { resolveMotionStyle } = require('./motion-style-presets.js');
+const { IdleActionScheduler } = require('./idle-action-scheduler.js');
+const { normalizeDuration } = require('./duration-utils.js');
+
+const APP_ROOT = path.join(__dirname, '..', '..', '..');
+const TWO_PI = Math.PI * 2;
+const RELEASE_MS = 600;
+const CANCEL_RELEASE_MS = 500;
+const NO_PROGRESS_FALLBACK_MS = 1500;
+const ESTIMATED_CHAR_MS = 210;
+// 'idle' 通道为「仅 AI 编舞」档的离散待机动作专用（idle-action-scheduler），blend/legacy 不产生该通道帧
+const VALID_TIMELINE_CHANNELS = new Set(['body', 'face', 'default', 'idle']);
+
+const PARAM_WHITELIST = /^(ParamAngle[XYZ]|Param[345]|ParamBodyAngle[XYZ]\d*|ParamEye[LR]Open|ParamEye[LR]Smile|Eye[LR]_Squint|ParamEyeBall[XY]|ParamBrow[LR](Y|X|Angle|Form)|Param(74|100)|ParamCheek|ParamCheeckPuff|ParamMouth(Form|Funnel|PressLipOpen|Shrug|X|PuckerWiden)|ParamJawOpen)$/;
+const ANGLE_PARAMS = ['ParamAngleX', 'ParamAngleY', 'ParamAngleZ', 'ParamBodyAngleX', 'ParamBodyAngleY', 'ParamBodyAngleZ'];
+const EYE_CONTROL_PARAMS = new Set(['ParamEyeLOpen', 'ParamEyeROpen', 'ParamEyeLSmile', 'ParamEyeRSmile', 'EyeL_Squint', 'EyeR_Squint']);
+
+const NORMAL_IDLE = {
+    ParamAngleX: 4,
+    ParamAngleY: 3,
+    ParamAngleZ: 3,
+    ParamBodyAngleX: 2,
+    ParamBodyAngleY: 0,
+    ParamBodyAngleZ: 1.5
+};
+
+const NORMAL_SWAY = {
+    ParamAngleX: 6,
+    ParamAngleY: 1,
+    ParamAngleZ: 9,
+    ParamBodyAngleX: 4.2,
+    ParamBodyAngleY: 1.2,
+    ParamBodyAngleZ: 5.8
+};
+
+const INTENSITY_SCALE = {
+    subtle: 0.5,
+    normal: 1,
+    dramatic: 1.6
+};
+
+function clamp(value, min, max) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return min;
+    return Math.max(min, Math.min(max, n));
+}
+
+function easeInOutCubic(t) {
+    const x = clamp(t, 0, 1);
+    return x < 0.5 ? 4 * x * x * x : 1 - Math.pow(-2 * x + 2, 3) / 2;
+}
+
+function readParamValue(coreModel, info) {
+    try {
+        return coreModel.getParameterValueByIndex(info.index);
+    } catch (_) {
+        return info.default;
+    }
+}
+
+function writeParamValue(coreModel, info, value) {
+    try {
+        coreModel.setParameterValueByIndex(info.index, clamp(value, info.min, info.max));
+    } catch (_) {}
+}
+
+class ParamDirector {
+    constructor(config) {
+        this.model = null;
+        this.coreModel = null;
+        this.config = {};
+        this.bodyConfig = {};
+        this._motionMode = 'blend';
+
+        this._catalog = [];
+        this._catalogById = new Map();
+        this._visibleCatalog = [];
+        this._angleInfos = [];
+        this._phase = new Map();
+
+        this._speaking = false;
+        this._pendingSpeech = false;
+        this._totalChars = 0;
+        this._lastProgressChars = 0;
+        this._lastProgressAt = 0;
+        this._speechStartAt = 0;
+        this._timelines = new Map();
+        this._energy = 0;
+        this._lastVadRuntime = vadState.getState();
+        this._faceMicro = new FaceMicroMotion();
+        this._faceMicroConfig = { enabled: true, intensity: 1 };
+        this._style = null;                    // 仅 director 档：解析后的风格预设
+        this._idleScheduler = new IdleActionScheduler();
+        this._idleActionsEnabled = false;      // 仅 director 档为 true
+        this._vadEnergyAccumMs = 0;
+
+        this._active = new Map();
+        this._lastApplied = new Map();
+
+        this._boundTtsStart = () => this._onTtsStart();
+        this._boundTtsEnd = () => this.endSpeech();
+        this._boundTtsInterrupted = () => this.cancel();
+        this._eventsAttached = false;
+
+        this.updateConfig(config);
+        this._attachEvents();
+    }
+
+    attach(model, coreModel) {
+        this.detach(false);
+        this.model = model;
+        this.coreModel = coreModel;
+
+        if (!coreModel || typeof coreModel.getParameterCount !== 'function') {
+            logToTerminal('warn', '[ParamDirector] coreModel 不可用，跳过参数导演');
+            return false;
+        }
+
+        this._buildCatalog(model, coreModel);
+        this._cacheAngleParams();
+        if (this._catalog.length === 0 || this._angleInfos.length === 0) {
+            logToTerminal('warn', '[ParamDirector] 未找到可驱动的角度参数，跳过参数导演');
+            return false;
+        }
+
+        this._resetRuntimeState();
+        logToTerminal('info', `[ParamDirector] 已启用，参数=${this._catalog.length}，可编舞=${this._visibleCatalog.length}`);
+        return true;
+    }
+
+    detach(removeEvents = true) {
+        if (removeEvents) this._detachEvents();
+        this.model = null;
+        this.coreModel = null;
+        this._catalog = [];
+        this._catalogById.clear();
+        this._visibleCatalog = [];
+        this._angleInfos = [];
+        this._phase.clear();
+        this._resetRuntimeState();
+    }
+
+    updateConfig(config) {
+        this.config = config || {};
+        this._motionMode = getAvatarMotionMode(this.config);
+        if (this._motionMode === 'legacy') {
+            this._resetRuntimeState();
+        }
+        const body = this.config?.ui?.body_motion || {};
+        const motion = this.config?.motion_director || {};
+        const vadCfg = motion.vad || {};
+        const faceMicroCfg = motion.face_micro || {};
+        try {
+            vadState.configure({
+                baseline: vadCfg.baseline || { valence: 0.1, arousal: 0, dominance: 0.05 },
+                reactivity: vadCfg.reactivity,
+                decay_rate: vadCfg.decay_rate,
+                hold_seconds: vadCfg.hold_seconds,
+                ambient_drift_strength: vadCfg.ambient_drift_strength
+            });
+        } catch (_) {}
+        this._faceMicroConfig = {
+            enabled: faceMicroCfg.enabled !== false,
+            intensity: this._positiveNumber(faceMicroCfg.intensity, 1)
+        };
+        const intensity = INTENSITY_SCALE[body.intensity] ? body.intensity : 'normal';
+        const enabled = shouldUseParamDirector(this.config);
+        const directorMode = this._motionMode === 'director';
+        const audioSwayEnabled = directorMode
+            ? body.director_audio_sway_enabled === true
+            : body.sway_enabled !== false;
+        this.bodyConfig = {
+            intensity,
+            idle_enabled: enabled && body.idle_enabled !== false,
+            director_idle_during_speech: directorMode && body.director_idle_during_speech === true,
+            sway_enabled: enabled && audioSwayEnabled,
+            idle_amplitude: this._positiveNumber(body.idle_amplitude, 1),
+            sway_amplitude: this._positiveNumber(body.sway_amplitude, 1),
+            sway_frequency: clamp(Number(body.sway_frequency) || 0.28, 0.12, 0.8),
+            sway_modulation: clamp(Number(vadCfg.sway_modulation ?? 0.35), 0, 1)
+        };
+        this._applyDirectorStyle(directorMode, motion, vadCfg, faceMicroCfg);
+    }
+
+    // 仅 director 档：应用风格预设（natural/lively/calm/shy）并装配离散待机动作调度器。
+    // blend / legacy 档：_style=null、调度器禁用，上面的旧配置路径原样生效。
+    _applyDirectorStyle(directorMode, motion = {}, vadCfg = {}, faceMicroCfg = {}) {
+        this._style = null;
+        this._idleActionsEnabled = false;
+        if (!directorMode) return;
+
+        const style = resolveMotionStyle(this.config);
+        this._style = style;
+        if (style) {
+            // 预设先落，用户显式写在 motion_director.vad 里的散值再覆盖（用户配置优先）
+            try {
+                vadState.configure(style.vad);
+                const explicit = {};
+                if (vadCfg.baseline) explicit.baseline = vadCfg.baseline;
+                for (const key of ['reactivity', 'decay_rate', 'hold_seconds', 'ambient_drift_strength']) {
+                    if (vadCfg[key] !== undefined) explicit[key] = vadCfg[key];
+                }
+                if (Object.keys(explicit).length > 0) vadState.configure(explicit);
+            } catch (_) {}
+            const swayScale = this._positiveNumber(style.sway?.amplitude_scale, 1);
+            this.bodyConfig.idle_amplitude *= swayScale;
+            this.bodyConfig.sway_amplitude *= swayScale;
+            if (faceMicroCfg.intensity === undefined) {
+                this._faceMicroConfig.intensity = this._positiveNumber(style.face_micro?.intensity, 1);
+            }
+        }
+
+        const idleActionsCfg = motion.idle_actions || {};
+        this._idleActionsEnabled = idleActionsCfg.enabled !== false;
+        if (this._idleActionsEnabled) {
+            const options = { ...(style?.idle || {}), ...idleActionsCfg };
+            const seed = idleActionsCfg.seed ?? style?.seed ?? null;
+            this._idleScheduler.configure(options, seed);
+        }
+    }
+
+    applyFrame(coreModel, now, deltaMs, speechEnergy) {
+        if (this._motionMode === 'legacy') return;
+        if (!coreModel || this._angleInfos.length === 0) return;
+
+        this._updateEnergy(speechEnergy, deltaMs);
+        const vadRuntime = this._updateVad(deltaMs);
+        this._accumulateVadEnergy(deltaMs);
+        this._applyTimelineFallback(now);
+        this._advanceKeyframes(now);
+        this._tickIdleActions(now, vadRuntime);
+
+        const t = now / 1000;
+        const swayFreq = this.bodyConfig.sway_frequency + 0.035 * Math.sin(TWO_PI * 0.017 * t);
+        const bodyGain = this._vadBodyGain();
+        const touched = new Set();
+
+        for (const info of this._angleInfos) {
+            const cur = readParamValue(coreModel, info);
+            const offset = (this._idleOffset(info, t) + this._swayOffset(info, t, swayFreq)) * bodyGain;
+            const value = cur + offset;
+            this._lastApplied.set(info.id, value);
+            touched.add(info.id);
+            writeParamValue(coreModel, info, value);
+        }
+
+        this._applyFaceMicroOffsets(coreModel, t, vadRuntime, touched);
+
+        for (const state of Array.from(this._active.values())) {
+            const info = state.info;
+            const base = touched.has(info.id)
+                ? this._lastApplied.get(info.id)
+                : readParamValue(coreModel, info);
+            const w = state.weight;
+            const value = base * (1 - w) + state.value * w;
+            this._lastApplied.set(info.id, value);
+            writeParamValue(coreModel, info, value);
+        }
+    }
+
+    prepareSpeech(totalChars) {
+        if (this._motionMode === 'legacy') return;
+        const chars = Math.max(0, Math.floor(Number(totalChars) || 0));
+        if (chars <= 0) return;
+        this._pendingSpeech = true;
+        this._totalChars = chars;
+        this._lastProgressChars = 0;
+        this._lastProgressAt = 0;
+        this._clearTimelines();
+    }
+
+    noteSpeechProgress(absChars) {
+        if (this._motionMode === 'legacy') return;
+        const chars = Math.max(0, Math.floor(Number(absChars) || 0));
+        if (chars <= this._lastProgressChars && this._lastProgressAt > 0) return;
+        this._lastProgressChars = chars;
+        this._lastProgressAt = performance.now();
+        this._consumeTimeline(chars / Math.max(1, this._totalChars));
+    }
+
+    endSpeech() {
+        this._speaking = false;
+        this._pendingSpeech = false;
+        this._clearTimelines();
+        this._totalChars = 0;
+        const now = performance.now();
+        for (const state of this._active.values()) {
+            this._startRelease(state, now, normalizeDuration(state.releaseMs, RELEASE_MS));
+        }
+    }
+
+    cancel() {
+        this._speaking = false;
+        this._pendingSpeech = false;
+        this._clearTimelines();
+        this._totalChars = 0;
+        this._energy = 0;
+        const now = performance.now();
+        for (const state of this._active.values()) {
+            this._startRelease(state, now, CANCEL_RELEASE_MS);
+        }
+        if (this._idleScheduler) this._idleScheduler.interrupt(now);
+        // 仅 director 档：被打断的"错愕"——arousal 瞬时小脉冲 + dominance 微降
+        if (this._motionMode === 'director') {
+            const vadCfg = this.config?.motion_director?.vad || {};
+            if (vadCfg.enabled !== false && vadCfg.interrupt_pulse_enabled !== false) {
+                try { vadState.nudgeVAD({ arousal: 0.14, dominance: -0.1 }, 1); } catch (_) {}
+            }
+        }
+    }
+
+    loadTimeline(keyframes, totalChars, channel = 'default') {
+        if (this._motionMode === 'legacy') return false;
+        if (!this._pendingSpeech && !this._speaking) {
+            logToTerminal('warn', '[ParamDirector] 收到过期 timeline，已丢弃');
+            return false;
+        }
+        if (!Array.isArray(keyframes) || keyframes.length === 0) return false;
+        const timelineChannel = this._normalizeChannel(channel);
+        const chars = Math.max(0, Math.floor(Number(totalChars) || this._totalChars || 0));
+        if (chars > 0) this._totalChars = chars;
+        const timeline = this._normalizeTimelineFrames(keyframes);
+        this._timelines.set(timelineChannel, timeline);
+        return timeline.length > 0;
+    }
+
+    appendTimelineFrames(frames, channel = 'default') {
+        if (this._motionMode === 'legacy') return false;
+        if (!this._pendingSpeech && !this._speaking) {
+            logToTerminal('warn', '[ParamDirector] 收到过期 timeline 追加，已丢弃');
+            return false;
+        }
+        if (!Array.isArray(frames) || frames.length === 0) return false;
+        const timelineChannel = this._normalizeChannel(channel);
+        const normalized = this._normalizeTimelineFrames(frames);
+        if (normalized.length === 0) return false;
+
+        const now = performance.now();
+        const frac = this._currentTimelineFrac(now);
+        const future = [];
+        let dueFrame = null;
+        for (const frame of normalized) {
+            if (frame.at <= frac) {
+                if (!dueFrame || frame.at >= dueFrame.at) dueFrame = frame;
+            } else {
+                future.push(frame);
+            }
+        }
+
+        if (future.length > 0) {
+            const timeline = this._getTimeline(timelineChannel);
+            timeline.push(...future);
+            timeline.sort((a, b) => a.at - b.at);
+            this._timelines.set(timelineChannel, timeline);
+        }
+        if (dueFrame) this._startKeyframe(dueFrame, now, timelineChannel);
+        return future.length > 0 || !!dueFrame;
+    }
+
+    truncateTimeline(channel = 'default', fromAt = 0) {
+        const timelineChannel = this._normalizeChannel(channel);
+        const timeline = this._getTimeline(timelineChannel);
+        if (timeline.length === 0) return 0;
+        const threshold = clamp(fromAt, 0, 1);
+        const kept = timeline.filter(frame => frame.at < threshold);
+        const removed = timeline.length - kept.length;
+        this._timelines.set(timelineChannel, kept);
+        return removed;
+    }
+
+    fireKeyframe(params, transitionMs = 400, holdMs = 1000, channel = 'default') {
+        if (this._motionMode === 'legacy') return false;
+        if (!params || typeof params !== 'object') return false;
+        const frame = {
+            params,
+            transition_ms: normalizeDuration(transitionMs, 400, { max: 4000 }),
+            hold_ms: normalizeDuration(holdMs, 1000, { max: 8000 })
+        };
+        return this._startKeyframe(frame, performance.now(), this._normalizeChannel(channel));
+    }
+
+    isChoreographyActive() {
+        if (this._motionMode === 'legacy') return false;
+        // 'idle' 通道的离散待机动作不算"编舞进行中"：既不阻断呼吸待机，也不触发调度器自锁。
+        // blend 档没有任何 idle 通道帧，此判定与旧实现等价。
+        for (const [channel, timeline] of this._timelines.entries()) {
+            if (channel !== 'idle' && Array.isArray(timeline) && timeline.length > 0) return true;
+        }
+        for (const state of this._active.values()) {
+            if (state.channel !== 'idle') return true;
+        }
+        return false;
+    }
+
+    isEyeControlled() {
+        if (this._motionMode === 'legacy') return false;
+        for (const state of this._active.values()) {
+            if (state.weight > 0.01 && EYE_CONTROL_PARAMS.has(state.info.id)) return true;
+        }
+        return false;
+    }
+
+    getParamCatalog() {
+        return this._visibleCatalog.map(item => ({ ...item }));
+    }
+
+    _attachEvents() {
+        if (this._eventsAttached) return;
+        eventBus.on(Events.TTS_START, this._boundTtsStart);
+        eventBus.on(Events.TTS_END, this._boundTtsEnd);
+        eventBus.on(Events.TTS_INTERRUPTED, this._boundTtsInterrupted);
+        this._eventsAttached = true;
+    }
+
+    _detachEvents() {
+        if (!this._eventsAttached) return;
+        eventBus.off(Events.TTS_START, this._boundTtsStart);
+        eventBus.off(Events.TTS_END, this._boundTtsEnd);
+        eventBus.off(Events.TTS_INTERRUPTED, this._boundTtsInterrupted);
+        this._eventsAttached = false;
+    }
+
+    _onTtsStart() {
+        this._speaking = true;
+        this._pendingSpeech = false;
+        this._speechStartAt = performance.now();
+        this._lastProgressAt = 0;
+        this._lastProgressChars = 0;
+        this._interruptIdleActions(260);
+    }
+
+    // 语音/编舞开始时：清空调度器待发步骤，并把 idle 通道在演的动作 260ms 内快速淡出
+    _interruptIdleActions(fadeMs = 260) {
+        const now = performance.now();
+        if (this._idleScheduler) this._idleScheduler.interrupt(now);
+        for (const state of this._active.values()) {
+            if (state.channel === 'idle' && state.phase !== 'release') {
+                this._startRelease(state, now, clamp(fadeMs, 80, 600));
+            }
+        }
+    }
+
+    // 仅 director 档：驱动离散待机动作调度器
+    _tickIdleActions(now, vadRuntime) {
+        if (this._motionMode !== 'director' || !this._idleActionsEnabled || !this._idleScheduler) return;
+        const busy = this._speaking || this._pendingSpeech || this._hasNonIdleActivity();
+        this._idleScheduler.tick(now, {
+            active: !busy,
+            vad: (vadRuntime || this._lastVadRuntime || {}).current || {},
+            fire: (frame) => this._playIdleFrame(frame)
+        });
+    }
+
+    _playIdleFrame(frame) {
+        const normalized = this._normalizeTimelineFrames([frame]);
+        if (normalized.length === 0) return false;
+        return this._startKeyframe(normalized[0], performance.now(), 'idle');
+    }
+
+    _hasNonIdleActivity() {
+        for (const [channel, timeline] of this._timelines.entries()) {
+            if (channel !== 'idle' && Array.isArray(timeline) && timeline.length > 0) return true;
+        }
+        for (const state of this._active.values()) {
+            if (state.channel !== 'idle' && state.weight > 0.01) return true;
+        }
+        return false;
+    }
+
+    // 仅 director 档：说话能量持续小幅推 arousal（VAD 第二输入源）
+    _accumulateVadEnergy(deltaMs) {
+        if (this._motionMode !== 'director') return;
+        const vadCfg = this.config?.motion_director?.vad || {};
+        if (vadCfg.enabled === false || vadCfg.energy_input_enabled === false) return;
+        if (!this._speaking || this._energy <= 0.02) {
+            this._vadEnergyAccumMs = 0;
+            return;
+        }
+        this._vadEnergyAccumMs += Math.max(1, deltaMs || 16.6);
+        if (this._vadEnergyAccumMs < 500) return;
+        this._vadEnergyAccumMs = 0;
+        const gain = clamp(Number(vadCfg.energy_arousal_gain ?? 0.05), 0, 0.5);
+        if (gain <= 0) return;
+        try { vadState.nudgeVAD({ arousal: this._energy * gain }, 0.5); } catch (_) {}
+    }
+
+    _resetRuntimeState() {
+        this._speaking = false;
+        this._pendingSpeech = false;
+        this._totalChars = 0;
+        this._lastProgressChars = 0;
+        this._lastProgressAt = 0;
+        this._speechStartAt = 0;
+        this._clearTimelines();
+        this._energy = 0;
+        this._active.clear();
+        this._lastApplied.clear();
+        if (this._faceMicro) this._faceMicro.reset();
+    }
+
+    _buildCatalog(model, coreModel) {
+        this._catalog = [];
+        this._catalogById.clear();
+        const names = this._readDisplayNames(model);
+        const count = coreModel.getParameterCount();
+
+        for (let i = 0; i < count; i++) {
+            const id = this._getParamId(coreModel, i);
+            if (!id) continue;
+            const min = this._getParamBound(coreModel, i, 'min');
+            const max = this._getParamBound(coreModel, i, 'max');
+            const def = this._getParamBound(coreModel, i, 'default');
+            const info = {
+                id,
+                index: i,
+                min: Number.isFinite(min) ? min : -30,
+                max: Number.isFinite(max) ? max : 30,
+                default: Number.isFinite(def) ? def : 0,
+                name: names[id] || ''
+            };
+            if (info.max < info.min) {
+                const tmp = info.max;
+                info.max = info.min;
+                info.min = tmp;
+            }
+            this._catalog.push(info);
+            this._catalogById.set(id, info);
+        }
+
+        this._visibleCatalog = this._catalog
+            .filter(info => info.id !== 'ParamMouthOpenY' && PARAM_WHITELIST.test(info.id))
+            .map(info => ({
+                id: info.id,
+                name: info.name,
+                min: info.min,
+                max: info.max,
+                default: info.default
+            }));
+    }
+
+    _cacheAngleParams() {
+        this._angleInfos = [];
+        for (const id of ANGLE_PARAMS) {
+            const info = this._catalogById.get(id);
+            if (!info) continue;
+            this._angleInfos.push(info);
+            this._phase.set(id, {
+                p1: Math.random() * TWO_PI,
+                p2: Math.random() * TWO_PI,
+                f1: 0.065 + Math.random() * 0.015,
+                f2: 0.107 + Math.random() * 0.019
+            });
+        }
+    }
+
+    _readDisplayNames(model) {
+        const result = {};
+        const displayInfo = this._resolveDisplayInfoPath(model);
+        if (!displayInfo) return result;
+        try {
+            const json = JSON.parse(fs.readFileSync(displayInfo, 'utf8'));
+            const groups = Array.isArray(json.Parameters) ? json.Parameters : [];
+            for (const item of groups) {
+                if (item?.Id && item?.Name) result[item.Id] = item.Name;
+            }
+        } catch (_) {}
+        return result;
+    }
+
+    _resolveDisplayInfoPath(model) {
+        try {
+            const settings = model?.internalModel?.settings;
+            const displayInfo = settings?.json?.FileReferences?.DisplayInfo || settings?.FileReferences?.DisplayInfo;
+            if (!displayInfo) return null;
+            const rawUrl = String(settings?.url || '');
+            const decoded = decodeURIComponent(rawUrl).replace(/^\/?live-2d\//, '').replace(/^\/+/, '');
+            const modelJsonPath = path.isAbsolute(decoded) ? decoded : path.join(APP_ROOT, decoded);
+            const baseDir = path.dirname(modelJsonPath);
+            const fullPath = path.join(baseDir, String(displayInfo).replace(/\//g, path.sep));
+            return fs.existsSync(fullPath) ? fullPath : null;
+        } catch (_) {
+            return null;
+        }
+    }
+
+    _getParamId(coreModel, index) {
+        try {
+            if (typeof coreModel.getParameterId === 'function') return coreModel.getParameterId(index);
+        } catch (_) {}
+        try {
+            return coreModel._model?.parameters?.ids?.[index] || null;
+        } catch (_) {
+            return null;
+        }
+    }
+
+    _getParamBound(coreModel, index, kind) {
+        const field = kind === 'min' ? 'minimumValues' : kind === 'max' ? 'maximumValues' : 'defaultValues';
+        try {
+            const value = coreModel._model?.parameters?.[field]?.[index];
+            if (Number.isFinite(Number(value))) return Number(value);
+        } catch (_) {}
+
+        const method = kind === 'min'
+            ? 'getParameterMinimumValue'
+            : kind === 'max'
+                ? 'getParameterMaximumValue'
+                : 'getParameterDefaultValue';
+        try {
+            if (typeof coreModel[method] === 'function') {
+                const value = coreModel[method](index);
+                if (Number.isFinite(Number(value))) return Number(value);
+            }
+        } catch (_) {}
+        return NaN;
+    }
+
+    _positiveNumber(value, fallback) {
+        const n = Number(value);
+        return Number.isFinite(n) && n >= 0 ? n : fallback;
+    }
+
+    _amplitude(info, table, multiplier) {
+        const raw = (table[info.id] || 0) * multiplier;
+        if (!raw) return 0;
+        const rangeCap = Math.max(Math.abs(info.min), Math.abs(info.max));
+        return rangeCap > 0 && rangeCap < 10 ? Math.min(raw, rangeCap * 0.8) : raw;
+    }
+
+    _idleOffset(info, t) {
+        if (!this.bodyConfig.idle_enabled) return 0;
+        if (this._motionMode === 'director' && !this.bodyConfig.director_idle_during_speech && this.isChoreographyActive()) return 0;
+        const phase = this._phase.get(info.id);
+        if (!phase) return 0;
+        const scale = INTENSITY_SCALE[this.bodyConfig.intensity] * this.bodyConfig.idle_amplitude;
+        const amp = this._amplitude(info, NORMAL_IDLE, scale);
+        if (!amp) return 0;
+        const noise = 0.6 * Math.sin(TWO_PI * phase.f1 * t + phase.p1) +
+            0.4 * Math.sin(TWO_PI * phase.f2 * t + phase.p2);
+        return amp * noise;
+    }
+
+    _swayOffset(info, t, swayFreq) {
+        if (!this.bodyConfig.sway_enabled) return 0;
+        const scale = INTENSITY_SCALE[this.bodyConfig.intensity] * this.bodyConfig.sway_amplitude;
+        const amp = this._amplitude(info, NORMAL_SWAY, scale);
+        if (!amp || this._energy <= 0.001) return 0;
+
+        switch (info.id) {
+            case 'ParamAngleZ':
+                return this._energy * amp * Math.sin(TWO_PI * swayFreq * t);
+            case 'ParamAngleX':
+                return this._energy * amp * Math.sin(TWO_PI * swayFreq * 0.7 * t + 1.1);
+            case 'ParamBodyAngleZ':
+                return this._energy * amp * Math.sin(TWO_PI * swayFreq * t - 0.55);
+            case 'ParamBodyAngleX':
+                return this._energy * amp * Math.sin(TWO_PI * swayFreq * 0.7 * t + 0.6);
+            case 'ParamBodyAngleY':
+                return this._energy * amp * Math.sin(TWO_PI * swayFreq * 0.55 * t - 0.4);
+            default:
+                return 0;
+        }
+    }
+
+    _updateEnergy(speechEnergy, deltaMs) {
+        const target = this._speaking ? clamp(speechEnergy || 0, 0, 1.5) / 1.5 : 0;
+        const tau = target > this._energy ? 200 : 800;
+        const alpha = 1 - Math.exp(-Math.max(1, deltaMs || 16.6) / tau);
+        this._energy += (target - this._energy) * alpha;
+        if (this._energy < 0.001) this._energy = 0;
+    }
+
+    _normalizeChannel(channel) {
+        const value = String(channel || 'default').trim();
+        return VALID_TIMELINE_CHANNELS.has(value) ? value : 'default';
+    }
+
+    _clearTimelines() {
+        this._timelines = new Map();
+    }
+
+    _getTimeline(channel) {
+        const timeline = this._timelines.get(channel);
+        return Array.isArray(timeline) ? timeline : [];
+    }
+
+    _hasQueuedTimelineFrames() {
+        for (const timeline of this._timelines.values()) {
+            if (Array.isArray(timeline) && timeline.length > 0) return true;
+        }
+        return false;
+    }
+
+    _normalizeTimelineFrames(keyframes) {
+        return (Array.isArray(keyframes) ? keyframes : [])
+            .map(frame => ({
+                at: clamp(frame.at, 0, 1),
+                params: frame.params || {},
+                transition_ms: normalizeDuration(frame.transition_ms, 400),
+                hold_ms: normalizeDuration(frame.hold_ms, 800),
+                release_ms: normalizeDuration(frame.release_ms, RELEASE_MS),
+                sticky: frame.sticky === true,
+                release_params: Array.isArray(frame.release_params) ? frame.release_params.map(String) : [],
+                hold_group: typeof frame.hold_group === 'string' ? frame.hold_group.trim() : '',
+                param_timing: this._normalizeParamTiming(frame.param_timing)
+            }))
+            .filter(frame => frame.params && Object.keys(frame.params).length > 0)
+            .sort((a, b) => a.at - b.at);
+    }
+
+    _currentTimelineFrac(now = performance.now()) {
+        if (this._totalChars <= 0) return 0;
+        if (this._lastProgressChars > 0) {
+            return clamp(this._lastProgressChars / Math.max(1, this._totalChars), 0, 1);
+        }
+        if (this._speaking && this._speechStartAt > 0 && now - this._speechStartAt >= NO_PROGRESS_FALLBACK_MS) {
+            return clamp((now - this._speechStartAt) / Math.max(1, this._totalChars * this._estimatedCharMs()), 0, 1);
+        }
+        return 0;
+    }
+
+    // 估算语速（无进度回报时的时钟推进用）。仅 director 档允许通过
+    // motion_director.estimated_char_ms 调整（如字节流式 TTS 语速偏快/偏慢时校准）；blend 档恒为 210。
+    _estimatedCharMs() {
+        if (this._motionMode !== 'director') return ESTIMATED_CHAR_MS;
+        const value = Number(this.config?.motion_director?.estimated_char_ms);
+        return Number.isFinite(value) && value >= 60 && value <= 600 ? value : ESTIMATED_CHAR_MS;
+    }
+
+    _updateVad(deltaMs) {
+        if (this.config?.motion_director?.vad?.enabled === false) return null;
+        try {
+            const runtime = vadState.update(Math.max(1, deltaMs || 16.6) / 1000);
+            this._lastVadRuntime = runtime;
+            return runtime;
+        } catch (_) {
+            return this._lastVadRuntime;
+        }
+    }
+
+    _vadBodyGain() {
+        const arousal = Number(this._lastVadRuntime?.current?.arousal) || 0;
+        const modulation = Number(this.bodyConfig?.sway_modulation) || 0;
+        return clamp(1 + modulation * Math.max(0, arousal), 1, 1.4);
+    }
+
+    _applyFaceMicroOffsets(coreModel, timeSeconds, vadRuntime, touched) {
+        if (!this._faceMicroConfig.enabled || this.config?.motion_director?.vad?.enabled === false) return;
+        if (!this._faceMicro || !vadRuntime) return;
+        const directorMode = this._motionMode === 'director';
+        const motionCfg = this.config?.motion_director || {};
+        const offsets = this._faceMicro.compute({
+            timeSeconds,
+            vadState: vadRuntime,
+            catalogById: this._catalogById,
+            speaking: this._speaking,
+            intensity: this._faceMicroConfig.intensity,
+            // 仅 director 档传入（undefined = face-micro 旧行为，blend 档不变）：
+            mouthFormScale: directorMode
+                ? clamp(Number(motionCfg.face?.mouth_form_speech_scale ?? motionCfg.mouth_form_speech_scale ?? 0.5), 0, 1)
+                : undefined,
+            gazeStability: directorMode && this._style ? Number(this._style.gaze?.stability) : undefined,
+            activeWeight: (id) => Math.max(
+                this._activeWeightForParam(id),
+                Number(global.auDriver?.activeWeightForParam?.(id)) || 0
+            )
+        });
+        for (const [id, offset] of Object.entries(offsets || {})) {
+            const info = this._catalogById.get(id);
+            if (!info) continue;
+            const base = touched.has(id)
+                ? this._lastApplied.get(id)
+                : readParamValue(coreModel, info);
+            const value = clamp(base + Number(offset), info.min, info.max);
+            this._lastApplied.set(id, value);
+            touched.add(id);
+            writeParamValue(coreModel, info, value);
+        }
+    }
+
+    _activeWeightForParam(id, channel = null) {
+        const state = this._active.get(id);
+        if (!state || state.phase === 'release') return 0;
+        if (channel && state.channel !== channel) return 0;
+        return clamp(state.weight || 0, 0, 1);
+    }
+
+    _applyTimelineFallback(now) {
+        if (!this._speaking || !this._hasQueuedTimelineFrames() || this._totalChars <= 0) return;
+        if (this._lastProgressAt > 0) return;
+        if (now - this._speechStartAt < NO_PROGRESS_FALLBACK_MS) return;
+        const frac = (now - this._speechStartAt) / Math.max(1, this._totalChars * this._estimatedCharMs());
+        this._consumeTimeline(frac);
+    }
+
+    _consumeTimeline(frac) {
+        if (!this._hasQueuedTimelineFrames()) return;
+        const at = clamp(frac, 0, 1);
+        for (const [channel, timeline] of Array.from(this._timelines.entries())) {
+            if (!Array.isArray(timeline) || timeline.length === 0) continue;
+            let index = -1;
+            for (let i = 0; i < timeline.length; i++) {
+                if (timeline[i].at <= at) index = i;
+                else break;
+            }
+            if (index < 0) continue;
+            const frame = timeline[index];
+            timeline.splice(0, index + 1);
+            this._timelines.set(channel, timeline);
+            this._startKeyframe(frame, performance.now(), channel);
+        }
+    }
+
+    _startKeyframe(frame, now, channel = 'default') {
+        const timelineChannel = this._normalizeChannel(channel);
+        let changed = false;
+        const entries = Object.entries(frame.params || {})
+            .filter(([id]) => this._catalogById.has(id));
+        if (entries.length === 0) return false;
+
+        const incomingIds = new Set(entries.map(([id]) => id));
+        const releaseParamIds = new Set(Array.isArray(frame.release_params) ? frame.release_params.map(String) : []);
+        for (const [id, state] of this._active.entries()) {
+            const shouldRelease = timelineChannel === 'default' || state.channel === timelineChannel;
+            const protectedGroup = !!state.holdGroup;
+            if (shouldRelease && !protectedGroup && !incomingIds.has(id) && state.phase !== 'release') {
+                this._startRelease(state, now, normalizeDuration(state.releaseMs, RELEASE_MS));
+            }
+        }
+
+        for (const [id, rawValue] of entries) {
+            const info = this._catalogById.get(id);
+            const target = clamp(rawValue, info.min, info.max);
+            const existing = this._active.get(id);
+            const current = existing
+                ? existing.value
+                : readParamValue(this.coreModel, info);
+            const timing = frame.param_timing?.[id] || {};
+            const transitionMs = normalizeDuration(timing.transition_ms, frame.transition_ms ?? 400);
+            const holdMs = normalizeDuration(timing.hold_ms, frame.hold_ms ?? 800);
+            const releaseMs = normalizeDuration(timing.release_ms, frame.release_ms ?? RELEASE_MS);
+            const sticky = timing.sticky === true
+                ? true
+                : timing.sticky === false
+                    ? false
+                    : frame.sticky === true && !releaseParamIds.has(id);
+            this._active.set(id, {
+                info,
+                target,
+                from: current,
+                value: current,
+                weight: existing ? existing.weight : 0,
+                fromWeight: existing ? existing.weight : 0,
+                phase: 'transition',
+                phaseStart: now,
+                transitionMs,
+                holdMs,
+                releaseMs,
+                sticky,
+                channel: timelineChannel,
+                holdGroup: timing.hold_group || frame.hold_group || ''
+            });
+            changed = true;
+        }
+        return changed;
+    }
+
+    _advanceKeyframes(now) {
+        for (const [id, state] of Array.from(this._active.entries())) {
+            if (state.phase === 'transition') {
+                if (state.transitionMs <= 0) {
+                    state.phase = 'hold';
+                    state.phaseStart = now;
+                    state.weight = 1;
+                    state.value = state.target;
+                    continue;
+                }
+                const p = easeInOutCubic((now - state.phaseStart) / state.transitionMs);
+                state.weight = state.fromWeight + (1 - state.fromWeight) * p;
+                state.value = state.from + (state.target - state.from) * p;
+                if (p >= 1) {
+                    state.phase = 'hold';
+                    state.phaseStart = now;
+                    state.weight = 1;
+                    state.value = state.target;
+                }
+            }
+            if (state.phase === 'hold') {
+                state.weight = 1;
+                state.value = state.target;
+                if (!state.sticky && now - state.phaseStart >= state.holdMs) {
+                    this._startRelease(state, now, normalizeDuration(state.releaseMs, RELEASE_MS));
+                }
+            }
+            if (state.phase === 'release') {
+                if (state.releaseMs <= 0) {
+                    state.weight = 0;
+                    this._active.delete(id);
+                    continue;
+                }
+                const p = easeInOutCubic((now - state.phaseStart) / state.releaseMs);
+                state.weight = state.releaseFromWeight * (1 - p);
+                state.value = state.releaseValue;
+                if (p >= 1 || state.weight <= 0.001) {
+                    this._active.delete(id);
+                }
+            }
+        }
+    }
+
+    _startRelease(state, now, releaseMs) {
+        state.phase = 'release';
+        state.phaseStart = now;
+        state.releaseMs = normalizeDuration(releaseMs, RELEASE_MS);
+        state.releaseFromWeight = Number.isFinite(Number(state.weight)) ? Number(state.weight) : 1;
+        state.releaseValue = state.value;
+    }
+
+    _normalizeParamTiming(raw) {
+        if (!raw || typeof raw !== 'object') return {};
+        const result = {};
+        for (const [id, timing] of Object.entries(raw)) {
+            if (!this._catalogById.has(id) || !timing || typeof timing !== 'object') continue;
+            const normalized = {};
+            for (const key of ['transition_ms', 'hold_ms', 'release_ms']) {
+                if (timing[key] === undefined || timing[key] === null) continue;
+                if (typeof timing[key] === 'string' && timing[key].trim() === '') continue;
+                const value = Number(timing[key]);
+                if (Number.isFinite(value)) normalized[key] = Math.max(0, value);
+            }
+            if (timing.sticky === true || timing.sticky === false) normalized.sticky = timing.sticky;
+            if (typeof timing.hold_group === 'string' && timing.hold_group.trim()) normalized.hold_group = timing.hold_group.trim();
+            if (Object.keys(normalized).length > 0) result[id] = normalized;
+        }
+        return result;
+    }
+}
+
+module.exports = { ParamDirector };

--- a/live-2d/js/avatar/live2d/runtime.js
+++ b/live-2d/js/avatar/live2d/runtime.js
@@ -1,0 +1,457 @@
+// runtime.js - Live2D 运行时驱动（口型 override + 眨眼 + 呼吸 + 视线跟随）
+// Adapted from Project-N-E-K-O/N.E.K.O (Apache-2.0): static/live2d-model.js 的
+// installMouthOverride 双注入点设计与眨眼/呼吸/视线 runtime 思路：
+//   注入点1: hook motionManager.update —— 快照参数 -> 调原始 update -> diff 判断
+//            "motion 是否正在驱动嘴部/眼部"（让位判定）
+//   注入点2: hook coreModel.update —— 渲染前最后写入：口型（说话时强制覆盖）、
+//            程序化眨眼（SDK 原生 eyeBlink 缺失时）、呼吸兜底
+//   视线跟随: 走 pixi-live2d-display 的 FocusController（model.focus），
+//            以 config.ui.focus_factor 为跟随强度（旧配置项，此前无消费者）
+const { logToTerminal } = require('../../api-utils.js');
+const { ParamDirector } = require('./param-director.js');
+const { AuDriver } = require('./expression/au-driver.js');
+const {
+    LIVE2D_MOUTH_OPEN_PARAMS,
+    LIVE2D_MOUTH_FALLBACK_PARAMS
+} = require('./expression/semantic-actions.js');
+
+const LIPSYNC_OVERRIDE_THRESHOLD = 0.001;
+// 口型写入参数（按存在性缓存 index）；ParamA 仅在开口参数都不存在时兜底
+const MOUTH_OPEN_PARAMS = LIVE2D_MOUTH_OPEN_PARAMS;
+const MOUTH_FALLBACK_PARAMS = LIVE2D_MOUTH_FALLBACK_PARAMS;
+const EYE_PARAM_PAIRS = [
+    ['ParamEyeLOpen', 'ParamEyeROpen'],
+    ['PARAM_EYE_L_OPEN', 'PARAM_EYE_R_OPEN']
+];
+const BREATH_PARAMS = ['ParamBreath', 'PARAM_BREATH'];
+
+// 眨眼节奏（毫秒）
+const BLINK_INTERVAL_MIN = 2000;
+const BLINK_INTERVAL_MAX = 6000;
+const BLINK_CLOSING_MS = 70;
+const BLINK_CLOSED_MS = 50;
+const BLINK_OPENING_MS = 110;
+
+class Live2DRuntime {
+    constructor() {
+        this.model = null;
+        this.config = null;
+
+        // 口型
+        this.mouthValue = 0;
+        this._smoothedMouth = 0;
+        this._mouthParamIndices = {};
+        this._isMouthDrivenByMotion = false;
+
+        // 眨眼
+        this._eyeParams = [];             // [{id, idx}]
+        this._blinkEnabled = false;
+        this._isEyeDrivenByMotion = false;
+        this._blinkState = 'idle';        // idle | closing | closed | opening
+        this._blinkStateStart = 0;
+        this._nextBlinkAt = 0;
+
+        // 呼吸兜底
+        this._breathParamIdx = -1;
+        this._breathEnabled = false;
+        this._breathPhase = 0;
+
+        // 视线跟随
+        this._gazeEnabled = true;
+        this._focusFactor = 1;
+        this._mouseHandler = null;
+        this._lastFocus = null;
+
+        // hook 管理
+        this._installed = false;
+        this._origMotionUpdate = null;
+        this._origCoreUpdate = null;
+        this._coreModelRef = null;
+        this._motionManagerRef = null;
+        this._lastFrameAt = 0;
+        this.paramDirector = null;
+        this.auDriver = null;
+    }
+
+    // ============ 安装 / 卸载 ============
+
+    attach(model, config = null) {
+        this.detach();
+        this.model = model;
+        if (config) this.config = config;
+
+        const internalModel = model?.internalModel;
+        const coreModel = internalModel?.coreModel;
+        const motionManager = internalModel?.motionManager;
+        if (!internalModel || !coreModel || !motionManager) {
+            console.warn('[Live2DRuntime] 模型内部结构未就绪，跳过安装');
+            return false;
+        }
+
+        this._cacheMouthParams(coreModel);
+        this._cacheEyeParams(coreModel);
+        this._cacheBreathParam(coreModel);
+
+        // SDK 原生能力存在时让位，避免双重驱动
+        this._blinkEnabled = this._eyeParams.length > 0 && !internalModel.eyeBlink;
+        this._breathEnabled = this._breathParamIdx >= 0 && !internalModel.breath;
+        this._scheduleNextBlink(performance.now());
+
+        this.paramDirector = new ParamDirector(this.config);
+        if (this.paramDirector.attach(model, coreModel)) {
+            global.paramDirector = this.paramDirector;
+        } else {
+            this.paramDirector.detach();
+            this.paramDirector = null;
+            if (global.paramDirector) global.paramDirector = null;
+        }
+
+        this.auDriver = new AuDriver(model, this.config);
+        global.auDriver = this.auDriver;
+
+        // 视线跟随配置
+        const uiCfg = this.config?.ui || {};
+        this._gazeEnabled = uiCfg.live2d_gaze_tracking !== false;
+        const factor = Number(uiCfg.focus_factor);
+        this._focusFactor = Number.isFinite(factor) && factor > 0 ? Math.min(factor, 1) : 0.3;
+
+        this._coreModelRef = coreModel;
+        this._motionManagerRef = motionManager;
+
+        // === 注入点 1: motionManager.update ===
+        const origMotionUpdate = motionManager.update ? motionManager.update.bind(motionManager) : null;
+        this._origMotionUpdate = origMotionUpdate;
+        motionManager.update = (...args) => {
+            if (!this._installed || this._coreModelRef !== coreModel) {
+                return origMotionUpdate ? origMotionUpdate(...args) : undefined;
+            }
+
+            // 快照嘴部/眼部参数
+            const preMouth = {};
+            for (const [id, idx] of Object.entries(this._mouthParamIndices)) {
+                try { preMouth[id] = coreModel.getParameterValueByIndex(idx); } catch (_) {}
+            }
+            const preEye = {};
+            if (this._blinkEnabled) {
+                for (const p of this._eyeParams) {
+                    try { preEye[p.id] = coreModel.getParameterValueByIndex(p.idx); } catch (_) {}
+                }
+            }
+
+            let result;
+            if (origMotionUpdate) {
+                try {
+                    result = origMotionUpdate(...args);
+                } catch (e) {
+                    // motion 异步加载期间 SDK 可能抛 getParameterIndex 错误（已知问题），静默
+                    if (!this.model?.internalModel?.coreModel) return;
+                }
+            }
+
+            // diff: motion 是否接管
+            this._isMouthDrivenByMotion = false;
+            for (const [id, idx] of Object.entries(this._mouthParamIndices)) {
+                try {
+                    const post = coreModel.getParameterValueByIndex(idx);
+                    if (preMouth[id] !== undefined && Math.abs(post - preMouth[id]) > 0.001) {
+                        this._isMouthDrivenByMotion = true;
+                        break;
+                    }
+                } catch (_) {}
+            }
+            this._isEyeDrivenByMotion = false;
+            if (this._blinkEnabled) {
+                for (const p of this._eyeParams) {
+                    try {
+                        const post = coreModel.getParameterValueByIndex(p.idx);
+                        if (preEye[p.id] !== undefined && Math.abs(post - preEye[p.id]) > 0.001) {
+                            this._isEyeDrivenByMotion = true;
+                            break;
+                        }
+                    } catch (_) {}
+                }
+            }
+            return result;
+        };
+
+        // === 注入点 2: coreModel.update（渲染前最后写入） ===
+        const origCoreUpdate = coreModel.update ? coreModel.update.bind(coreModel) : null;
+        this._origCoreUpdate = origCoreUpdate;
+        coreModel.update = () => {
+            if (!this._installed || this._coreModelRef !== coreModel) {
+                if (origCoreUpdate) origCoreUpdate();
+                return;
+            }
+            try {
+                const now = performance.now();
+                const delta = this._lastFrameAt ? Math.min(100, now - this._lastFrameAt) : 16.6;
+                this._lastFrameAt = now;
+
+                // 参数导演分层混合（在口型/眨眼之前，保证 lipsync 对嘴的最终覆盖权）
+                if (this.paramDirector) {
+                    try { this.paramDirector.applyFrame(coreModel, now, delta, this.mouthValue); } catch (_) {}
+                }
+                if (this.auDriver) {
+                    try { this.auDriver.applyFrame(coreModel, now); } catch (_) {}
+                }
+
+                // 口型：说话时强制覆盖；静默时让位给 motion 或 AU 嘴部目标
+                const lipSyncActive = this.mouthValue > LIPSYNC_OVERRIDE_THRESHOLD;
+                const auMouthActive = !lipSyncActive && this.auDriver?.isMouthControlled();
+                if (lipSyncActive || (!this._isMouthDrivenByMotion && !auMouthActive)) {
+                    for (const idx of Object.values(this._mouthParamIndices)) {
+                        try { coreModel.setParameterValueByIndex(idx, this.mouthValue); } catch (_) {}
+                    }
+                }
+                // 眨眼（motion 未接管时）
+                if (
+                    this._blinkEnabled &&
+                    !this._isEyeDrivenByMotion &&
+                    !(this.paramDirector && this.paramDirector.isEyeControlled()) &&
+                    !(this.auDriver && this.auDriver.isEyeControlled())
+                ) {
+                    this._updateBlink(coreModel, now);
+                }
+                // 呼吸兜底
+                if (this._breathEnabled) {
+                    this._breathPhase = (this._breathPhase + delta / 3200) % 1;
+                    const v = 0.5 + 0.5 * Math.sin(this._breathPhase * Math.PI * 2);
+                    try { coreModel.setParameterValueByIndex(this._breathParamIdx, v); } catch (_) {}
+                }
+            } catch (_) {}
+            if (origCoreUpdate) origCoreUpdate();
+        };
+
+        this._setupGaze();
+        this._installed = true;
+        logToTerminal('info', `[Live2DRuntime] 已安装: 嘴部=${Object.keys(this._mouthParamIndices).join('/') || '无'}, 程序化眨眼=${this._blinkEnabled ? '开' : '关(SDK原生或无参数)'}, 呼吸兜底=${this._breathEnabled ? '开' : '关(SDK原生)'}, 视线跟随=${this._gazeEnabled ? '开' : '关'}(强度${this._focusFactor})`);
+        return true;
+    }
+
+    detach() {
+        if (this.auDriver) {
+            try { this.auDriver.destroy(); } catch (_) {}
+            if (global.auDriver === this.auDriver) global.auDriver = null;
+            this.auDriver = null;
+        }
+        if (this.paramDirector) {
+            try { this.paramDirector.detach(); } catch (_) {}
+            if (global.paramDirector === this.paramDirector) global.paramDirector = null;
+            this.paramDirector = null;
+        }
+        if (this._mouseHandler) {
+            window.removeEventListener('mousemove', this._mouseHandler);
+            this._mouseHandler = null;
+        }
+        if (!this._installed) {
+            this.model = null;
+            return;
+        }
+        this._installed = false;
+        try {
+            if (this._motionManagerRef && this._origMotionUpdate) {
+                this._motionManagerRef.update = this._origMotionUpdate;
+            }
+        } catch (_) {}
+        try {
+            if (this._coreModelRef && this._origCoreUpdate) {
+                this._coreModelRef.update = this._origCoreUpdate;
+            }
+        } catch (_) {}
+        this._origMotionUpdate = null;
+        this._origCoreUpdate = null;
+        this._coreModelRef = null;
+        this._motionManagerRef = null;
+        this.model = null;
+        this.mouthValue = 0;
+        this._smoothedMouth = 0;
+        this._lastFrameAt = 0;
+        this._headPatParams = [];
+        this._headPatHx = 0;
+        this._headPatHy = 0;
+        this._headPatActive = false;
+    }
+
+    // ============ 参数缓存 ============
+
+    _cacheMouthParams(coreModel) {
+        this._mouthParamIndices = {};
+        const tryCache = (paramId) => {
+            try {
+                const idx = coreModel.getParameterIndex(paramId);
+                if (idx >= 0 && this._paramIdExists(coreModel, paramId, idx)) {
+                    this._mouthParamIndices[paramId] = idx;
+                    return true;
+                }
+            } catch (_) {}
+            return false;
+        };
+        let found = false;
+        for (const id of MOUTH_OPEN_PARAMS) {
+            if (tryCache(id)) found = true;
+        }
+        if (!found) {
+            for (const id of MOUTH_FALLBACK_PARAMS) {
+                if (tryCache(id)) found = true;
+            }
+        }
+    }
+
+    _cacheEyeParams(coreModel) {
+        this._eyeParams = [];
+        for (const pair of EYE_PARAM_PAIRS) {
+            const cached = [];
+            for (const id of pair) {
+                try {
+                    const idx = coreModel.getParameterIndex(id);
+                    if (idx >= 0 && this._paramIdExists(coreModel, id, idx)) {
+                        cached.push({ id, idx });
+                    }
+                } catch (_) {}
+            }
+            if (cached.length > 0) {
+                this._eyeParams = cached;
+                return;
+            }
+        }
+    }
+
+    _cacheBreathParam(coreModel) {
+        this._breathParamIdx = -1;
+        for (const id of BREATH_PARAMS) {
+            try {
+                const idx = coreModel.getParameterIndex(id);
+                if (idx >= 0 && this._paramIdExists(coreModel, id, idx)) {
+                    this._breathParamIdx = idx;
+                    return;
+                }
+            } catch (_) {}
+        }
+    }
+
+    _paramIdExists(coreModel, paramId, idx) {
+        try {
+            if (typeof coreModel.getParameterId === 'function') {
+                return coreModel.getParameterId(idx) === paramId;
+            }
+        } catch (_) {}
+        return true;
+    }
+
+    // ============ 口型 ============
+
+    /** TTS 音量包络驱动（0~1，带平滑） */
+    setMouth(value) {
+        const v = Math.max(0, Math.min(Number(value) || 0, 1.5));
+        this._smoothedMouth = this._smoothedMouth * 0.5 + v * 0.5;
+        // 收尾时快速归零，避免嘴巴悬停半开
+        this.mouthValue = this._smoothedMouth < 0.01 ? 0 : this._smoothedMouth;
+    }
+
+    // ============ 眨眼 ============
+
+    _scheduleNextBlink(now) {
+        this._nextBlinkAt = now + BLINK_INTERVAL_MIN + Math.random() * (BLINK_INTERVAL_MAX - BLINK_INTERVAL_MIN);
+        this._blinkState = 'idle';
+    }
+
+    _updateBlink(coreModel, now) {
+        let eyeValue = null;
+        switch (this._blinkState) {
+            case 'idle':
+                if (now >= this._nextBlinkAt) {
+                    this._blinkState = 'closing';
+                    this._blinkStateStart = now;
+                }
+                break;
+            case 'closing': {
+                const t = Math.min(1, (now - this._blinkStateStart) / BLINK_CLOSING_MS);
+                eyeValue = 1 - t;
+                if (t >= 1) {
+                    this._blinkState = 'closed';
+                    this._blinkStateStart = now;
+                }
+                break;
+            }
+            case 'closed': {
+                eyeValue = 0;
+                if (now - this._blinkStateStart >= BLINK_CLOSED_MS) {
+                    this._blinkState = 'opening';
+                    this._blinkStateStart = now;
+                }
+                break;
+            }
+            case 'opening': {
+                const t = Math.min(1, (now - this._blinkStateStart) / BLINK_OPENING_MS);
+                eyeValue = t;
+                if (t >= 1) this._scheduleNextBlink(now);
+                break;
+            }
+        }
+        if (eyeValue !== null) {
+            for (const p of this._eyeParams) {
+                try { coreModel.setParameterValueByIndex(p.idx, eyeValue); } catch (_) {}
+            }
+        }
+    }
+
+    // ============ 视线跟随 ============
+
+    _setupGaze() {
+        if (this._mouseHandler) {
+            window.removeEventListener('mousemove', this._mouseHandler);
+        }
+        let pending = false;
+        this._mouseHandler = (e) => {
+            if (!this._gazeEnabled || !this.model || pending) return;
+            pending = true;
+            requestAnimationFrame(() => {
+                pending = false;
+                this._applyGaze(e.clientX, e.clientY);
+            });
+        };
+        window.addEventListener('mousemove', this._mouseHandler, { passive: true });
+    }
+
+    _applyGaze(clientX, clientY) {
+        const model = this.model;
+        if (!model || typeof model.focus !== 'function') return;
+        try {
+            // 以模型头部附近为锚点，按 focus_factor 衰减跟随幅度
+            const anchorX = model.x + model.width / 2;
+            const anchorY = model.y + model.height * 0.3;
+            const fx = anchorX + (clientX - anchorX) * this._focusFactor;
+            const fy = anchorY + (clientY - anchorY) * this._focusFactor;
+            model.focus(fx, fy);
+            this._lastFocus = { x: fx, y: fy };
+        } catch (_) {}
+    }
+
+    setGazeTracking(enabled) {
+        this._gazeEnabled = !!enabled;
+        if (!enabled && this.model) {
+            // 关闭时视线回正（对准模型头部锚点，FocusController 自带平滑）
+            try {
+                this.model.focus(this.model.x + this.model.width / 2, this.model.y + this.model.height * 0.3);
+            } catch (_) {}
+        }
+    }
+
+    isGazeTrackingEnabled() {
+        return this._gazeEnabled;
+    }
+
+    updateConfig(config) {
+        this.config = config;
+        const factor = Number(config?.ui?.focus_factor);
+        if (Number.isFinite(factor) && factor > 0) this._focusFactor = Math.min(factor, 1);
+        if (this.paramDirector) {
+            try { this.paramDirector.updateConfig(config); } catch (_) {}
+        }
+        if (this.auDriver) {
+            try { this.auDriver.updateConfig(config); } catch (_) {}
+        }
+    }
+}
+
+module.exports = { Live2DRuntime, LIPSYNC_OVERRIDE_THRESHOLD };

--- a/live-2d/js/avatar/live2d/setup.js
+++ b/live-2d/js/avatar/live2d/setup.js
@@ -1,0 +1,208 @@
+// setup.js - Live2D 形态装配（替代旧 js/model/model-setup.js）
+// 职责：创建/复用舞台 -> 解析模型路径 -> 加载模型 -> 装配交互/情绪/音乐/口型 -> 注册热切换。
+// 返回结构与旧 ModelSetup.initialize 完全一致：{ app, model, emotionMapper, expressionMapper, musicPlayer }
+//
+// 热切换策略：形态切走时只 suspend（保留 PIXI app 与 WebGL 上下文），切回时复用。
+// （销毁上下文后立刻创建 Three.js 上下文会在 ANGLE/D3D11 原生层冻结渲染进程。）
+const { ipcRenderer } = require('electron');
+const { Live2DStage } = require('./core.js');
+const { Live2DModelLoader } = require('./model-loader.js');
+const { resolveLive2DModel } = require('../model-registry.js');
+const { getModelPrefs } = require('../preferences-store.js');
+const { EmotionEngine } = require('./emotion-engine.js');
+const { Live2DRuntime } = require('./runtime.js');
+const { MusicPlayer } = require('../../services/music-player.js');
+const { logToTerminal } = require('../../api-utils.js');
+const { bindVoiceChatAvatar } = require('../avatar-voice-chat-binding.js');
+
+// 模块级单例（跨形态切换存活）
+let _stage = null;
+let _loader = null;
+let _runtime = null;
+let _musicPlayer = null;
+let _engine = null;
+let _ipcBound = false;
+let _context = null;
+
+class Live2DSetup {
+    /**
+     * @param {object} modelController Live2DInteractionController 实例（app.js 创建）
+     * @returns {{ app, model, emotionMapper, expressionMapper, musicPlayer, stage, loader }}
+     */
+    static async initialize(modelController, config, ttsEnabled, asrEnabled, ttsProcessor, voiceChat) {
+        _context = { modelController, config, ttsEnabled, ttsProcessor, voiceChat };
+
+        // 1. 舞台（首次创建 / 挂起后复用）
+        if (!_stage) _stage = new Live2DStage();
+        await _stage.init('canvas', config);
+
+        // 2. 通过注册表解析模型（config.ui.live2d_model 驱动）
+        const { modelPath, entry, all } = resolveLive2DModel(config?.ui?.live2d_model);
+        if (!modelPath) {
+            throw new Error('2D 目录下没有找到任何 .model3.json 模型');
+        }
+        const fallbackPath = (all.find(m => m.modelPath !== modelPath) || {}).modelPath || null;
+        logToTerminal('info', `[Live2DSetup] 共发现 ${all.length} 个模型，选用: ${entry.name} (${modelPath})`);
+
+        // 3. 加载（应用 per-model 偏好，回退全局 config）
+        if (!_loader) _loader = new Live2DModelLoader(_stage);
+        if (!_runtime) _runtime = new Live2DRuntime();
+        global.live2dRuntime = _runtime;
+
+        const prefs = getModelPrefs('live2d', entry.name);
+        const model = await _loader.loadModel(modelPath, {
+            config,
+            preferences: prefs,
+            fallbackPath,
+            // The explicit wireModel call below is the single setup path for
+            // startup and resume. The loader callback is reserved for hot
+            // switches so a resume cannot assemble the same model twice.
+            notifyLoaded: false
+        });
+
+        // 4. 交互控制器
+        modelController.init(model, _stage.app, config, { stage: _stage });
+        modelController.setupInitialModelProperties();
+        modelController.setMouthSetter((v) => {
+            _runtime.setMouth(v);
+            _stage.notifyActivity();
+        });
+
+        // 5. 装配上下游（首次 + 每次热切换/模型切换都要执行）
+        const wireModel = async (m) => {
+            const ctx = _context;
+            m.isPointOverModel = (x, y) => ctx.modelController.isPointOverModel(x, y);
+            m.hitTest = (x, y) => ctx.modelController.isPointOverModel(x, y);
+            ctx.modelController.rebind(m);
+            global.currentModel = m;
+            _runtime.attach(m, ctx.config);
+
+            // 统一表情/动作引擎（双门面兼容旧 Mapper 契约）
+            if (_engine) {
+                try { _engine.destroy(); } catch (_) {}
+            }
+            _engine = await EmotionEngine.create(m, ctx.config);
+            global.emotionEngine = _engine;
+
+            const emotionMapper = _engine.motionFacade;
+            const expressionMapper = _engine.expressionFacade;
+            global.currentCharacterName = await _engine.getCurrentCharacterName();
+            global.emotionMapper = emotionMapper;
+            global.expressionMapper = expressionMapper;
+
+            if (ctx.ttsEnabled && ctx.ttsProcessor?.setEmotionMapper) {
+                ctx.ttsProcessor.setEmotionMapper(emotionMapper);
+            }
+            if (ctx.ttsEnabled && ctx.ttsProcessor?.setExpressionMapper) {
+                ctx.ttsProcessor.setExpressionMapper(expressionMapper);
+            }
+            if (_musicPlayer) {
+                _musicPlayer.setEmotionMapper(emotionMapper);
+            }
+            bindVoiceChatAvatar(ctx.voiceChat, m, emotionMapper);
+            return { emotionMapper, expressionMapper };
+        };
+
+        const { emotionMapper, expressionMapper } = await wireModel(model);
+
+        // 6. 音乐播放器（依赖 modelController.setMouthOpenY）
+        if (!_musicPlayer) {
+            _musicPlayer = new MusicPlayer(modelController);
+        }
+        _musicPlayer.setEmotionMapper(emotionMapper);
+        global.musicPlayer = _musicPlayer;
+
+        // 7. 热切换：主进程 switch-live2d-model / update-live2d-model 触发
+        _loader.onModelLoaded = async (newModel) => {
+            await wireModel(newModel);
+        };
+        _loader.onModelRemoved = () => {
+            _runtime.detach();
+        };
+
+        if (!_ipcBound) {
+            _ipcBound = true;
+            ipcRenderer.on('live2d-switch-model', async (event, payload) => {
+                const { modelName, modelPath: nextPath, requestId } = payload || {};
+                let result = { success: false, message: 'Live2D 模型切换未执行' };
+                const reportResult = async () => {
+                    if (!requestId) return;
+                    try {
+                        await ipcRenderer.invoke('live2d-switch-model-result', {
+                            requestId,
+                            success: result.success === true,
+                            message: result.message,
+                            restored: result.restored === true
+                        });
+                    } catch (reportError) {
+                        console.warn('[Live2DSetup] 上报切换结果失败:', reportError);
+                    }
+                };
+
+                if (!nextPath) {
+                    result = { success: false, message: '缺少 Live2D 模型路径' };
+                    await reportResult();
+                    return;
+                }
+                if (global.avatarFacade && global.avatarFacade.getActiveType() !== 'live2d') {
+                    console.log('[Live2DSetup] 当前非 Live2D 形态，忽略模型切换事件');
+                    result = { success: false, message: '当前不是 Live2D 形态' };
+                    await reportResult();
+                    return;
+                }
+                if (_loader.currentModelPath === nextPath) {
+                    console.log(`[Live2DSetup] 已是当前模型，跳过切换: ${modelName}`);
+                    result = { success: true, message: `已经是当前模型: ${modelName}` };
+                    await reportResult();
+                    return;
+                }
+                const previousModel = _loader.currentModel;
+                try {
+                    logToTerminal('info', `[Live2DSetup] 热切换模型: ${modelName} (${nextPath})`);
+                    const nextPrefs = getModelPrefs('live2d', modelName);
+                    await _loader.loadModel(nextPath, {
+                        config: _context.config,
+                        preferences: nextPrefs,
+                        fallbackPath: null
+                    });
+                    _stage.notifyActivity();
+                    result = { success: true, message: `模型已切换到 ${modelName}` };
+                } catch (e) {
+                    console.error('[Live2DSetup] 热切换失败:', e);
+                    logToTerminal('error', `[Live2DSetup] 热切换失败: ${e.message}`);
+                    let restored = Boolean(previousModel && _loader.currentModel === previousModel);
+                    let restoreError = null;
+                    if (restored && global.currentModel !== previousModel) {
+                        try {
+                            await wireModel(previousModel);
+                        } catch (error) {
+                            restored = false;
+                            restoreError = error;
+                        }
+                    }
+                    const suffix = restoreError ? `；恢复失败: ${restoreError.message}` : '';
+                    result = {
+                        success: false,
+                        restored,
+                        message: `模型切换失败: ${e.message}${restored ? '，已保留原模型' : ''}${suffix}`
+                    };
+                }
+                await reportResult();
+            });
+        }
+
+        return { app: _stage.app, model, emotionMapper, expressionMapper, musicPlayer: _musicPlayer, stage: _stage, loader: _loader };
+    }
+
+    // 形态切走：挂起而非销毁（保留 WebGL 上下文）
+    static async suspend() {
+        try { _runtime?.detach?.(); } catch (_) {}
+        try { await _loader?.removeModel?.(); } catch (_) {}
+        try { _engine?.destroy?.(); } catch (_) {}
+        _engine = null;
+        try { _stage?.suspend?.(); } catch (_) {}
+        logToTerminal('info', '[Live2DSetup] 已挂起（保留渲染上下文）');
+    }
+}
+
+module.exports = { Live2DSetup };

--- a/live-2d/js/avatar/live2d/vad-state.js
+++ b/live-2d/js/avatar/live2d/vad-state.js
@@ -1,0 +1,264 @@
+'use strict';
+
+const { VAD_PRESETS, getVADPreset, normalizeEmotion, resolveStrictEmotionName, seededRandom } = require('./emotion-archetypes.js');
+
+const NEUTRAL = { valence: 0, arousal: 0, dominance: 0 };
+
+function clamp(value, min, max) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return min;
+    return Math.max(min, Math.min(max, n));
+}
+
+function normalizeVector(value, fallback = NEUTRAL) {
+    const source = value && typeof value === 'object' ? value : {};
+    return clampVAD({
+        valence: source.valence ?? source.v ?? fallback.valence,
+        arousal: source.arousal ?? source.a ?? fallback.arousal,
+        dominance: source.dominance ?? source.d ?? fallback.dominance
+    });
+}
+
+function clampVAD(vector) {
+    return {
+        valence: clamp(vector.valence, -1, 1),
+        arousal: clamp(vector.arousal, -1, 1),
+        dominance: clamp(vector.dominance, -1, 1)
+    };
+}
+
+function lerp(from, to, amount) {
+    return from + (to - from) * clamp(amount, 0, 1);
+}
+
+function lerpVAD(from, to, amount) {
+    return clampVAD({
+        valence: lerp(from.valence, to.valence, amount),
+        arousal: lerp(from.arousal, to.arousal, amount),
+        dominance: lerp(from.dominance, to.dominance, amount)
+    });
+}
+
+function magnitude(vector) {
+    return clamp(
+        (Math.abs(vector.valence) + Math.abs(vector.arousal) * 0.82 + Math.abs(vector.dominance) * 0.64) / 2.46,
+        0,
+        1
+    );
+}
+
+function weightedDistance(a, b) {
+    const valence = a.valence - b.valence;
+    const arousal = a.arousal - b.arousal;
+    const dominance = a.dominance - b.dominance;
+    return valence * valence * 1.08 + arousal * arousal * 0.88 + dominance * dominance * 1.28;
+}
+
+class VADState {
+    constructor(personality = {}) {
+        this.random = seededRandom(9137);
+        this.reactivity = 1;
+        this.targetApproachRate = 1.35;
+        this.decayRate = 0.018;
+        this.emotionHoldSeconds = 18;
+        this.ambientDriftStrength = 0.034;
+        this.emotionBias = {};
+        this.baseline = { ...NEUTRAL };
+        this.current = { ...NEUTRAL };
+        this.target = { ...NEUTRAL };
+        this.ambient = { ...NEUTRAL };
+        this.ambientTarget = { valence: 0.018, arousal: -0.012, dominance: 0.01 };
+        this.driftClock = 0;
+        this.nextDriftAt = 0;
+        this.holdRemainingSeconds = 0;
+        this.dominantEmotion = 'neutral';
+        this.intensity = 0;
+        this.configure(personality);
+        this.reset();
+    }
+
+    configure(personality = {}) {
+        const cfg = personality || {};
+        if (cfg.baseline) this.setBaseline(cfg.baseline);
+        if (Number.isFinite(Number(cfg.reactivity))) this.reactivity = clamp(cfg.reactivity, 0.2, 2.5);
+        if (Number.isFinite(Number(cfg.targetApproachRate ?? cfg.target_approach_rate))) {
+            this.targetApproachRate = clamp(cfg.targetApproachRate ?? cfg.target_approach_rate, 0.2, 4);
+        }
+        if (Number.isFinite(Number(cfg.decayRate ?? cfg.decay_rate))) {
+            this.decayRate = clamp(cfg.decayRate ?? cfg.decay_rate, 0.002, 0.4);
+        }
+        if (Number.isFinite(Number(cfg.emotionHoldSeconds ?? cfg.hold_seconds))) {
+            this.emotionHoldSeconds = clamp(cfg.emotionHoldSeconds ?? cfg.hold_seconds, 0, 90);
+        }
+        if (Number.isFinite(Number(cfg.ambientDriftStrength ?? cfg.ambient_drift_strength))) {
+            this.ambientDriftStrength = clamp(cfg.ambientDriftStrength ?? cfg.ambient_drift_strength, 0, 0.09);
+        }
+        if (cfg.emotionBias && typeof cfg.emotionBias === 'object') {
+            this.emotionBias = { ...this.emotionBias, ...cfg.emotionBias };
+        }
+    }
+
+    setBaseline(baseline) {
+        this.baseline = normalizeVector(baseline, this.baseline);
+    }
+
+    reset() {
+        this.current = { ...this.baseline };
+        this.target = { ...this.baseline };
+        this.ambient = { ...NEUTRAL };
+        this.ambientTarget = this._pickAmbientTarget();
+        this.driftClock = 0;
+        this.nextDriftAt = 0.8 + this.random() * 2.1;
+        this.holdRemainingSeconds = 0;
+        this.dominantEmotion = 'neutral';
+        this.intensity = magnitude(this.current);
+    }
+
+    nudge(emotion, intensity = 0.65, options = null) {
+        // strict 仅由「仅 AI 编舞」档调用方传入：允许直达 excited/calm/anxiety/tired 等
+        // 被 normalizeEmotion 折叠的预设。不传 options = 旧行为，blend 档不变。
+        const strict = !!(options && options.strict);
+        const strictName = strict ? resolveStrictEmotionName(emotion) : null;
+        const normalized = strictName || normalizeEmotion(emotion);
+        const preset = getVADPreset(emotion, strict ? { strict: true } : null);
+        const bias = this.emotionBias[normalized] ?? 1;
+        const amount = clamp((0.28 + clamp(intensity, 0, 1.5) * 0.58) * this.reactivity * bias, 0, 0.96);
+        this.target = lerpVAD(this.target, preset, amount);
+        this._extendHold(6 + clamp(intensity, 0, 1.5) * this.emotionHoldSeconds);
+        this.dominantEmotion = normalized;
+        return this.getState();
+    }
+
+    blendTo(target, amount = 0.65) {
+        const clamped = clamp(amount, 0, 1);
+        this.target = lerpVAD(this.target, normalizeVector(target, this.target), clamped);
+        this._extendHold(4 + clamped * this.emotionHoldSeconds);
+        return this.getState();
+    }
+
+    nudgeVAD(delta, amount = 1) {
+        const source = normalizeVector(delta, NEUTRAL);
+        const gain = clamp(amount * this.reactivity, 0, 2);
+        this.target = clampVAD({
+            valence: this.target.valence + source.valence * gain,
+            arousal: this.target.arousal + source.arousal * gain,
+            dominance: this.target.dominance + source.dominance * gain
+        });
+        this._extendHold(3 + clamp(amount, 0, 1.5) * this.emotionHoldSeconds * 0.55);
+        return this.getState();
+    }
+
+    update(deltaSeconds) {
+        const dt = clamp(deltaSeconds, 0, 1);
+        const approach = 1 - Math.exp(-dt * this.targetApproachRate);
+        const decay = this.holdRemainingSeconds > 0 ? 0 : 1 - Math.exp(-dt * this.decayRate);
+        this._updateAmbientDrift(dt);
+        this.holdRemainingSeconds = Math.max(0, this.holdRemainingSeconds - dt);
+        this.current = lerpVAD(this.current, this._withAmbient(this.target), approach);
+        this.target = lerpVAD(this.target, this.baseline, decay);
+        this.intensity = magnitude(this.current);
+        this.dominantEmotion = this._inferEmotion(this.current, this.intensity);
+        return this.getState();
+    }
+
+    getState() {
+        return {
+            current: { ...this.current },
+            target: { ...this.target },
+            baseline: { ...this.baseline },
+            ambient: { ...this.ambient },
+            dominantEmotion: this.dominantEmotion,
+            intensity: this.intensity,
+            holdSeconds: this.holdRemainingSeconds,
+            decayRate: this.decayRate
+        };
+    }
+
+    _inferEmotion(vad, value) {
+        if (value < 0.0018) return 'neutral';
+        if (value < 0.08) return this._inferSubtleEmotion(vad);
+        if (vad.valence > 0.12 && vad.dominance < -0.22) return 'shy';
+        if (vad.valence < -0.34 && vad.arousal > 0.38 && vad.dominance < -0.12) return 'anxiety';
+        if (vad.valence < -0.42 && vad.arousal > 0.42 && vad.dominance > 0.18) return 'angry';
+        if (vad.valence > 0.58 && vad.arousal > 0.62) return 'excited';
+        if (vad.valence > 0.2 && vad.arousal < -0.24) return 'calm';
+        return this._nearestPreset(vad);
+    }
+
+    _inferSubtleEmotion(vad) {
+        if (vad.valence > 0.004 && vad.arousal > 0.004) return 'soft-happy';
+        if (vad.valence > 0.004 && vad.arousal < -0.004) return 'soft-calm';
+        if (vad.valence > 0.004) return 'soft-positive';
+        if (vad.valence < -0.004 && vad.arousal > 0.004) return 'soft-uneasy';
+        if (vad.valence < -0.004) return 'soft-low';
+        if (vad.arousal > 0.004) return 'soft-curious';
+        if (vad.arousal < -0.004) return 'soft-calm';
+        if (vad.dominance < -0.004) return 'soft-shy';
+        if (vad.dominance > 0.004) return 'soft-steady';
+        return 'neutral';
+    }
+
+    _nearestPreset(vad) {
+        let bestEmotion = 'neutral';
+        let bestDistance = Number.POSITIVE_INFINITY;
+        for (const [emotion, preset] of Object.entries(VAD_PRESETS)) {
+            if (emotion === 'neutral' || emotion === 'angry') continue;
+            const distance = weightedDistance(vad, preset);
+            if (distance < bestDistance) {
+                bestDistance = distance;
+                bestEmotion = emotion;
+            }
+        }
+        return bestDistance < 0.92 ? bestEmotion : 'neutral';
+    }
+
+    _updateAmbientDrift(deltaSeconds) {
+        if (this.ambientDriftStrength <= 0) return;
+        this.driftClock += deltaSeconds;
+        if (this.driftClock >= this.nextDriftAt) {
+            this.ambientTarget = this._pickAmbientTarget();
+            this.nextDriftAt = this.driftClock + 1.7 + this.random() * 4.2;
+        }
+        const approach = 1 - Math.exp(-deltaSeconds * 0.62);
+        this.ambient = lerpVAD(this.ambient, this.ambientTarget, approach);
+    }
+
+    _pickAmbientTarget() {
+        const strength = this.ambientDriftStrength;
+        const centerBias = this.random() < 0.26 ? 0.42 : 1;
+        const pick = (axisScale) => {
+            const half = strength * axisScale * centerBias;
+            return -half + this.random() * half * 2;
+        };
+        return clampVAD({
+            valence: pick(1),
+            arousal: pick(0.82),
+            dominance: pick(0.68)
+        });
+    }
+
+    _withAmbient(vector) {
+        return clampVAD({
+            valence: vector.valence + this.ambient.valence,
+            arousal: vector.arousal + this.ambient.arousal,
+            dominance: vector.dominance + this.ambient.dominance
+        });
+    }
+
+    _extendHold(seconds) {
+        this.holdRemainingSeconds = Math.max(this.holdRemainingSeconds, seconds);
+    }
+}
+
+const vadState = global.vadState || new VADState();
+global.vadState = vadState;
+
+module.exports = {
+    NEUTRAL,
+    VADState,
+    clamp,
+    clampVAD,
+    magnitude,
+    normalizeVector,
+    vadState
+};

--- a/live-2d/js/avatar/model-registry.js
+++ b/live-2d/js/avatar/model-registry.js
@@ -1,0 +1,137 @@
+// model-registry.js - 四形态模型注册表（纯 fs 实现，主进程与渲染进程均可 require）
+// 目录约定：
+//   Live2D:   2D/<模型名>/**/*.model3.json
+//   VRM:      3D/**/*.vrm            （Phase 7 启用）
+//   MMD:      3D/mmd/<模型名>/**/*.pmx（Phase 8 启用）
+//   PNGTuber: PNG/<模型名>/pngtuber.json（Phase 9 启用）
+const fs = require('fs');
+const path = require('path');
+
+// live-2d 应用根目录（本文件位于 js/avatar/ 下）
+const APP_ROOT = path.join(__dirname, '..', '..');
+
+function toPosix(p) {
+    return p.replace(/\\/g, '/');
+}
+
+function walkFiles(rootDir, matcher, results, relBase) {
+    let items;
+    try { items = fs.readdirSync(rootDir, { withFileTypes: true }); } catch (_) { return; }
+    for (const it of items) {
+        const abs = path.join(rootDir, it.name);
+        const rel = relBase ? `${relBase}/${it.name}` : it.name;
+        if (it.isDirectory()) {
+            walkFiles(abs, matcher, results, rel);
+        } else if (matcher(it.name)) {
+            results.push(rel);
+        }
+    }
+}
+
+/**
+ * 扫描 Live2D 模型
+ * @returns {Array<{ name: string, dir: string, modelPath: string }>}
+ *   name: 模型目录名（2D 下的一级目录）
+ *   modelPath: 相对 live-2d 根的 posix 路径（可直接给 PIXI 加载）
+ */
+function scanLive2DModels() {
+    const modelsDir = path.join(APP_ROOT, '2D');
+    const files = [];
+    walkFiles(modelsDir, (n) => n.endsWith('.model3.json'), files, '');
+    // 一个模型目录可能包含多份 .model3.json（如主模型+配件），按目录名去重取第一份
+    const byName = new Map();
+    for (const rel of files) {
+        const posix = toPosix(rel);
+        const name = posix.split('/')[0];
+        if (!byName.has(name)) {
+            byName.set(name, {
+                name,
+                dir: `2D/${name}`,
+                modelPath: `2D/${posix}`
+            });
+        }
+    }
+    return [...byName.values()];
+}
+
+/**
+ * 解析启动/切换时要加载的 Live2D 模型
+ * 优先级：preferredName（config.ui.live2d_model）> 字母序第一个
+ * @returns {{ modelPath: string|null, entry: object|null, all: Array }}
+ */
+function resolveLive2DModel(preferredName) {
+    const all = scanLive2DModels();
+    if (all.length === 0) return { modelPath: null, entry: null, all };
+
+    if (preferredName) {
+        const hit = all.find(m => m.name === preferredName);
+        if (hit) return { modelPath: hit.modelPath, entry: hit, all };
+    }
+
+    const sorted = [...all].sort((a, b) => a.modelPath.localeCompare(b.modelPath));
+    return { modelPath: sorted[0].modelPath, entry: sorted[0], all };
+}
+
+/**
+ * 扫描 VRM 模型：3D/**\/*.vrm（排除 3D/mmd/）
+ * @returns {Array<{ name, modelPath }>} name = 文件名（不含扩展名）
+ */
+function scanVRMModels() {
+    const dir = path.join(APP_ROOT, '3D');
+    const files = [];
+    walkFiles(dir, (n) => n.toLowerCase().endsWith('.vrm'), files, '');
+    return files
+        .map(toPosix)
+        .filter(rel => !rel.toLowerCase().startsWith('mmd/'))
+        .map(rel => ({
+            name: rel.split('/').pop().replace(/\.vrm$/i, ''),
+            modelPath: `3D/${rel}`
+        }));
+}
+
+/**
+ * 扫描 MMD 模型：3D/mmd/<模型名>/**\/*.pmx
+ * @returns {Array<{ name, dir, modelPath }>}
+ */
+function scanMMDModels() {
+    const dir = path.join(APP_ROOT, '3D', 'mmd');
+    const files = [];
+    walkFiles(dir, (n) => n.toLowerCase().endsWith('.pmx'), files, '');
+    return files.map(toPosix).map(rel => {
+        const name = rel.includes('/') ? rel.split('/')[0] : rel.replace(/\.pmx$/i, '');
+        return {
+            name,
+            dir: `3D/mmd/${name}`,
+            modelPath: `3D/mmd/${rel}`
+        };
+    });
+}
+
+/**
+ * 扫描 PNGTuber 模型：PNG/<模型名>/pngtuber.json
+ * @returns {Array<{ name, dir, configPath }>}
+ */
+function scanPNGTuberModels() {
+    const dir = path.join(APP_ROOT, 'PNG');
+    const results = [];
+    let items;
+    try { items = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return results; }
+    for (const it of items) {
+        if (!it.isDirectory()) continue;
+        const cfg = path.join(dir, it.name, 'pngtuber.json');
+        if (fs.existsSync(cfg)) {
+            results.push({
+                name: it.name,
+                dir: `PNG/${it.name}`,
+                configPath: `PNG/${it.name}/pngtuber.json`
+            });
+        }
+    }
+    return results;
+}
+
+module.exports = {
+    APP_ROOT,
+    scanLive2DModels, resolveLive2DModel,
+    scanVRMModels, scanMMDModels, scanPNGTuberModels
+};

--- a/live-2d/js/avatar/motion-mode.js
+++ b/live-2d/js/avatar/motion-mode.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const VALID_AVATAR_MOTION_MODES = new Set(['blend', 'legacy', 'director']);
+
+function normalizeAvatarMotionMode(value) {
+    const mode = String(value || '').trim().toLowerCase();
+    return VALID_AVATAR_MOTION_MODES.has(mode) ? mode : 'blend';
+}
+
+function getAvatarMotionMode(config = null) {
+    return normalizeAvatarMotionMode(
+        config?.ui?.avatar_motion_mode ||
+        global.live2dRuntime?.config?.ui?.avatar_motion_mode ||
+        global.paramDirector?.config?.ui?.avatar_motion_mode ||
+        'blend'
+    );
+}
+
+function shouldUseLegacyEmotionLogic(config = null) {
+    return getAvatarMotionMode(config) !== 'director';
+}
+
+function shouldUseParamDirector(config = null) {
+    return getAvatarMotionMode(config) !== 'legacy';
+}
+
+// 「仅 AI 编舞」档专用门控：本次 soullink 对齐更新的所有新行为统一挂在此判定之后，
+// blend / legacy 两档保持原有行为不变（见 SOULLINK_ALIGNMENT_PLAN.md §0.5）。
+function isDirectorOnly(config = null) {
+    return getAvatarMotionMode(config) === 'director';
+}
+
+module.exports = {
+    getAvatarMotionMode,
+    normalizeAvatarMotionMode,
+    shouldUseLegacyEmotionLogic,
+    shouldUseParamDirector,
+    isDirectorOnly
+};

--- a/live-2d/js/avatar/preferences-store.js
+++ b/live-2d/js/avatar/preferences-store.js
@@ -1,0 +1,58 @@
+// preferences-store.js - 按模型持久化位置/缩放偏好（主进程与渲染进程均可 require）
+// 存储文件: live-2d/model-preferences.json
+// 结构: { "<type>:<name>": { position: {x,y,x_dual,y_dual}, scale } }
+//   type: live2d | vrm | mmd | pngtuber
+//   scale 使用 legacy 语义（与 config.ui.model_scale 一致）
+const fs = require('fs');
+const path = require('path');
+
+const STORE_PATH = path.join(__dirname, '..', '..', 'model-preferences.json');
+
+function _readStore() {
+    try {
+        return JSON.parse(fs.readFileSync(STORE_PATH, 'utf8'));
+    } catch (_) {
+        return {};
+    }
+}
+
+function _writeStore(store) {
+    try {
+        fs.writeFileSync(STORE_PATH, JSON.stringify(store, null, 2), 'utf8');
+        return true;
+    } catch (e) {
+        console.error('[PreferencesStore] 写入失败:', e);
+        return false;
+    }
+}
+
+function _key(type, name) {
+    return `${type}:${name}`;
+}
+
+/** 读取某模型的偏好；无记录返回 null */
+function getModelPrefs(type, name) {
+    if (!name) return null;
+    const store = _readStore();
+    const entry = store[_key(type, name)];
+    return entry && typeof entry === 'object' ? entry : null;
+}
+
+/** 合并写入某模型的偏好（position/scale 局部更新） */
+function saveModelPrefs(type, name, prefs) {
+    if (!name || !prefs) return false;
+    const store = _readStore();
+    const key = _key(type, name);
+    const prev = store[key] && typeof store[key] === 'object' ? store[key] : {};
+    const next = { ...prev };
+    if (prefs.position && typeof prefs.position === 'object') {
+        next.position = { ...(prev.position || {}), ...prefs.position };
+    }
+    if (Number.isFinite(Number(prefs.scale)) && Number(prefs.scale) > 0) {
+        next.scale = Number(prefs.scale);
+    }
+    store[key] = next;
+    return _writeStore(store);
+}
+
+module.exports = { STORE_PATH, getModelPrefs, saveModelPrefs };

--- a/live-2d/js/avatar/vrm/emotion.js
+++ b/live-2d/js/avatar/vrm/emotion.js
@@ -1,0 +1,177 @@
+// emotion.js - VRM 情绪/表情映射器（v2，由 js/model/vrm-model-setup.js 的静态工厂迁移）
+// 契约与 Live2D 的双门面一致：prepareTextForTTS / triggerEmotionByTextPosition /
+// playConfiguredEmotion / triggerExpressionByEmotion / triggerExpression。
+// 中文情绪 -> VRM preset 表情映射可被模型目录下的 emotion_mapping.json 覆盖（可选）。
+
+function getCharacterName(modelPath) {
+    const match = String(modelPath || '').match(/3D\/(?:.*\/)?([^\/]+?)\.vrm$/i);
+    if (match) return match[1];
+    return 'VRM角色';
+}
+
+function parseEmotionTagsWithPosition(text) {
+    const pattern = /<([^>]+)>/g;
+    const emotions = [];
+    let match;
+    while ((match = pattern.exec(text)) !== null) {
+        emotions.push({
+            emotion: match[1],
+            startIndex: match.index,
+            endIndex: match.index + match[0].length,
+            fullTag: match[0]
+        });
+    }
+    return emotions;
+}
+
+function prepareTextForTTS(text) {
+    const emotionTags = parseEmotionTagsWithPosition(text);
+    if (emotionTags.length === 0) {
+        return { text, emotionMarkers: [] };
+    }
+    let purifiedText = text;
+    for (let i = emotionTags.length - 1; i >= 0; i--) {
+        const tag = emotionTags[i];
+        purifiedText = purifiedText.substring(0, tag.startIndex) + purifiedText.substring(tag.endIndex);
+    }
+    const emotionMarkers = [];
+    let offset = 0;
+    for (const tag of emotionTags) {
+        emotionMarkers.push({ position: tag.startIndex - offset, emotion: tag.emotion });
+        offset += tag.endIndex - tag.startIndex;
+    }
+    return { text: purifiedText, emotionMarkers };
+}
+
+function createVRMEmotionMapper(model, expressionMap) {
+    return {
+        model,
+        currentMotionGroup: 'TapBody',
+        emotionConfig: expressionMap,
+        isPlayingMotion: false,
+        currentCharacter: getCharacterName(model._modelPath),
+
+        async getCurrentCharacterName() {
+            return getCharacterName(model._modelPath);
+        },
+        prepareTextForTTS(text) {
+            return prepareTextForTTS(text);
+        },
+        triggerEmotionByTextPosition(position, textLength, emotionMarkers) {
+            if (!emotionMarkers || emotionMarkers.length === 0) return;
+            for (let i = emotionMarkers.length - 1; i >= 0; i--) {
+                const marker = emotionMarkers[i];
+                if (position >= marker.position && position <= marker.position + 2) {
+                    this.playConfiguredEmotion(marker.emotion);
+                    emotionMarkers.splice(i, 1);
+                    break;
+                }
+            }
+            if (position >= textLength - 1 && emotionMarkers.length > 0) {
+                for (const marker of emotionMarkers) this.playConfiguredEmotion(marker.emotion);
+                emotionMarkers.length = 0;
+            }
+        },
+        playConfiguredEmotion(emotion) {
+            if (expressionMap[emotion]) {
+                model.playEmotionExpression(emotion);
+            } else {
+                console.warn(`VRM未配置情绪: ${emotion}`);
+            }
+        },
+        parseEmotionTagsWithPosition,
+        playMotionByEmotion(emotion) {
+            this.playConfiguredEmotion(emotion);
+        },
+        playMotion(group) {
+            model.motion(typeof group === 'number' ? 'TapBody' : group);
+        },
+        playDefaultMotion() { /* VRM 无 idle motion 语义（由 Idle 姿态动画承担） */ },
+        getEmotionList() {
+            return Object.keys(expressionMap);
+        },
+        getEmotionConfig() {
+            const config = {};
+            for (const [emotion, vrmName] of Object.entries(expressionMap)) {
+                config[emotion] = [`vrm_expression:${vrmName}`];
+            }
+            return config;
+        },
+        async loadEmotionConfig() {},
+        async reloadConfig() {},
+        triggerMotionByEmotion(text) {
+            const match = text.match(/<([^>]+)>/);
+            if (match && match[1]) this.playConfiguredEmotion(match[1]);
+            return text.replace(/<[^>]+>/g, '').trim();
+        },
+        setEmotionCallback(callback) {
+            this._emotionCallback = callback;
+        }
+    };
+}
+
+function createVRMExpressionMapper(model, expressionMap) {
+    return {
+        model,
+        defaultExpression: 'neutral',
+        expressionConfig: expressionMap,
+        currentCharacter: getCharacterName(model._modelPath),
+
+        async getCurrentCharacterName() {
+            return getCharacterName(model._modelPath);
+        },
+        setEmotionMapper() {},
+        prepareTextForTTS(text) {
+            return prepareTextForTTS(text);
+        },
+        triggerExpressionByEmotion(emotion) {
+            if (expressionMap[emotion]) {
+                model.playEmotionExpression(emotion);
+                return expressionMap[emotion];
+            }
+            return null;
+        },
+        triggerEmotionByTextPosition(position, textLength, expressionMarkers) {
+            if (!expressionMarkers || expressionMarkers.length === 0) return;
+            for (let i = expressionMarkers.length - 1; i >= 0; i--) {
+                const marker = expressionMarkers[i];
+                if (position >= marker.position && position <= marker.position + 2) {
+                    this.triggerExpressionByEmotion(marker.emotion);
+                    expressionMarkers.splice(i, 1);
+                    break;
+                }
+            }
+            if (position >= textLength - 1 && expressionMarkers.length > 0) {
+                for (const marker of expressionMarkers) this.triggerExpressionByEmotion(marker.emotion);
+                expressionMarkers.length = 0;
+            }
+        },
+        triggerExpression(expressionName) {
+            if (!expressionName || expressionName === 'neutral' || expressionName === this.defaultExpression) {
+                model._playExpression('neutral', 2000);
+                return true;
+            }
+            if (expressionMap[expressionName]) {
+                model.playEmotionExpression(expressionName);
+                return true;
+            }
+            // 直接透传 VRM preset 名（happy/angry/...）
+            model._playExpression(expressionName, 3000);
+            return true;
+        },
+        playExpression(name) {
+            return this.triggerExpression(name);
+        },
+        playDefaultExpression() {
+            model._playExpression('neutral', 2000);
+            return true;
+        },
+        bindExpressionToEmotion() {
+            console.warn('[VRM] bindExpressionToEmotion 不适用于 VRM 形态');
+            return false;
+        },
+        async reloadConfig() {}
+    };
+}
+
+module.exports = { createVRMEmotionMapper, createVRMExpressionMapper, getCharacterName, prepareTextForTTS, parseEmotionTagsWithPosition };

--- a/live-2d/js/avatar/vrm/interaction.js
+++ b/live-2d/js/avatar/vrm/interaction.js
@@ -1,0 +1,440 @@
+// interaction.js - VRM 交互控制器（v2，由 js/model/vrm-model-interaction.js 迁移）
+// v2 变更：所有事件监听统一登记，提供 destroy()（配合形态热切换）；
+//         鼠标穿透判定交由 ui-controller 的统一 mousemove 路径 + 本类的拖拽联动。
+const { ipcRenderer } = require('electron');
+
+// VRM视口参数（与旧实现一致的实测校准值）
+const VRM_VIEWPORT_ASPECT = 1.5;
+const VRM_SCALE_FACTOR = 0.896;
+const VRM_PADDING_X = 0.104;
+const VRM_PADDING_Y = 0.282;
+
+class VRMInteractionController {
+    constructor() {
+        this.model = null;
+        this.manager = null;
+        this.canvas = null;
+        this.isDragging = false;
+        this.dragOffset = { x: 0, y: 0 };
+        this.config = null;
+        this._listeners = [];
+    }
+
+    init(model, manager, config = null) {
+        this.model = model;
+        this.manager = manager;
+        this.canvas = manager.canvas;
+        this.config = config;
+        this._teardown();
+        this._setupVRMInteractivity();
+        this._setupControlPanel();
+        this._setupScrollZoom();
+        this._setupWindowResize();
+        this._setupContextMenu();
+    }
+
+    _on(target, type, handler, options) {
+        target.addEventListener(type, handler, options);
+        this._listeners.push({ target, type, handler, options });
+    }
+
+    _teardown() {
+        for (const { target, type, handler, options } of this._listeners) {
+            try { target.removeEventListener(type, handler, options); } catch (_) {}
+        }
+        this._listeners = [];
+    }
+
+    destroy() {
+        this._teardown();
+        // 隐藏 VRM 控制面板
+        const panel = document.getElementById('model-controls');
+        if (panel) panel.style.display = 'none';
+        this.model = null;
+        this.manager = null;
+        this.canvas = null;
+    }
+
+    // 供 ui-controller 的统一穿透判定
+    isPointOverInteractive(clientX, clientY) {
+        if (!this.model) return false;
+        return this.model.containsPoint({ x: clientX, y: clientY });
+    }
+
+    // VRM控制面板（重置、VMC、渲染开关、穿透、视线）
+    _setupControlPanel() {
+        const panel = document.getElementById('model-controls');
+        if (!panel) return;
+        panel.style.display = 'flex';
+
+        const toggleBtn = document.getElementById('btn-toggle-panel');
+        const panelButtons = document.getElementById('panel-buttons');
+        if (toggleBtn && panelButtons) {
+            this._on(toggleBtn, 'click', (e) => {
+                e.stopPropagation();
+                const isExpanded = panelButtons.classList.toggle('expanded');
+                toggleBtn.textContent = isExpanded ? '✕' : '⚙';
+                toggleBtn.title = isExpanded ? '收起面板' : '展开控制面板';
+            });
+        }
+
+        const resetBtn = document.getElementById('btn-reset-position');
+        if (resetBtn) {
+            resetBtn.style.display = '';
+            this._on(resetBtn, 'click', (e) => {
+                e.stopPropagation();
+                this.model?.resetOrbit();
+            });
+        }
+
+        // VMC开关（肥牛独有功能，保留）
+        const vmcBtn = document.getElementById('btn-toggle-vmc');
+        if (vmcBtn) {
+            const vmcSender = this.model.getVMCSender && this.model.getVMCSender();
+            vmcBtn.classList.toggle('active', !!(vmcSender && vmcSender.enabled));
+            this._updateRenderBtnState();
+
+            this._on(vmcBtn, 'click', (e) => {
+                e.stopPropagation();
+                const sender = this.model.getVMCSender && this.model.getVMCSender();
+                if (!sender) return;
+                if (sender.enabled) {
+                    sender.enabled = false;
+                    sender.stop();
+                    vmcBtn.classList.remove('active');
+                } else {
+                    sender.enabled = true;
+                    if (!sender.socket) sender.start();
+                    vmcBtn.classList.add('active');
+                }
+                this._updateRenderBtnState();
+            });
+        }
+
+        const renderBtn = document.getElementById('btn-toggle-render');
+        if (renderBtn) {
+            this._on(renderBtn, 'click', (e) => {
+                e.stopPropagation();
+                const vmcSender = this.model.getVMCSender && this.model.getVMCSender();
+                if (!vmcSender || !vmcSender.enabled) return;
+                const nowEnabled = this.model.isRenderingEnabled();
+                this.model.setRenderingEnabled(!nowEnabled);
+                renderBtn.classList.toggle('active', !nowEnabled);
+            });
+        }
+
+        const ctBtn = document.getElementById('btn-click-through');
+        if (ctBtn) {
+            this._on(ctBtn, 'click', (e) => {
+                e.stopPropagation();
+                const newVal = !this.model.clickThrough;
+                this.model.clickThrough = newVal;
+                ctBtn.classList.toggle('active', newVal);
+            });
+        }
+
+        const gazeBtn = document.getElementById('btn-toggle-gaze');
+        if (gazeBtn) {
+            gazeBtn.classList.toggle('active', this.model._gazeEnabled);
+            this._on(gazeBtn, 'click', (e) => {
+                e.stopPropagation();
+                this.model._gazeEnabled = !this.model._gazeEnabled;
+                gazeBtn.classList.toggle('active', this.model._gazeEnabled);
+            });
+        }
+
+        this._on(panel, 'mouseenter', () => {
+            ipcRenderer.send('set-ignore-mouse-events', { ignore: false });
+        });
+        this._on(panel, 'mouseleave', () => {
+            ipcRenderer.send('set-ignore-mouse-events', { ignore: true, options: { forward: true } });
+        });
+
+        const chatContainer = document.getElementById('text-chat-container');
+        if (chatContainer) {
+            this._on(chatContainer, 'mouseenter', () => {
+                ipcRenderer.send('set-ignore-mouse-events', { ignore: false });
+            });
+            this._on(chatContainer, 'mouseleave', () => {
+                ipcRenderer.send('set-ignore-mouse-events', { ignore: true, options: { forward: true } });
+            });
+        }
+    }
+
+    _updateRenderBtnState() {
+        const renderBtn = document.getElementById('btn-toggle-render');
+        if (!renderBtn || !this.model) return;
+        const vmcSender = this.model.getVMCSender && this.model.getVMCSender();
+        const vmcEnabled = vmcSender && vmcSender.enabled;
+        renderBtn.classList.toggle('disabled', !vmcEnabled);
+        if (!vmcEnabled) {
+            this.model.setRenderingEnabled(true);
+            renderBtn.classList.remove('active');
+        }
+    }
+
+    _setupVRMInteractivity() {
+        const canvas = this.canvas;
+        const model = this.model;
+        let mouseDownPos = null;
+        let isRightDragging = false;
+        const rightDragStart = { x: 0, y: 0 };
+
+        // containsPoint：检查client坐标是否在模型/UI元素上（穿透判定用）
+        model.containsPoint = (point) => {
+            const overFeiniuBoardPanel = () => {
+                const boardPanel = document.querySelector('#feiniu-board-game-root .feiniu-panel');
+                if (!boardPanel || !boardPanel.isConnected) return false;
+                const r = boardPanel.getBoundingClientRect();
+                if (r.width <= 0 || r.height <= 0) return false;
+                return point.x >= r.left && point.x <= r.right && point.y >= r.top && point.y <= r.bottom;
+            };
+            const overRect = (el) => {
+                if (!el || el.style.display === 'none') return false;
+                const r = el.getBoundingClientRect();
+                return point.x >= r.left && point.x <= r.right && point.y >= r.top && point.y <= r.bottom;
+            };
+            if (!model._interactive || !model._visible) return false;
+            if (model._clickThrough) {
+                return overRect(document.getElementById('model-controls'))
+                    || overRect(document.getElementById('text-chat-container'))
+                    || overFeiniuBoardPanel();
+            }
+            return model.isPointOverModel(point.x, point.y)
+                || overRect(document.getElementById('text-chat-container'))
+                || overRect(document.getElementById('model-controls'))
+                || overFeiniuBoardPanel();
+        };
+
+        this._on(canvas, 'mousemove', (e) => {
+            if (model._gazeEnabled && model.setMousePosition) {
+                model.setMousePosition(e.clientX, e.clientY);
+            }
+            if (this.isDragging) {
+                const vr = model.viewRect;
+                vr.x = e.clientX - this.dragOffset.x;
+                vr.y = e.clientY - this.dragOffset.y;
+                return;
+            }
+            if (isRightDragging) {
+                const dx = e.clientX - rightDragStart.x;
+                const dy = e.clientY - rightDragStart.y;
+                model._orbitTheta -= dx * 0.005;
+                model._orbitPhi += dy * 0.005;
+                model._orbitPhi = Math.max(-Math.PI / 3, Math.min(Math.PI / 3, model._orbitPhi));
+                rightDragStart.x = e.clientX;
+                rightDragStart.y = e.clientY;
+                return;
+            }
+            if (model.containsPoint({ x: e.clientX, y: e.clientY })) {
+                ipcRenderer.send('set-ignore-mouse-events', { ignore: false });
+            } else {
+                ipcRenderer.send('set-ignore-mouse-events', { ignore: true, options: { forward: true } });
+            }
+            if (model._clickThrough) {
+                model.setHoverTransparent(model.isPointOverModel(e.clientX, e.clientY));
+            }
+        });
+
+        this._on(canvas, 'mousedown', (e) => {
+            const isOverModel = model.isPointOverModel(e.clientX, e.clientY);
+            if (model._clickThrough) return;
+            if (e.button === 0) {
+                mouseDownPos = { x: e.clientX, y: e.clientY };
+                if (isOverModel) {
+                    this.isDragging = true;
+                    const vr = model.viewRect;
+                    this.dragOffset.x = e.clientX - vr.x;
+                    this.dragOffset.y = e.clientY - vr.y;
+                    ipcRenderer.send('set-ignore-mouse-events', { ignore: false });
+                }
+            } else if (e.button === 2) {
+                if (isOverModel) {
+                    isRightDragging = true;
+                    rightDragStart.x = e.clientX;
+                    rightDragStart.y = e.clientY;
+                    ipcRenderer.send('set-ignore-mouse-events', { ignore: false });
+                }
+            }
+        });
+
+        this._on(window, 'mouseup', (e) => {
+            if (e.button === 0 && this.isDragging) {
+                this.isDragging = false;
+
+                // 点击判定：位移<5px 触发点击表情（与 Live2D 的点击交互对齐）
+                if (mouseDownPos && !model._clickThrough) {
+                    const dx = e.clientX - mouseDownPos.x;
+                    const dy = e.clientY - mouseDownPos.y;
+                    if (Math.hypot(dx, dy) < 5 && model.isPointOverModel(e.clientX, e.clientY)) {
+                        model.motion('Tap');
+                    }
+                }
+
+                this._clampViewRect();
+                this.saveModelPosition();
+                setTimeout(() => {
+                    if (this.model && !model.containsPoint({ x: e.clientX, y: e.clientY })) {
+                        ipcRenderer.send('set-ignore-mouse-events', { ignore: true, options: { forward: true } });
+                    }
+                }, 100);
+            }
+            if (e.button === 2 && isRightDragging) {
+                isRightDragging = false;
+                setTimeout(() => {
+                    if (this.model && !model.containsPoint({ x: e.clientX, y: e.clientY })) {
+                        ipcRenderer.send('set-ignore-mouse-events', { ignore: true, options: { forward: true } });
+                    }
+                }, 100);
+            }
+            if (e.button === 0) mouseDownPos = null;
+        });
+
+        this._on(canvas, 'mouseover', (e) => {
+            if (model.containsPoint({ x: e.clientX, y: e.clientY })) {
+                ipcRenderer.send('set-ignore-mouse-events', { ignore: false });
+            }
+        });
+
+        this._on(canvas, 'mouseout', (e) => {
+            if (this.isDragging) return;
+            const t = e.relatedTarget;
+            const root = document.getElementById('feiniu-board-game-root');
+            if (t && root && root.contains(t)) return;
+            ipcRenderer.send('set-ignore-mouse-events', { ignore: true, options: { forward: true } });
+        });
+    }
+
+    _setupScrollZoom() {
+        this._on(window, 'wheel', (e) => {
+            if (!this.model || !this.model.isPointOverModel(e.clientX, e.clientY)) return;
+            e.preventDefault();
+            if (this.model._clickThrough) return;
+
+            if (e.altKey) {
+                const factor = e.deltaY > 0 ? 1.1 : 0.9;
+                this.model._orbitDistance = Math.max(0.5, Math.min(20, this.model._orbitDistance * factor));
+                return;
+            }
+
+            const vr = this.model.viewRect;
+            const factor = e.deltaY > 0 ? 0.95 : 1.05;
+            const newWidth = vr.width * factor;
+            const newHeight = newWidth * VRM_VIEWPORT_ASPECT;
+            if (newWidth < 100 || newWidth > window.innerWidth * 5) return;
+
+            const mouseRelX = (e.clientX - vr.x) / vr.width;
+            const mouseRelY = (e.clientY - vr.y) / vr.height;
+            vr.x -= (newWidth - vr.width) * mouseRelX;
+            vr.y -= (newHeight - vr.height) * mouseRelY;
+            vr.width = newWidth;
+            vr.height = newHeight;
+
+            this._clampViewRect();
+            this.saveModelPosition();
+        }, { passive: false });
+    }
+
+    _setupWindowResize() {
+        this._on(window, 'resize', () => {
+            if (this.manager?.renderer) {
+                this.manager.renderer.setSize(window.innerWidth, window.innerHeight);
+            }
+        });
+    }
+
+    _setupContextMenu() {
+        this._on(window, 'contextmenu', (e) => {
+            e.preventDefault();
+            return false;
+        });
+    }
+
+    // 设置嘴部动画（TTS/音乐口型链路）
+    setMouthOpenY(v) {
+        if (!this.model) return;
+        try {
+            v = Math.max(0, Math.min(v, 3.0));
+            this.model.internalModel.coreModel.setParameterValueById('ParamMouthOpenY', v);
+        } catch (_) {}
+    }
+
+    setupInitialModelProperties() {
+        if (!this.model) return;
+        const rememberPosition = this.config?.ui?.model_position?.remember_position !== false;
+        const savedPos = this.config?.ui?.model_position;
+        const savedScale = this.config?.ui?.model_scale;
+        if (rememberPosition && savedPos?.x != null && savedPos?.y != null && savedScale && savedScale > 0) {
+            this.model.viewRect = this._savedToViewRect(savedPos.x, savedPos.y, savedScale);
+        } else {
+            this.model.viewRect = this._savedToViewRect(1.35, 0.8, 2.3);
+        }
+        this._clampViewRect();
+    }
+
+    saveModelPosition() {
+        if (!this.model || !this.config) return;
+        const vr = this.model.viewRect;
+        if (!vr || !this.config.ui?.model_position?.remember_position) return;
+
+        const saved = this._viewRectToSaved();
+        this.config.ui.model_position.x = saved.x;
+        this.config.ui.model_position.y = saved.y;
+        this.config.ui.model_scale = saved.scale;
+
+        ipcRenderer.send('save-model-position', {
+            ...saved,
+            modelName: null   // VRM 位置沿用全局 config 键（与旧行为一致）
+        });
+    }
+
+    resetModelPosition() {
+        if (!this.model) return { success: false };
+        this.model.viewRect = this._savedToViewRect(1.35, 0.8, 2.3);
+        this._clampViewRect();
+        this.saveModelPosition();
+        return { success: true };
+    }
+
+    _savedToViewRect(relX, relY, scale) {
+        const iW = window.innerWidth;
+        const iH = window.innerHeight;
+        const width = scale * VRM_SCALE_FACTOR * iW;
+        const height = width * VRM_VIEWPORT_ASPECT;
+        return {
+            x: relX * iW / 2 - VRM_PADDING_X * width,
+            y: relY * iH / 2 - VRM_PADDING_Y * height,
+            width,
+            height
+        };
+    }
+
+    _viewRectToSaved() {
+        const vr = this.model.viewRect;
+        const iW = window.innerWidth;
+        const iH = window.innerHeight;
+        return {
+            x: (vr.x + VRM_PADDING_X * vr.width) * 2 / iW,
+            y: (vr.y + VRM_PADDING_Y * vr.height) * 2 / iH,
+            scale: vr.width / (VRM_SCALE_FACTOR * iW)
+        };
+    }
+
+    _clampViewRect() {
+        if (!this.model) return;
+        const vr = this.model.viewRect;
+        const iW = window.innerWidth;
+        const iH = window.innerHeight;
+        const modelLeft = vr.x + VRM_PADDING_X * vr.width;
+        const modelRight = vr.x + (1 - VRM_PADDING_X) * vr.width;
+        const modelTop = vr.y + VRM_PADDING_Y * vr.height;
+        const modelBottom = vr.y + 0.96 * vr.height;
+        const margin = 80;
+        if (modelRight < margin) vr.x += margin - modelRight;
+        if (modelLeft > iW - margin) vr.x -= modelLeft - (iW - margin);
+        if (modelBottom < margin) vr.y += margin - modelBottom;
+        if (modelTop > iH - margin) vr.y -= modelTop - (iH - margin);
+    }
+}
+
+module.exports = { VRMInteractionController };

--- a/live-2d/js/avatar/vrm/manager.js
+++ b/live-2d/js/avatar/vrm/manager.js
@@ -1,0 +1,292 @@
+// manager.js - VRM 管理器（v2，组合式架构）
+// Adapted from Project-N-E-K-O/N.E.K.O (Apache-2.0): static/vrm-manager.js 的
+// 组合式结构（manager 持有 adapter/interaction 子模块）、load token 竞态防护与 dispose 清理思路。
+// 渲染路径沿用肥牛旧实现的"视口/裁剪局部渲染"（与 viewRect 拖拽/缩放/持久化联动）。
+//
+// v2 关键变更（相对 js/model/vrm-model-setup.js）：
+//   - 支持 VRM 0.x 与 1.0（旧实现直接抛错拒绝 1.0）；1.0 模型自动转向面对相机
+//   - 完整 dispose()：rAF 取消、VMC 停止、场景遍历释放 geometry/material/texture、
+//     renderer.dispose + forceContextLoss（配合形态热切换不再需要整窗 reload）
+//   - 渲染循环带异常保护，单帧异常不再冻结渲染进程
+const fs = require('fs');
+const path = require('path');
+const THREE = require('three');
+const { GLTFLoader } = require('../../lib/gltf-loader-bundle.cjs');
+const { VRMLoaderPlugin, VRMUtils } = require('@pixiv/three-vrm');
+const { VRMModelAdapter } = require('./model-adapter.js');
+const { logToTerminal } = require('../../api-utils.js');
+
+const APP_ROOT = path.join(__dirname, '..', '..', '..');
+
+class VRMManager {
+    constructor() {
+        this.renderer = null;
+        this.scene = null;
+        this.camera = null;
+        this.canvas = null;
+        this.currentModel = null;   // VRMModelAdapter
+        this.clock = null;
+        this._animationFrameId = null;
+        this._disposed = false;
+        this._activeLoadToken = 0;
+        this._frameErrorCount = 0;
+    }
+
+    // renderer 是否存活（供 setup 判断复用）
+    isAlive() {
+        return !!(this.renderer && !this._disposed);
+    }
+
+    initThreeJS(canvasId = 'vrm-canvas') {
+        this.canvas = document.getElementById(canvasId);
+        if (!this.canvas) {
+            throw new Error(`VRMManager: 找不到 canvas 元素 #${canvasId}`);
+        }
+
+        this.renderer = new THREE.WebGLRenderer({
+            canvas: this.canvas,
+            alpha: true,
+            antialias: false,   // 高 DPI 下抗锯齿开销过大（可能触发软件渲染时秒级帧耗时冻结主线程）
+            premultipliedAlpha: false,
+            powerPreference: 'high-performance'
+        });
+        this.renderer.setSize(window.innerWidth, window.innerHeight);
+        // 钳制 pixelRatio：4K/300% 缩放环境下按 devicePixelRatio 全量渲染会拖死渲染进程
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.5));
+        this.renderer.setClearColor(0x000000, 0);
+        this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+        try {
+            const gl = this.renderer.getContext();
+            const dbg = gl.getExtension('WEBGL_debug_renderer_info');
+            const glRenderer = dbg ? gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL) : 'unknown';
+            logToTerminal('info', `[VRMManager] WebGL渲染器: ${glRenderer}, pixelRatio=${this.renderer.getPixelRatio()}`);
+        } catch (_) {}
+
+        this.scene = new THREE.Scene();
+
+        this.camera = new THREE.PerspectiveCamera(40, window.innerWidth / window.innerHeight, 0.1, 100);
+        this.camera.position.set(0, 1.0, 3.0);
+        this.camera.lookAt(0, 1.0, 0);
+
+        const ambientLight = new THREE.AmbientLight(0xffffff, 0.7);
+        this.scene.add(ambientLight);
+        const directionalLight = new THREE.DirectionalLight(0xffffff, 0.8);
+        directionalLight.position.set(1.0, 1.5, 1.0);
+        this.scene.add(directionalLight);
+
+        this.clock = new THREE.Clock();
+        this._disposed = false;
+    }
+
+    /**
+     * 加载 VRM 模型（支持 0.x 与 1.0）
+     * @param {string} modelPath 相对 live-2d 根目录，如 "3D/Sample_A.vrm"
+     * @param {object} options { gazeEnabled }
+     * @returns {VRMModelAdapter}
+     */
+    async loadModel(modelPath, options = {}) {
+        const token = ++this._activeLoadToken;
+        const absPath = path.resolve(APP_ROOT, modelPath);
+        if (!fs.existsSync(absPath)) {
+            throw new Error(`VRM文件不存在: ${absPath}`);
+        }
+
+        const fileBuffer = fs.readFileSync(absPath);
+        const arrayBuffer = fileBuffer.buffer.slice(
+            fileBuffer.byteOffset,
+            fileBuffer.byteOffset + fileBuffer.byteLength
+        );
+        logToTerminal('info', `[VRMManager] 加载 VRM: ${modelPath} (${(fileBuffer.length / 1024 / 1024).toFixed(2)} MB)`);
+
+        const loader = new GLTFLoader();
+        loader.register((parser) => new VRMLoaderPlugin(parser));
+        const resourcePath = path.dirname(absPath) + path.sep;
+        const gltf = await new Promise((resolve, reject) => {
+            loader.parse(arrayBuffer, resourcePath, resolve, reject);
+        });
+
+        if (token !== this._activeLoadToken || this._disposed) {
+            throw new Error('VRM 加载已被更新的请求取代');
+        }
+
+        const vrm = gltf.userData.vrm;
+        if (!vrm) throw new Error('GLTF文件中未找到VRM数据');
+
+        // 优化
+        try {
+            VRMUtils.removeUnnecessaryJoints(vrm.scene);
+            if (VRMUtils.combineSkeletons) VRMUtils.combineSkeletons(vrm.scene);
+        } catch (e) {
+            console.warn('[VRMManager] VRM 优化警告:', e.message);
+        }
+        vrm.scene.traverse((object) => { object.frustumCulled = false; });
+
+        const metaVersion = String(vrm.meta?.metaVersion ?? '0');
+        logToTerminal('info', `[VRMManager] VRM 规格版本: ${metaVersion}，表情: ${vrm.expressionManager ? Object.keys(vrm.expressionManager._expressionMap || {}).length : 0} 个`);
+
+        // 卸载旧模型
+        await this.removeModel();
+
+        // 包裹 Group（朝向修正）：旧实现的轨道相机在 -Z 侧，VRM0 原生面向 -Z 可直接用；
+        // VRM1 规格面向 +Z，旋转 180° 使其面对相机。
+        const vrmGroup = new THREE.Group();
+        vrmGroup.add(vrm.scene);
+        if (metaVersion === '1') {
+            vrmGroup.rotation.y = Math.PI;
+        }
+        this.scene.add(vrmGroup);
+
+        const adapter = new VRMModelAdapter(vrm, this.scene, this.camera, this.renderer, this.canvas, options);
+        adapter.vrmGroup = vrmGroup;
+        adapter.setModelPath(modelPath);
+        this.currentModel = adapter;
+        return adapter;
+    }
+
+    async removeModel() {
+        const adapter = this.currentModel;
+        if (!adapter) return;
+        this.currentModel = null;
+        try { adapter.dispose(); } catch (_) {}
+        try {
+            if (adapter.vrmGroup) {
+                this.scene.remove(adapter.vrmGroup);
+                this._disposeObject3D(adapter.vrmGroup);
+            }
+            if (adapter.vrm && typeof VRMUtils.deepDispose === 'function') {
+                VRMUtils.deepDispose(adapter.vrm.scene);
+            }
+        } catch (e) {
+            console.warn('[VRMManager] 卸载模型警告:', e.message);
+        }
+    }
+
+    // 启动渲染循环（视口/裁剪局部渲染，单帧异常保护）
+    startLoop() {
+        if (this._animationFrameId) return;
+        this._disposed = false;
+        if (this.clock) this.clock.getDelta(); // 丢弃挂起期间累计的 delta
+        this.renderer.autoClear = false;
+        let firstFrameLogged = false;
+        const animate = () => {
+            if (this._disposed) return;
+            this._animationFrameId = requestAnimationFrame(animate);
+            try {
+                const model = this.currentModel;
+                if (!model) return;
+                const frameStart = performance.now();
+                const delta = this.clock.getDelta();
+                model.update(delta);
+
+                this.renderer.setScissorTest(false);
+                this.renderer.setViewport(0, 0, window.innerWidth, window.innerHeight);
+                this.renderer.clear(true, true, true);
+
+                const vr = model.viewRect;
+                const vpY = window.innerHeight - vr.y - vr.height;
+                this.renderer.setViewport(vr.x, vpY, vr.width, vr.height);
+                this.renderer.setScissor(vr.x, vpY, vr.width, vr.height);
+                this.renderer.setScissorTest(true);
+                model.updateCameraOrbit();
+                this.camera.aspect = vr.width / vr.height;
+                this.camera.updateProjectionMatrix();
+                this.renderer.render(this.scene, this.camera);
+                this._frameErrorCount = 0;
+
+                // 帧耗时观测：首帧 + 每 300 帧汇报一次均值（性能问题定位用）
+                const cost = performance.now() - frameStart;
+                this._frameCostSum = (this._frameCostSum || 0) + cost;
+                this._frameCount = (this._frameCount || 0) + 1;
+                if (!firstFrameLogged) {
+                    firstFrameLogged = true;
+                    const vr = model.viewRect;
+                    logToTerminal('info', `[VRMManager] 首帧完成: ${cost.toFixed(1)}ms, viewRect=(${vr.x.toFixed(0)},${vr.y.toFixed(0)},${vr.width.toFixed(0)}x${vr.height.toFixed(0)})`);
+                } else if (this._frameCount % 300 === 0) {
+                    logToTerminal('info', `[VRMManager] 帧观测: 近300帧均值 ${(this._frameCostSum / 300).toFixed(2)}ms`);
+                    this._frameCostSum = 0;
+                }
+            } catch (e) {
+                // 单帧异常不冻结渲染进程；连续异常则停机避免刷屏
+                this._frameErrorCount++;
+                if (this._frameErrorCount <= 3) {
+                    console.error('[VRMManager] 渲染帧异常:', e);
+                } else if (this._frameErrorCount === 4) {
+                    logToTerminal('error', `[VRMManager] 渲染循环连续异常，已停止: ${e.message}`);
+                    this.stopLoop();
+                }
+            }
+        };
+        animate();
+    }
+
+    stopLoop() {
+        if (this._animationFrameId) {
+            cancelAnimationFrame(this._animationFrameId);
+            this._animationFrameId = null;
+        }
+    }
+
+    _disposeObject3D(root) {
+        root.traverse((object) => {
+            if (object.geometry) {
+                try { object.geometry.dispose(); } catch (_) {}
+            }
+            if (object.material) {
+                const mats = Array.isArray(object.material) ? object.material : [object.material];
+                for (const m of mats) {
+                    for (const key of Object.keys(m)) {
+                        const v = m[key];
+                        if (v && v.isTexture) {
+                            try { v.dispose(); } catch (_) {}
+                        }
+                    }
+                    try { m.dispose(); } catch (_) {}
+                }
+            }
+        });
+    }
+
+    // 挂起（形态热切换用）：停循环、卸模型，但保留 renderer/scene/WebGL 上下文。
+    // 不做 forceContextLoss —— 热切换中销毁上下文后立刻创建新上下文会在
+    // ANGLE/D3D11 原生层冻结渲染进程（实测），保留上下文跨切换复用。
+    async suspend() {
+        this.stopLoop();
+        await this.removeModel();
+        try {
+            // 清一帧为全透明，避免残影
+            if (this.renderer) {
+                this.renderer.setScissorTest(false);
+                this.renderer.setViewport(0, 0, window.innerWidth, window.innerHeight);
+                this.renderer.clear(true, true, true);
+            }
+        } catch (_) {}
+        logToTerminal('info', '[VRMManager] 已挂起（保留渲染上下文）');
+    }
+
+    // 完整释放（仅应用退出/异常兜底；热切换请用 suspend）
+    async dispose() {
+        this._disposed = true;
+        this.stopLoop();
+        await this.removeModel();
+        try {
+            if (this.scene) {
+                this.scene.clear();
+            }
+        } catch (_) {}
+        try {
+            if (this.renderer) {
+                this.renderer.dispose();
+                this.renderer.forceContextLoss();
+            }
+        } catch (e) {
+            console.warn('[VRMManager] renderer 释放警告:', e.message);
+        }
+        this.renderer = null;
+        this.scene = null;
+        this.camera = null;
+        this.clock = null;
+        logToTerminal('info', '[VRMManager] 已释放 Three.js 资源');
+    }
+}
+
+module.exports = { VRMManager };

--- a/live-2d/js/avatar/vrm/model-adapter.js
+++ b/live-2d/js/avatar/vrm/model-adapter.js
@@ -1,0 +1,500 @@
+// model-adapter.js - VRM 模型适配器（v2）
+// 由 js/model/vrm-model-adapter.js 迁移，将 VRM 包装为与 Live2D 模型兼容的接口。
+// v2 变更：
+//   - 支持 VRM 0.x 与 1.0（朝向统一由 core.js 的 rotateVRM0 处理）
+//   - 新增 dispose()（VMC 停止 / mixer 清理），配合形态热切换
+//   - 表情映射表可由外部注入（默认六情绪 -> VRM preset）
+const EventEmitter = require('events');
+const THREE = require('three');
+const { VMCSender } = require('../../services/vmc-sender.js');
+
+const DEFAULT_EXPRESSION_MAP = {
+    '开心': 'happy',
+    '生气': 'angry',
+    '难过': 'sad',
+    '惊讶': 'surprised',
+    '害羞': 'relaxed',
+    '俏皮': 'happy'
+};
+
+class VRMModelAdapter extends EventEmitter {
+    constructor(vrm, scene, camera, renderer, canvas, options = {}) {
+        super();
+        this.vrm = vrm;
+        this.scene = scene;
+        this.camera = camera;
+        this.renderer = renderer;
+        this.canvas = canvas;
+        this.modelType = 'vrm';
+        this.vrmGroup = null;
+
+        this._x = 0;
+        this._y = 0;
+        this._width = 300;
+        this._height = 600;
+        this._visible = true;
+        this._interactive = true;
+        this._renderingEnabled = true;
+        this._viewRect = { x: 0, y: 0, width: 400, height: 600 };
+
+        // 模拟 internalModel 结构（兼容口型链路与角色名提取）
+        this.internalModel = {
+            coreModel: {
+                setParameterValueById: (paramId, value) => this._setVRMParameter(paramId, value),
+                SetParameterValue: (paramId, value) => this._setVRMParameter(paramId, value)
+            },
+            settings: { url: '3D/unknown.vrm' }
+        };
+
+        this._expressionMap = { ...DEFAULT_EXPRESSION_MAP, ...(options.expressionMap || {}) };
+        this._currentExpression = null;
+        this._animationMixer = null;
+
+        // 眨眼
+        this._blinkTimer = 0;
+        this._nextBlinkTime = 2 + Math.random() * 4;
+        this._isBlinking = false;
+        this._blinkProgress = 0;
+
+        this._vmcSender = null;
+
+        // 摄像头轨道
+        this._orbitTheta = 0;
+        this._orbitPhi = 0;
+        this._orbitDistance = 3.0;
+        this._orbitTarget = new THREE.Vector3();
+        this._orbitYOffset = 0.1;
+
+        this._screenHitBox = null;
+        this._vec3Proj = new THREE.Vector3();
+
+        this._clickThrough = false;
+        this._hoverTransparent = false;
+
+        // Idle 动画
+        this._idleTime = 0;
+        this._breathPhase = Math.random() * Math.PI * 2;
+        this._swayPhase = Math.random() * Math.PI * 2;
+        this._idlePoseApplied = false;
+
+        // 视线跟随
+        this._gazeEnabled = options.gazeEnabled !== false;
+        this._gazeMouseX = 0;
+        this._gazeMouseY = 0;
+        this._gazeHeadYaw = 0;
+        this._gazeHeadPitch = 0;
+        this._gazeEyeYaw = 0;
+        this._gazeEyePitch = 0;
+
+        this._disposed = false;
+        this._initAnimationMixer();
+    }
+
+    get x() { return this._x; }
+    set x(val) { this._x = val; }
+    get y() { return this._y; }
+    set y(val) { this._y = val; }
+    get width() { return this._width; }
+    set width(val) { this._width = val; }
+    get height() { return this._height; }
+    set height(val) { this._height = val; }
+
+    get visible() { return this._visible; }
+    set visible(val) {
+        this._visible = val;
+        if (this.vrmGroup) {
+            this.vrmGroup.visible = val;
+        } else if (this.vrm && this.vrm.scene) {
+            this.vrm.scene.visible = val;
+        }
+    }
+
+    get interactive() { return this._interactive; }
+    set interactive(val) { this._interactive = val; }
+
+    get viewRect() { return this._viewRect; }
+    set viewRect(rect) {
+        this._viewRect = rect;
+        this._width = rect.width;
+        this._height = rect.height;
+        this._x = rect.x;
+        this._y = rect.y;
+    }
+
+    setModelPath(path) {
+        this._modelPath = path;
+        this.internalModel.settings.url = path;
+    }
+
+    _initAnimationMixer() {
+        if (this.vrm && this.vrm.scene) {
+            this._animationMixer = new THREE.AnimationMixer(this.vrm.scene);
+        }
+    }
+
+    // 每帧更新眨眼动画
+    _updateBlinkAnimation(deltaTime) {
+        if (!this.vrm || !this.vrm.expressionManager) return;
+
+        this._blinkTimer += deltaTime;
+        if (!this._isBlinking && this._blinkTimer >= this._nextBlinkTime) {
+            this._isBlinking = true;
+            this._blinkProgress = 0;
+        }
+        if (this._isBlinking) {
+            this._blinkProgress += deltaTime;
+            const blinkDuration = 0.15;
+            const half = blinkDuration / 2;
+            let v;
+            if (this._blinkProgress < half) {
+                v = this._blinkProgress / half;
+            } else if (this._blinkProgress < blinkDuration) {
+                v = 1 - (this._blinkProgress - half) / half;
+            } else {
+                v = 0;
+                this._isBlinking = false;
+                this._blinkTimer = 0;
+                this._nextBlinkTime = 2 + Math.random() * 4;
+            }
+            try { this.vrm.expressionManager.setValue('blink', v); } catch (_) {}
+        }
+    }
+
+    // Live2D 口型参数 -> VRM 元音 blendshape
+    _setVRMParameter(paramId, value) {
+        if (!this.vrm || !this.vrm.expressionManager) return;
+        const mouthParams = ['PARAM_MOUTH_OPEN_Y', 'ParamMouthOpenY'];
+        if (mouthParams.includes(paramId)) {
+            const v = Math.max(0, Math.min(value * 1.3, 1.0));
+            try {
+                this.vrm.expressionManager.setValue('aa', v);
+                this.vrm.expressionManager.setValue('oh', v * 0.3);
+                this.vrm.expressionManager.setValue('ou', v * 0.15);
+            } catch (_) {}
+        }
+    }
+
+    // 兼容 Live2D motion：点击时随机表情
+    motion(group) {
+        if (!this.vrm || !this.vrm.expressionManager) return;
+        if (group === 'Tap' || group === 'TapBody') {
+            const expressions = ['happy', 'surprised', 'relaxed'];
+            this._playExpression(expressions[Math.floor(Math.random() * expressions.length)], 2000);
+        }
+    }
+
+    // 兼容 Live2D expression
+    expression(name) {
+        if (!this.vrm || !this.vrm.expressionManager) return;
+        if (name) {
+            this._playExpression(this._expressionMap[name] || name, 3000);
+        } else {
+            const expressions = ['happy', 'angry', 'sad', 'surprised', 'relaxed'];
+            this._playExpression(expressions[Math.floor(Math.random() * expressions.length)], 2000);
+        }
+    }
+
+    _playExpression(expressionName, duration = 3000) {
+        if (!this.vrm || !this.vrm.expressionManager) return;
+        if (this._currentExpression) {
+            try { this.vrm.expressionManager.setValue(this._currentExpression, 0); } catch (_) {}
+        }
+        try {
+            this.vrm.expressionManager.setValue(expressionName, 1.0);
+            this._currentExpression = expressionName;
+            setTimeout(() => {
+                if (this._disposed) return;
+                if (this._currentExpression === expressionName) {
+                    try { this.vrm.expressionManager.setValue(expressionName, 0); } catch (_) {}
+                    this._currentExpression = null;
+                }
+            }, duration);
+        } catch (_) {
+            console.warn(`VRM表情 "${expressionName}" 不可用`);
+        }
+    }
+
+    playEmotionExpression(emotionName) {
+        this._playExpression(this._expressionMap[emotionName] || emotionName, 3000);
+    }
+
+    containsPoint(point) {
+        if (!this._interactive || !this._visible) return false;
+        return this.isPointOverModel(point.x, point.y);
+    }
+
+    isPointOverModel(clientX, clientY) {
+        const hb = this.getScreenHitBox();
+        return clientX >= hb.x && clientX <= hb.x + hb.width &&
+               clientY >= hb.y && clientY <= hb.y + hb.height;
+    }
+
+    getScreenHitBox() {
+        return this._screenHitBox || this._viewRect;
+    }
+
+    hitTest(x, y) {
+        return this.containsPoint({ x, y });
+    }
+
+    // 每帧更新
+    update(deltaTime) {
+        if (!this.vrm || this._disposed) return;
+        this._updateIdleAnimation(deltaTime);
+        if (this._gazeEnabled) this._updateGazeTracking(deltaTime);
+        this._updateBlinkAnimation(deltaTime);
+        this.vrm.update(deltaTime);
+        if (this._animationMixer) this._animationMixer.update(deltaTime);
+        if (this._vmcSender) this._vmcSender.sendFrame();
+    }
+
+    _updateIdleAnimation(deltaTime) {
+        if (!this.vrm || !this.vrm.humanoid) return;
+        if (!this._idlePoseApplied) {
+            this._applyIdlePose();
+            this._idlePoseApplied = true;
+        }
+
+        this._idleTime += deltaTime;
+        const humanoid = this.vrm.humanoid;
+
+        this._breathPhase += deltaTime * 2.1;
+        const breathVal = Math.sin(this._breathPhase) * 0.012;
+
+        const spine = humanoid.getNormalizedBoneNode('spine');
+        if (spine) spine.rotation.x = breathVal;
+        const upperChest = humanoid.getNormalizedBoneNode('upperChest');
+        if (upperChest) upperChest.rotation.x = breathVal * 0.8;
+
+        this._swayPhase += deltaTime * 0.9;
+        const swayX = Math.sin(this._swayPhase * 0.7) * 0.006;
+        const swayZ = Math.sin(this._swayPhase * 1.1 + 1.3) * 0.008;
+        if (spine) {
+            spine.rotation.x += swayX;
+            spine.rotation.z = swayZ;
+        }
+
+        const armSway = Math.sin(this._swayPhase * 0.8 + 0.5) * 0.03;
+        const leftUpperArm = humanoid.getNormalizedBoneNode('leftUpperArm');
+        const rightUpperArm = humanoid.getNormalizedBoneNode('rightUpperArm');
+        if (leftUpperArm) leftUpperArm.rotation.x = 0.15 + armSway;
+        if (rightUpperArm) rightUpperArm.rotation.x = 0.15 - armSway;
+
+        const head = humanoid.getNormalizedBoneNode('head');
+        if (head && !this._gazeEnabled) {
+            head.rotation.y = Math.sin(this._swayPhase * 0.5 + 2.0) * 0.015;
+            head.rotation.x = Math.sin(this._swayPhase * 0.6 + 0.7) * 0.008;
+        }
+    }
+
+    _applyIdlePose() {
+        const humanoid = this.vrm.humanoid;
+        const leftUpperArm = humanoid.getNormalizedBoneNode('leftUpperArm');
+        const rightUpperArm = humanoid.getNormalizedBoneNode('rightUpperArm');
+        const leftLowerArm = humanoid.getNormalizedBoneNode('leftLowerArm');
+        const rightLowerArm = humanoid.getNormalizedBoneNode('rightLowerArm');
+        if (leftUpperArm) leftUpperArm.rotation.set(0.15, 0, 1.2);
+        if (rightUpperArm) rightUpperArm.rotation.set(0.15, 0, -1.2);
+        if (leftLowerArm) leftLowerArm.rotation.set(0, 0, 0.08);
+        if (rightLowerArm) rightLowerArm.rotation.set(0, 0, -0.08);
+    }
+
+    setMousePosition(px, py) {
+        this._gazeMouseX = px;
+        this._gazeMouseY = py;
+    }
+
+    _getHeadScreenPos() {
+        const head = this.vrm.humanoid?.getNormalizedBoneNode('head');
+        if (!head || !this.camera) return null;
+        const v = this._vec3Proj;
+        head.getWorldPosition(v);
+        v.project(this.camera);
+        const vr = this._viewRect;
+        return {
+            x: vr.x + (v.x * 0.5 + 0.5) * vr.width,
+            y: vr.y + (-v.y * 0.5 + 0.5) * vr.height
+        };
+    }
+
+    _updateGazeTracking(deltaTime) {
+        if (!this.vrm?.humanoid) return;
+        const headPos = this._getHeadScreenPos();
+        if (!headPos) return;
+
+        const pixelDx = this._gazeMouseX - headPos.x;
+        const pixelDy = this._gazeMouseY - headPos.y;
+        const refSize = this._viewRect.width * 0.5;
+        const dx = Math.max(-1, Math.min(1, pixelDx / refSize));
+        const dy = Math.max(-1, Math.min(1, pixelDy / refSize));
+
+        const headYawTarget = dx * 0.3;
+        const headPitchTarget = -dy * 0.2;
+        const eyeYawTarget = dx * 0.7;
+        const eyePitchTarget = -dy * 0.5;
+
+        const headSmooth = 1 - Math.exp(-4.0 * deltaTime);
+        const eyeSmooth = 1 - Math.exp(-10.0 * deltaTime);
+        this._gazeHeadYaw += (headYawTarget - this._gazeHeadYaw) * headSmooth;
+        this._gazeHeadPitch += (headPitchTarget - this._gazeHeadPitch) * headSmooth;
+        this._gazeEyeYaw += (eyeYawTarget - this._gazeEyeYaw) * eyeSmooth;
+        this._gazeEyePitch += (eyePitchTarget - this._gazeEyePitch) * eyeSmooth;
+
+        const humanoid = this.vrm.humanoid;
+        const head = humanoid.getNormalizedBoneNode('head');
+        if (head) {
+            const idleYaw = Math.sin(this._swayPhase * 0.5 + 2.0) * 0.015;
+            const idlePitch = Math.sin(this._swayPhase * 0.6 + 0.7) * 0.008;
+            head.rotation.y = idleYaw + this._gazeHeadYaw;
+            head.rotation.x = idlePitch + this._gazeHeadPitch;
+        }
+
+        const em = this.vrm.expressionManager;
+        if (em) {
+            try {
+                em.setValue('lookLeft', Math.max(0, this._gazeEyeYaw));
+                em.setValue('lookRight', Math.max(0, -this._gazeEyeYaw));
+                em.setValue('lookUp', Math.max(0, this._gazeEyePitch));
+                em.setValue('lookDown', Math.max(0, -this._gazeEyePitch));
+            } catch (_) {}
+        }
+    }
+
+    setupVMC(options = {}) {
+        this._vmcSender = new VMCSender(options);
+        this._vmcSender.setVRM(this.vrm);
+        if (options.enabled !== false) {
+            this._vmcSender.start();
+        }
+        return this._vmcSender;
+    }
+
+    getVMCSender() {
+        return this._vmcSender;
+    }
+
+    setRenderingEnabled(enabled) {
+        this._renderingEnabled = enabled;
+        if (this.vrmGroup) {
+            this.vrmGroup.visible = enabled;
+        } else if (this.vrm && this.vrm.scene) {
+            this.vrm.scene.visible = enabled;
+        }
+    }
+
+    isRenderingEnabled() {
+        return this._renderingEnabled;
+    }
+
+    toGlobal(localPos) {
+        const vr = this._viewRect;
+        return {
+            x: vr.x + vr.width / 2 + (localPos.x || 0),
+            y: vr.y + vr.height / 2 + (localPos.y || 0)
+        };
+    }
+
+    updateCameraOrbit() {
+        if (!this.camera || !this.vrm) return;
+        const target = this._orbitTarget;
+        const hips = this.vrm.humanoid?.getNormalizedBoneNode('hips');
+        if (hips) {
+            hips.getWorldPosition(target);
+        } else {
+            target.set(0, 1, 0);
+        }
+        target.y += this._orbitYOffset;
+
+        const d = this._orbitDistance;
+        const theta = this._orbitTheta;
+        const phi = this._orbitPhi;
+        this.camera.position.set(
+            target.x - d * Math.sin(theta) * Math.cos(phi),
+            target.y + d * Math.sin(phi),
+            target.z - d * Math.cos(theta) * Math.cos(phi)
+        );
+        this.camera.lookAt(target);
+        this.camera.updateMatrixWorld();
+        this._updateScreenHitBox();
+    }
+
+    _updateScreenHitBox() {
+        if (!this.vrm?.humanoid || !this.camera) return;
+        const vr = this._viewRect;
+        const humanoid = this.vrm.humanoid;
+        const v = this._vec3Proj;
+
+        let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+        const boneNames = ['head', 'hips', 'leftUpperArm', 'rightUpperArm',
+                           'leftFoot', 'rightFoot', 'leftHand', 'rightHand'];
+        let count = 0;
+        for (const name of boneNames) {
+            const bone = humanoid.getRawBoneNode(name);
+            if (!bone) continue;
+            bone.getWorldPosition(v);
+            v.project(this.camera);
+            const sx = vr.x + (v.x * 0.5 + 0.5) * vr.width;
+            const sy = vr.y + (-v.y * 0.5 + 0.5) * vr.height;
+            minX = Math.min(minX, sx);
+            maxX = Math.max(maxX, sx);
+            minY = Math.min(minY, sy);
+            maxY = Math.max(maxY, sy);
+            count++;
+        }
+        if (count < 2) return;
+
+        const h = maxY - minY;
+        const w = maxX - minX;
+        const padX = Math.max(w * 0.3, 30);
+        const padTop = Math.max(h * 0.15, 25);
+        const padBot = Math.max(h * 0.05, 15);
+        this._screenHitBox = {
+            x: minX - padX,
+            y: minY - padTop,
+            width: (maxX - minX) + padX * 2,
+            height: (maxY - minY) + padTop + padBot
+        };
+    }
+
+    resetOrbit() {
+        this._orbitTheta = 0;
+        this._orbitPhi = 0;
+        this._orbitDistance = 3.0;
+    }
+
+    get clickThrough() { return this._clickThrough; }
+    set clickThrough(val) {
+        this._clickThrough = val;
+        if (!val && this._hoverTransparent) {
+            this._hoverTransparent = false;
+            if (this.canvas) this.canvas.style.opacity = '1.0';
+        }
+    }
+
+    setHoverTransparent(isOver) {
+        if (!this._clickThrough) return;
+        if (isOver === this._hoverTransparent) return;
+        this._hoverTransparent = isOver;
+        if (this.canvas) this.canvas.style.opacity = isOver ? '0.35' : '1.0';
+    }
+
+    // v2: 释放适配器持有的资源（配合形态热切换）
+    dispose() {
+        this._disposed = true;
+        try {
+            if (this._vmcSender) {
+                this._vmcSender.stop();
+                this._vmcSender = null;
+            }
+        } catch (_) {}
+        try {
+            if (this._animationMixer) {
+                this._animationMixer.stopAllAction();
+                this._animationMixer = null;
+            }
+        } catch (_) {}
+        if (this.canvas) this.canvas.style.opacity = '1.0';
+    }
+}
+
+module.exports = { VRMModelAdapter, DEFAULT_EXPRESSION_MAP };

--- a/live-2d/js/avatar/vrm/setup.js
+++ b/live-2d/js/avatar/vrm/setup.js
@@ -1,0 +1,135 @@
+// setup.js - VRM 形态装配（v2，替代旧 js/model/vrm-model-setup.js）
+// 返回结构与旧 VRMModelSetup.initialize 一致：
+//   { app, model, emotionMapper, expressionMapper, musicPlayer, vrmController, manager }
+//
+// 热切换策略：形态切走时 manager.suspend()（保留 Three renderer/WebGL 上下文），
+// 切回时复用同一 manager 重新 loadModel。（热切换中销毁再新建上下文会冻结渲染进程。）
+const fs = require('fs');
+const path = require('path');
+const { VRMManager } = require('./manager.js');
+const { VRMInteractionController } = require('./interaction.js');
+const { createVRMEmotionMapper, createVRMExpressionMapper, getCharacterName } = require('./emotion.js');
+const { DEFAULT_EXPRESSION_MAP } = require('./model-adapter.js');
+const { MusicPlayer } = require('../../services/music-player.js');
+const { logToTerminal } = require('../../api-utils.js');
+const { bindVoiceChatAvatar } = require('../avatar-voice-chat-binding.js');
+
+const APP_ROOT = path.join(__dirname, '..', '..', '..');
+
+// 模块级单例（跨形态切换存活，保留 WebGL 上下文）
+let _manager = null;
+let _controller = null;
+let _musicPlayer = null;
+
+// 中文情绪 -> VRM 表情映射：模型同目录 <名字>.emotion_mapping.json 可覆盖（可选）
+function resolveExpressionMap(modelPath) {
+    try {
+        const abs = path.resolve(APP_ROOT, modelPath);
+        const sidecar = abs.replace(/\.vrm$/i, '.emotion_mapping.json');
+        if (fs.existsSync(sidecar)) {
+            const data = JSON.parse(fs.readFileSync(sidecar, 'utf8'));
+            if (data && typeof data === 'object') {
+                logToTerminal('info', `[VRMSetup] 使用表情映射 sidecar: ${sidecar}`);
+                return { ...DEFAULT_EXPRESSION_MAP, ...data };
+            }
+        }
+    } catch (_) {}
+    return DEFAULT_EXPRESSION_MAP;
+}
+
+// 解析要加载的 VRM 路径：config.ui.vrm_model_path 有效 > 注册表第一个
+function resolveVRMPath(config) {
+    let modelPath = config?.ui?.vrm_model_path || '';
+    if (modelPath && fs.existsSync(path.resolve(APP_ROOT, modelPath))) {
+        return modelPath;
+    }
+    const { scanVRMModels } = require('../model-registry.js');
+    const all = scanVRMModels();
+    if (all.length > 0) {
+        if (modelPath) console.warn(`[VRMSetup] 配置的 VRM 路径 "${modelPath}" 无效，回退到: ${all[0].modelPath}`);
+        return all[0].modelPath;
+    }
+    throw new Error('3D 目录下没有找到任何 .vrm 模型');
+}
+
+class VRMSetup {
+    static async initialize(modelController, config, ttsEnabled, asrEnabled, ttsProcessor, voiceChat) {
+        // 1. Three.js 场景（首次创建 / 挂起后复用）
+        if (!_manager) _manager = new VRMManager();
+        if (!_manager.isAlive()) {
+            _manager.initThreeJS('vrm-canvas');
+        }
+
+        // 2. 加载模型
+        const modelPath = resolveVRMPath(config);
+        const expressionMap = resolveExpressionMap(modelPath);
+        const gazeEnabled = config?.ui?.live2d_gaze_tracking !== false;
+        const model = await _manager.loadModel(modelPath, { expressionMap, gazeEnabled });
+
+        const showModel = config?.ui?.show_model !== false;
+        model.visible = showModel;
+
+        // 3. 交互控制器（含 VMC/穿透/视线 控制面板）
+        if (!_controller) _controller = new VRMInteractionController();
+        _controller.init(model, _manager, config);
+        _controller.setupInitialModelProperties();
+
+        // 4. VMC 协议发送器（肥牛独有功能，保留）
+        const vmcConfig = config?.vmc || {};
+        model.setupVMC({
+            enabled: vmcConfig.enabled !== false,
+            host: vmcConfig.host || '127.0.0.1',
+            port: vmcConfig.port || 39539
+        });
+
+        // 5. 情绪/表情映射器
+        const emotionMapper = createVRMEmotionMapper(model, expressionMap);
+        global.currentCharacterName = getCharacterName(modelPath);
+        global.emotionMapper = emotionMapper;
+        global.currentVRMAdapter = model;   // 供 HTTP API 访问 VMC
+
+        const expressionMapper = createVRMExpressionMapper(model, expressionMap);
+        global.expressionMapper = expressionMapper;
+
+        if (ttsEnabled && ttsProcessor?.setEmotionMapper) {
+            ttsProcessor.setEmotionMapper(emotionMapper);
+        }
+        if (ttsEnabled && ttsProcessor?.setExpressionMapper) {
+            ttsProcessor.setExpressionMapper(expressionMapper);
+        }
+
+        // 6. 音乐播放器
+        if (!_musicPlayer) {
+            _musicPlayer = new MusicPlayer(_controller);
+        }
+        _musicPlayer.setEmotionMapper(emotionMapper);
+        global.musicPlayer = _musicPlayer;
+
+        // 7. 语音链路
+        bindVoiceChatAvatar(voiceChat, model, emotionMapper);
+
+        // 8. 渲染循环
+        _manager.startLoop();
+        logToTerminal('info', `[VRMSetup] VRM 形态就绪: ${modelPath}`);
+
+        // app 代理（兼容周边对 global.pixiApp 的弱引用；仅提供必要字段）
+        const appProxy = {
+            renderer: { view: _manager.canvas },
+            _isVRMProxy: true,
+            _renderer: _manager.renderer,
+            _scene: _manager.scene,
+            _camera: _manager.camera
+        };
+
+        return { app: appProxy, model, emotionMapper, expressionMapper, musicPlayer: _musicPlayer, vrmController: _controller, manager: _manager };
+    }
+
+    // 形态切走：挂起而非销毁（保留 WebGL 上下文）
+    static async suspend() {
+        try { _controller?.destroy?.(); } catch (_) {}
+        try { await _manager?.suspend?.(); } catch (_) {}
+        logToTerminal('info', '[VRMSetup] 已挂起');
+    }
+}
+
+module.exports = { VRMSetup };

--- a/live-2d/js/core/config-loader.js
+++ b/live-2d/js/core/config-loader.js
@@ -5,7 +5,9 @@ const os = require('os');
 class ConfigLoader {
     constructor() {
         this.config = null;
-        this.configPath = path.join(__dirname, '..', '..', 'config.json');
+        this.configPath = process.env.MY_NEURO_CONFIG_PATH
+            ? path.resolve(process.env.MY_NEURO_CONFIG_PATH)
+            : path.join(__dirname, '..', '..', 'config.json');
         this.defaultConfigPath = path.join(__dirname, '..', '..', 'default_config.json');
     }
 

--- a/live-2d/js/services/electron-screen-bridge.js
+++ b/live-2d/js/services/electron-screen-bridge.js
@@ -43,7 +43,8 @@ ipcRenderer.on('display-changed', (event, info) => {
             const h = window.innerHeight;
             window.actualWindowWidth = w;
             window.actualWindowHeight = h;
-            const canvas = document.getElementById('canvas');
+            const canvas = global.avatarFacade?.getActiveCanvas?.()
+                || document.getElementById('canvas');
             if (canvas) {
                 canvas.style.width = w + 'px';
                 canvas.style.height = h + 'px';

--- a/live-2d/js/ui/ui-controller.js
+++ b/live-2d/js/ui/ui-controller.js
@@ -48,9 +48,17 @@ class UIController {
                 if (el && el.closest && el.closest(INTERACTIVE_UI)) overUI = true;
             }
 
-            const overModel = global.currentModel.containsPoint(
-                global.pixiApp.renderer.plugins.interaction.mouse.global
-            );
+            const facade = global.avatarFacade || window.avatar;
+            const controller = facade?.getController?.() || global.modelController;
+            const model = facade?.getModel?.() || global.currentModel;
+            let overModel = false;
+            if (controller && typeof controller.isPointOverInteractive === 'function') {
+                overModel = controller.isPointOverInteractive(e.clientX, e.clientY);
+            } else if (model && typeof model.containsPoint === 'function') {
+                try {
+                    overModel = !!model.containsPoint({ x: e.clientX, y: e.clientY });
+                } catch (_) {}
+            }
 
             ipcRenderer.send('set-ignore-mouse-events', {
                 ignore: !overModel && !overUI,
@@ -216,32 +224,47 @@ class UIController {
         }
     }
 
+    _getActiveAvatarState() {
+        const facade = global.avatarFacade || window.avatar;
+        return {
+            type: facade?.getActiveType?.() || global.currentModel?.modelType || 'live2d',
+            model: facade?.getModel?.() || global.currentModel,
+            canvas: facade?.getActiveCanvas?.() || document.getElementById('canvas')
+        };
+    }
+
+    _getModelScreenPosition() {
+        const { type, model, canvas } = this._getActiveAvatarState();
+        if (!model || typeof model.toGlobal !== 'function') return null;
+
+        const point = model.toGlobal({ x: 0, y: 0 });
+        const modelX = Number(point?.x);
+        const modelY = Number(point?.y);
+        if (!Number.isFinite(modelX) || !Number.isFinite(modelY)) return null;
+
+        if (type === 'live2d' && canvas) {
+            const canvasRect = canvas.getBoundingClientRect();
+            const canvasWidth = Number(canvas.width) || canvasRect.width || 1;
+            const canvasHeight = Number(canvas.height) || canvasRect.height || 1;
+            return {
+                x: canvasRect.left + modelX * (canvasRect.width / canvasWidth),
+                y: canvasRect.top + modelY * (canvasRect.height / canvasHeight)
+            };
+        }
+
+        return { x: modelX, y: modelY };
+    }
+
     // 更新气泡框位置，使其跟随模型
     updateBubblePosition() {
         const bubbleContainer = document.getElementById('bubble-container');
         const toolBubblesContainer = document.getElementById('tool-bubbles-container');
 
         try {
-            // 检查模型和PIXI应用是否存在
-            if (!global.currentModel || !global.pixiApp) {
-                return;
-            }
-
-            // 获取canvas元素的屏幕位置和尺寸
-            const canvas = document.getElementById('canvas');
-            const canvasRect = canvas.getBoundingClientRect();
-
-            // 使用 toGlobal 方法将模型的本地坐标转换为全局坐标
-            const modelLocalPos = { x: 0, y: 0 };
-            const modelGlobalPos = global.currentModel.toGlobal(modelLocalPos);
-
-            // PIXI Canvas 的内部尺寸和显示尺寸的缩放比例
-            const scaleX = canvasRect.width / canvas.width;
-            const scaleY = canvasRect.height / canvas.height;
-
-            // 将 PIXI 内部坐标转换为屏幕坐标
-            const screenX = canvasRect.left + modelGlobalPos.x * scaleX;
-            const screenY = canvasRect.top + modelGlobalPos.y * scaleY;
+            const position = this._getModelScreenPosition();
+            if (!position) return;
+            const screenX = position.x;
+            const screenY = position.y;
 
             // 检查值是否有效
             if (screenX === undefined || screenY === undefined || isNaN(screenX) || isNaN(screenY)) {

--- a/live-2d/main.js
+++ b/live-2d/main.js
@@ -2,14 +2,38 @@ const { app, BrowserWindow, ipcMain, screen, globalShortcut, desktopCapturer, di
 const path = require('path')
 const fs = require('fs')
 const { HttpServer } = require('./js/services/http-server')
-const { ModelPathUpdater } = require('./js/model/model-path-updater')
+const {
+    scanLive2DModels,
+    resolveLive2DModel,
+    scanVRMModels
+} = require('./js/avatar/model-registry')
+const { saveModelPrefs } = require('./js/avatar/preferences-store')
+const {
+    AvatarSwitchTransaction,
+    normalizeAvatarType
+} = require('./js/avatar/avatar-switch-transaction')
 const { ShortcutManager } = require('./js/shortcut-manager')
 const screenshot = require('screenshot-desktop');
 const { logToTerminal } = require('./js/api-utils');
 
-// 添加配置文件路径
-const configPath = path.join(app.getAppPath(), 'config.json');
+// 添加配置文件路径；隔离测试可通过环境变量指向临时副本。
+const configPath = process.env.MY_NEURO_CONFIG_PATH
+    ? path.resolve(process.env.MY_NEURO_CONFIG_PATH)
+    : path.join(app.getAppPath(), 'config.json');
 let shortcutManager = null;
+let rendererRequestCounter = 0;
+const pendingRendererRequests = new Map();
+let avatarSwitchTransaction = null;
+const SUPPORTED_AVATAR_TYPES = new Set(['live2d', 'vrm']);
+const AVATAR_RESULT_PHASES = new Set([
+    'ready',
+    'busy',
+    'failed',
+    'rolled-back',
+    'reload-required',
+    'reload-scheduled',
+    'rollback-reload-scheduled'
+]);
 
 function loadConfigData() {
     return JSON.parse(fs.readFileSync(configPath, 'utf8'));
@@ -19,38 +43,220 @@ function saveConfigData(configData) {
     fs.writeFileSync(configPath, JSON.stringify(configData, null, 2), 'utf8');
 }
 
-function setLive2DConfig(modelName) {
+function updateUiConfig(patch) {
     const configData = loadConfigData();
     if (!configData.ui) configData.ui = {};
-    configData.ui.model_type = 'live2d';
-    configData.ui.vrm_model = '';
-    configData.ui.vrm_model_path = '';
-    if (modelName) {
-        configData.ui.live2d_model = modelName;
+    Object.assign(configData.ui, patch);
+    saveConfigData(configData);
+    return configData;
+}
+
+function nextRendererRequestId(prefix) {
+    rendererRequestCounter += 1;
+    return `${prefix}-${Date.now()}-${rendererRequestCounter}`;
+}
+
+function waitForRendererRequest(requestId, senderId, timeoutMs = 30000) {
+    return new Promise((resolve) => {
+        const timer = setTimeout(() => {
+            pendingRendererRequests.delete(requestId);
+            resolve({
+                success: false,
+                phase: 'failed',
+                timedOut: true,
+                reloadRequired: true,
+                message: `渲染进程未在 ${timeoutMs}ms 内确认操作`
+            });
+        }, timeoutMs);
+        pendingRendererRequests.set(requestId, { resolve, timer, senderId });
+    });
+}
+
+function cancelRendererRequest(requestId) {
+    const pending = pendingRendererRequests.get(requestId);
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    pendingRendererRequests.delete(requestId);
+    pending.resolve({
+        success: false,
+        phase: 'failed',
+        message: '渲染请求已取消'
+    });
+}
+
+function completeRendererRequest(event, payload) {
+    const requestId = String(payload?.requestId || '');
+    const pending = pendingRendererRequests.get(requestId);
+    if (!pending) {
+        return { success: false, message: '找不到待确认的渲染请求' };
     }
+    if (pending.senderId != null && event.sender?.id !== pending.senderId) {
+        return { success: false, message: '渲染请求来源不匹配' };
+    }
+
+    clearTimeout(pending.timer);
+    pendingRendererRequests.delete(requestId);
+    pending.resolve({
+        success: payload?.success === true,
+        phase: AVATAR_RESULT_PHASES.has(payload?.phase) ? payload.phase : undefined,
+        message: typeof payload?.message === 'string'
+            ? payload.message
+            : (payload?.success === true ? '操作成功' : '操作失败'),
+        restored: payload?.restored === true,
+        reloadRequired: payload?.reloadRequired === true,
+        timedOut: payload?.timedOut === true,
+        targetType: normalizeAvatarType(payload?.targetType),
+        activeType: Object.prototype.hasOwnProperty.call(payload || {}, 'activeType')
+            ? normalizeAvatarType(payload.activeType)
+            : undefined
+    });
+    return { success: true };
+}
+
+function getRendererWindow(event) {
+    const sender = event?.sender;
+    if (!sender || sender.isDestroyed?.()) {
+        throw new Error('渲染窗口不可用');
+    }
+    const win = BrowserWindow.fromWebContents(sender);
+    if (!win || win.isDestroyed() || win.webContents.isDestroyed()) {
+        throw new Error('渲染窗口不可用');
+    }
+    return win;
+}
+
+async function requestRendererConfirmation(event, channel, payload, prefix, timeoutMs = 30000) {
+    const requestId = nextRendererRequestId(prefix);
+    const pending = waitForRendererRequest(requestId, event?.sender?.id, timeoutMs);
+    try {
+        const win = getRendererWindow(event);
+        win.webContents.send(channel, { ...payload, requestId });
+        return await pending;
+    } catch (error) {
+        cancelRendererRequest(requestId);
+        throw error;
+    } finally {
+        cancelRendererRequest(requestId);
+    }
+}
+
+function sendUiConfigPatch(win, patch) {
+    if (!win || win.isDestroyed() || win.webContents.isDestroyed()) return;
+    win.webContents.send('avatar-config-updated', { ui: patch });
+}
+
+function scheduleWindowReload(win, reason) {
+    if (!win || win.isDestroyed() || win.webContents.isDestroyed()) {
+        throw new Error('渲染窗口不可用，无法安排重载');
+    }
+    setImmediate(() => {
+        if (!win || win.isDestroyed() || win.webContents.isDestroyed()) return;
+        console.log(`[Avatar] 安排窗口重载: ${reason || '状态同步'}`);
+        win.webContents.reload();
+    });
+}
+
+function resolveAvatarModelSelection(type, requestedName) {
+    const scanners = {
+        live2d: scanLive2DModels,
+        vrm: scanVRMModels
+    };
+    const scan = scanners[type];
+    const all = scan ? scan() : [];
+    const requested = String(requestedName || '').trim();
+    const entry = all.find(model => model.modelPath === requested)
+        || all.find(model => model.name === requested)
+        || (type === 'vrm'
+            ? all.find(model => path.basename(model.modelPath) === requested)
+            : null);
+
+    return {
+        entry: entry || null,
+        all,
+        configValue: entry
+            ? (type === 'vrm' ? entry.modelPath : entry.name)
+            : null
+    };
+}
+
+function avatarModelCount(type) {
+    if (!SUPPORTED_AVATAR_TYPES.has(type)) return 0;
+    if (type === 'live2d') return scanLive2DModels().length;
+    if (type === 'vrm') return scanVRMModels().length;
+    return 0;
+}
+
+function hasAvatarModel(type) {
+    return avatarModelCount(type) > 0;
+}
+
+function normalizeConfiguredAvatarType(configData) {
+    if (!configData || typeof configData !== 'object') return null;
+    if (!configData.ui || typeof configData.ui !== 'object') configData.ui = {};
+
+    const requested = normalizeAvatarType(configData.ui.model_type) || 'live2d';
+    const usable = SUPPORTED_AVATAR_TYPES.has(requested) && hasAvatarModel(requested)
+        ? requested
+        : ['live2d', 'vrm'].find(hasAvatarModel);
+    if (!usable || usable === requested) return usable;
+
+    configData.ui.model_type = usable;
     saveConfigData(configData);
+    console.warn(`[Avatar] ${requested} 当前没有可用 driver 或模型，已回退到 ${usable}`);
+    return usable;
 }
 
-function setVRMConfig(vrmFileName) {
-    const configData = loadConfigData();
-    if (!configData.ui) configData.ui = {};
-    configData.ui.model_type = 'vrm';
-    configData.ui.vrm_model = vrmFileName;
-    configData.ui.vrm_model_path = `3D/${vrmFileName}`;
-    saveConfigData(configData);
+function getAvatarSwitchTransaction() {
+    if (avatarSwitchTransaction) return avatarSwitchTransaction;
+    avatarSwitchTransaction = new AvatarSwitchTransaction({
+        readModelType() {
+            return loadConfigData().ui?.model_type || 'live2d';
+        },
+        updateModelType(type) {
+            updateUiConfig({ model_type: type });
+        },
+        hasAvatarModel(type) {
+            return hasAvatarModel(type);
+        },
+        requestRendererSwitch(type, context) {
+            return requestRendererConfirmation(
+                context.event,
+                'avatar-switch-type',
+                { type },
+                'avatar-type-switch'
+            );
+        },
+        publishModelType(type, context) {
+            sendUiConfigPatch(context.win, { model_type: type });
+        },
+        scheduleReload({ context, reason }) {
+            scheduleWindowReload(context.win, reason);
+        },
+        log(level, message) {
+            console[level === 'error' ? 'error' : 'log'](`[Avatar] ${message}`);
+        }
+    });
+    return avatarSwitchTransaction;
 }
 
-function reloadSenderWindow(event) {
-    const win = BrowserWindow.fromWebContents(event.sender);
-    if (win) win.reload();
+function finalizeRendererFailure(win, result, reason) {
+    if (result?.success !== true && result?.reloadRequired === true) {
+        try {
+            scheduleWindowReload(win, reason || result.message);
+            return {
+                ...result,
+                phase: 'reload-scheduled'
+            };
+        } catch (error) {
+            return {
+                ...result,
+                phase: 'failed',
+                message: `${result.message || '渲染操作失败'}；安排恢复重载失败: ${error.message}`
+            };
+        }
+    }
+    return result;
 }
-
-function serializePriorityFolders(folders) {
-    return `[${folders.map(folder => JSON.stringify(folder)).join(', ')}]`;
-}
-
-// Live2D模型优先级配置（Python程序会修改这个列表来切换模型）
-const priorityFolders = ['肥牛', 'Hiyouri', 'Default', 'Main'];
 
 
 function ensureTopMost(win) {
@@ -228,6 +434,9 @@ function createWindow () {
     win.on('blur', () => {
         ensureTopMost(win)
     })
+    win.on('closed', () => {
+        avatarSwitchTransaction?.clearWindow(win.id);
+    })
     setInterval(() => {
         ensureTopMost(win)
     }, 1000)
@@ -248,13 +457,7 @@ app.whenReady().then(() => {
         console.log('读取配置失败，使用默认Live2D模式');
     }
 
-    // 仅在Live2D模式下更新模型路径
-    if (modelType === 'live2d') {
-        const modelPathUpdater = new ModelPathUpdater(app.getAppPath(), priorityFolders);
-        modelPathUpdater.update();
-    } else {
-        console.log('VRM模式，跳过Live2D模型路径更新');
-    }
+    normalizeConfiguredAvatarType(configData);
 
     const mainWindow = createWindow();
 
@@ -278,6 +481,8 @@ app.on('window-all-closed', () => {
 })
 
 app.on('will-quit', () => {
+    avatarSwitchTransaction?.dispose();
+    avatarSwitchTransaction = null;
     if (shortcutManager) {
         shortcutManager.unregisterAll();
         shortcutManager = null;
@@ -427,80 +632,121 @@ ipcMain.handle('siliconflow-asr-transcribe', async (event, audioBytes) => {
     }
 })
 
-// 添加IPC处理器，允许从渲染进程手动更新模型
+// 列出已扫描到的 Live2D 模型（供 WebUI、快捷面板和兼容接口使用）。
+ipcMain.handle('get-live2d-models', async () => {
+    try {
+        return { success: true, models: scanLive2DModels() };
+    } catch (error) {
+        return { success: false, message: error.message, models: [] };
+    }
+});
+
+// 渲染进程完成热切换后，通过 requestId 确认主进程正在等待的请求。
+ipcMain.handle('live2d-switch-model-result', (event, payload) => {
+    return completeRendererRequest(event, payload);
+});
+
+ipcMain.handle('avatar-switch-type-result', (event, payload) => {
+    return completeRendererRequest(event, payload);
+});
+
+ipcMain.handle('avatar-reload-model-result', (event, payload) => {
+    return completeRendererRequest(event, payload);
+});
+
+// 每次窗口启动并完成 Avatar 初始化后回报 ready，用于结束跨渲染引擎切换事务。
+ipcMain.handle('avatar-runtime-ready', async (event, payload) => {
+    try {
+        const win = getRendererWindow(event);
+        const result = await getAvatarSwitchTransaction().handleRuntimeReady({
+            windowId: win.id,
+            success: payload?.success === true,
+            activeType: payload?.activeType,
+            message: typeof payload?.message === 'string' ? payload.message : ''
+        });
+        console.log(
+            `[Avatar] runtime ready: phase=${result.phase}, active=${result.activeType || 'none'}`
+        );
+        return result;
+    } catch (error) {
+        console.error('处理 Avatar runtime ready 失败:', error);
+        return { success: false, phase: 'failed', message: error.message };
+    }
+});
+
+// 重新扫描并热重载当前 Live2D 模型（保留旧接口名，不再改写源码、不再直接 reload 窗口）。
 ipcMain.handle('update-live2d-model', async (event) => {
     try {
-        // 调用更新模型的函数
-        const modelPathUpdater = new ModelPathUpdater(app.getAppPath(), priorityFolders);
-        modelPathUpdater.update();
+        let preferred = null;
+        try {
+            preferred = loadConfigData().ui?.live2d_model || null;
+        } catch (_) {}
 
-        // 通知渲染进程需要重新加载以应用新模型
-        const win = BrowserWindow.fromWebContents(event.sender)
-        win.reload()
+        const { modelPath, entry, all } = resolveLive2DModel(preferred);
+        if (!modelPath || !entry) {
+            return { success: false, message: '2D 目录下没有找到任何模型' };
+        }
 
-        return { success: true, message: '模型已更新，页面将重新加载' }
+        const win = getRendererWindow(event);
+        const result = await requestRendererConfirmation(
+            event,
+            'live2d-switch-model',
+            { modelName: entry.name, modelPath },
+            'live2d-refresh'
+        );
+        if (!result.success) {
+            return finalizeRendererFailure(win, result, 'Live2D 模型恢复需要窗口重载');
+        }
+        return {
+            success: true,
+            phase: 'ready',
+            targetType: 'live2d',
+            activeType: 'live2d',
+            message: `已重新扫描（共 ${all.length} 个模型），已加载 ${entry.name}`
+        };
     } catch (error) {
-        console.error('手动更新模型时出错:', error)
-        return { success: false, message: `更新失败: ${error.message}` }
+        console.error('手动更新模型时出错:', error);
+        return { success: false, message: `更新失败: ${error.message}` };
     }
-})
+});
 
-// 添加切换Live2D模型的IPC处理器
+// 切换 Live2D 模型：先让渲染进程成功加载，再持久化选择。
 ipcMain.handle('switch-live2d-model', async (event, modelName) => {
     try {
         console.log(`切换模型到: ${modelName}`);
-
-        setLive2DConfig(modelName);
-
-        // 更新priorityFolders，将选中的模型放在第一位
-        const index = priorityFolders.indexOf(modelName);
-        if (index > 0) {
-            // 如果模型已存在，移到第一位
-            priorityFolders.splice(index, 1);
-            priorityFolders.unshift(modelName);
-        } else if (index === -1) {
-            // 如果模型不在列表中，添加到第一位
-            priorityFolders.unshift(modelName);
-        }
-        // 如果已经在第一位(index === 0)，不需要操作
-
-        console.log(`更新后的优先级列表: ${priorityFolders.join(', ')}`);
-
-        // 保存priorityFolders到main.js文件
-        try {
-            const mainJsPath = path.join(app.getAppPath(), 'main.js');
-            let mainJsContent = fs.readFileSync(mainJsPath, 'utf8');
-
-            // 构建新的priorityFolders数组字符串
-            const newPriorityString = serializePriorityFolders(priorityFolders);
-
-            // 替换main.js中的priorityFolders定义
-            mainJsContent = mainJsContent.replace(
-                /const priorityFolders = \[.*?\];/,
-                `const priorityFolders = ${newPriorityString};`
-            );
-
-            // 写回文件
-            fs.writeFileSync(mainJsPath, mainJsContent, 'utf8');
-            console.log('已保存模型优先级到main.js');
-        } catch (saveError) {
-            console.error('保存优先级到main.js失败:', saveError);
-            // 不影响继续执行
+        const { entry, all } = resolveAvatarModelSelection('live2d', modelName);
+        if (!entry) {
+            return {
+                success: false,
+                message: `未找到模型 "${modelName}"（2D 目录下共 ${all.length} 个模型）`
+            };
         }
 
-        // 调用更新模型的函数
-        const modelPathUpdater = new ModelPathUpdater(app.getAppPath(), priorityFolders);
-        modelPathUpdater.update();
+        const win = getRendererWindow(event);
+        const result = await requestRendererConfirmation(
+            event,
+            'live2d-switch-model',
+            { modelName: entry.name, modelPath: entry.modelPath },
+            'live2d-switch'
+        );
+        if (!result.success) {
+            return finalizeRendererFailure(win, result, 'Live2D 模型恢复需要窗口重载');
+        }
 
-        // 通知渲染进程需要重新加载以应用新模型
-        reloadSenderWindow(event)
-
-        return { success: true, message: `模型已切换到 ${modelName}，页面将重新加载` }
+        updateUiConfig({ live2d_model: entry.name });
+        sendUiConfigPatch(win, { live2d_model: entry.name });
+        return {
+            success: true,
+            phase: 'ready',
+            targetType: 'live2d',
+            activeType: 'live2d',
+            message: `模型已切换到 ${entry.name}`
+        };
     } catch (error) {
-        console.error('切换模型时出错:', error)
-        return { success: false, message: `切换失败: ${error.message}` }
+        console.error('切换模型时出错:', error);
+        return { success: false, message: `切换失败: ${error.message}` };
     }
-})
+});
 
 
 // 添加获取窗口实际尺寸的IPC处理器
@@ -641,6 +887,7 @@ ipcMain.handle('move-window-to-display', async (event, screenX, screenY) => {
 // 添加保存模型位置的IPC处理器
 ipcMain.on('save-model-position', (event, position) => {
     try {
+        const nextPosition = position && typeof position === 'object' ? position : {};
         // 读取当前配置
         const configData = JSON.parse(fs.readFileSync(configPath, 'utf8'));
 
@@ -657,9 +904,9 @@ ipcMain.on('save-model-position', (event, position) => {
         }
 
         // 跨屏方案：位置按“当前显示器内的相对位置（0~1）”保存，不再区分单/双屏 x_dual/y_dual。
-        configData.ui.model_position.x = position.x;
-        configData.ui.model_position.y = position.y;
-        configData.ui.model_scale = position.scale;
+        configData.ui.model_position.x = nextPosition.x;
+        configData.ui.model_position.y = nextPosition.y;
+        configData.ui.model_scale = nextPosition.scale;
 
         // 记录当前窗口所在显示器的屏幕原点，供下次启动把窗口落回同一块屏（findStartupDisplay 使用）。
         const win = BrowserWindow.fromWebContents(event.sender);
@@ -673,25 +920,214 @@ ipcMain.on('save-model-position', (event, position) => {
         // 保存到文件
         fs.writeFileSync(configPath, JSON.stringify(configData, null, 2), 'utf8');
 
+        // v2：如果渲染端提供模型名，同时保存该模型自己的位置/缩放偏好。
+        if (nextPosition.modelName) {
+            saveModelPrefs('live2d', nextPosition.modelName, {
+                position: {
+                    x: nextPosition.x,
+                    y: nextPosition.y
+                },
+                scale: nextPosition.scale
+            });
+        }
+
     } catch (error) {
         console.error('保存模型位置失败:', error);
     }
-})
+});
 
-// 切换到VRM模型的IPC处理器
+// 形态切换：主进程负责配置提交、渲染侧确认、窗口重载和失败回滚。
+ipcMain.handle('avatar:switch-type', async (event, type) => {
+    try {
+        const win = getRendererWindow(event);
+        return await getAvatarSwitchTransaction().switchType(type, {
+            event,
+            win,
+            windowId: win.id
+        });
+    } catch (error) {
+        console.error('形态切换失败:', error);
+        return { success: false, phase: 'failed', message: `形态切换失败: ${error.message}` };
+    }
+});
+
+// 设置指定形态的模型：先确认当前渲染侧已应用，再持久化选择。
+ipcMain.handle('avatar:set-model', async (event, payload) => {
+    try {
+        const type = String(payload?.type || '').trim().toLowerCase();
+        if (!SUPPORTED_AVATAR_TYPES.has(type)) {
+            return { success: false, message: `当前 PR 未接入形态: ${type || '未指定'}` };
+        }
+
+        const requestedName = String(payload?.model_name || payload?.name || '');
+        if (!requestedName.trim()) {
+            return { success: false, message: '未提供模型' };
+        }
+
+        const selection = resolveAvatarModelSelection(type, requestedName);
+        if (!selection.entry) {
+            return {
+                success: false,
+                message: `未找到 ${type} 模型 "${requestedName}"（当前共 ${selection.all.length} 个）`
+            };
+        }
+
+        const configPatch = type === 'vrm'
+            ? {
+                vrm_model: selection.entry.name,
+                vrm_model_path: selection.entry.modelPath
+            }
+            : { live2d_model: selection.entry.name };
+        const configData = loadConfigData();
+        const activeType = normalizeAvatarType(configData.ui?.model_type) || 'live2d';
+        const win = getRendererWindow(event);
+
+        if (activeType === type) {
+            let result;
+            if (type === 'live2d') {
+                result = await requestRendererConfirmation(
+                    event,
+                    'live2d-switch-model',
+                    {
+                        modelName: selection.entry.name,
+                        modelPath: selection.entry.modelPath
+                    },
+                    'live2d-set-model'
+                );
+            } else {
+                result = await requestRendererConfirmation(
+                    event,
+                    'avatar-reload-model',
+                    {
+                        type,
+                        configKey: 'vrm_model_path',
+                        configValue: selection.entry.modelPath
+                    },
+                    'avatar-reload-model'
+                );
+            }
+            if (!result.success) {
+                return finalizeRendererFailure(
+                    win,
+                    result,
+                    `${type} 模型恢复需要窗口重载`
+                );
+            }
+        }
+
+        updateUiConfig(configPatch);
+        sendUiConfigPatch(win, configPatch);
+        if (activeType === type) {
+            return {
+                success: true,
+                phase: 'ready',
+                targetType: type,
+                activeType: type,
+                message: `已应用模型：${selection.entry.name}`
+            };
+        }
+        return {
+            success: true,
+            phase: 'ready',
+            targetType: type,
+            activeType,
+            message: `已保存模型选择：${selection.entry.name}（切换到 ${type} 形态时生效）`
+        };
+    } catch (error) {
+        console.error('设置形态模型失败:', error);
+        return { success: false, message: `设置失败: ${error.message}` };
+    }
+});
+
+// 形态模型列表：本 PR 只暴露已经接入的 Live2D 和 VRM。
+ipcMain.handle('avatar:get-models', async (event, type) => {
+    try {
+        const normalized = String(type || 'live2d').trim().toLowerCase();
+        const scanners = {
+            live2d: scanLive2DModels,
+            vrm: scanVRMModels
+        };
+        const scan = scanners[normalized];
+        if (!scan) {
+            return {
+                success: false,
+                message: `当前 PR 未接入形态: ${type}`,
+                models: []
+            };
+        }
+        return { success: true, models: scan() };
+    } catch (error) {
+        return { success: false, message: error.message, models: [] };
+    }
+});
+
+// 切换到 VRM 模型：保留旧 IPC 名称，同时接入统一切换事务。
 ipcMain.handle('switch-vrm-model', async (event, vrmFileName) => {
     try {
         console.log(`切换VRM模型到: ${vrmFileName}`);
 
-        // 更新config.json
-        setVRMConfig(vrmFileName);
+        const selection = resolveAvatarModelSelection('vrm', vrmFileName);
+        if (!selection.entry) {
+            return {
+                success: false,
+                message: `未找到 VRM 模型 "${vrmFileName}"（当前共 ${selection.all.length} 个）`
+            };
+        }
 
-        // 重新加载窗口
-        reloadSenderWindow(event);
+        const configData = loadConfigData();
+        const activeType = normalizeAvatarType(configData.ui?.model_type) || 'live2d';
+        const win = getRendererWindow(event);
+        const modelPatch = {
+            vrm_model: selection.entry.name,
+            vrm_model_path: selection.entry.modelPath
+        };
 
-        return { success: true, message: `VRM模型已切换到 ${vrmFileName}，页面将重新加载` };
+        if (activeType === 'vrm') {
+            const reloadResult = await requestRendererConfirmation(
+                event,
+                'avatar-reload-model',
+                {
+                    type: 'vrm',
+                    configKey: 'vrm_model_path',
+                    configValue: selection.entry.modelPath
+                },
+                'legacy-vrm-reload'
+            );
+            if (!reloadResult.success) {
+                return finalizeRendererFailure(
+                    win,
+                    reloadResult,
+                    'VRM 模型恢复需要窗口重载'
+                );
+            }
+            updateUiConfig(modelPatch);
+            sendUiConfigPatch(win, modelPatch);
+            return {
+                success: true,
+                phase: 'ready',
+                targetType: 'vrm',
+                activeType: 'vrm',
+                message: `VRM 模型已切换到 ${selection.entry.name}`
+            };
+        }
+
+        // 先保存 VRM 选择，但不提前改 model_type，让事务仍能读取真实旧形态。
+        updateUiConfig(modelPatch);
+        sendUiConfigPatch(win, modelPatch);
+        const switchResult = await getAvatarSwitchTransaction().switchType('vrm', {
+            event,
+            win,
+            windowId: win.id
+        });
+
+        return {
+            ...switchResult,
+            message: switchResult.success
+                ? `${switchResult.message}；VRM 模型：${selection.entry.name}`
+                : switchResult.message
+        };
     } catch (error) {
         console.error('切换VRM模型时出错:', error);
         return { success: false, message: `切换失败: ${error.message}` };
     }
-})
+});

--- a/live-2d/package.json
+++ b/live-2d/package.json
@@ -5,7 +5,9 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "start-server": "node server.js"
+    "start-server": "node server.js",
+    "test:avatar:switch": "node scripts/test-avatar-switch-transaction.js",
+    "test:avatar:voice": "node scripts/test-avatar-voice-chat-binding.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.18.1",

--- a/live-2d/scripts/test-avatar-switch-transaction.js
+++ b/live-2d/scripts/test-avatar-switch-transaction.js
@@ -1,0 +1,294 @@
+'use strict';
+
+const assert = require('assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { AvatarSwitchTransaction } = require('../js/avatar/avatar-switch-transaction.js');
+const {
+    PROFILE_FILE_NAME,
+    loadExpressionProfile
+} = require('../js/avatar/live2d/expression/expression-units.js');
+
+function createHarness(options = {}) {
+    const config = {
+        ui: {
+            model_type: options.initialType || 'live2d',
+            unrelated: 'keep'
+        }
+    };
+    const events = [];
+    const rendererResults = [...(options.rendererResults || [])];
+    const scheduled = [];
+    const published = [];
+    const manager = new AvatarSwitchTransaction({
+        readyTimeoutMs: options.readyTimeoutMs || 30000,
+        readModelType() {
+            events.push('read');
+            return config.ui.model_type;
+        },
+        updateModelType(type) {
+            events.push(`write:${type}`);
+            if (options.failWrites?.includes(type)) throw new Error(`write ${type} failed`);
+            config.ui.model_type = type;
+        },
+        hasAvatarModel(type) {
+            events.push(`model:${type}`);
+            return !(options.missingModels || []).includes(type);
+        },
+        async requestRendererSwitch(type) {
+            events.push(`renderer:${type}`);
+            if (options.rendererError) throw new Error(options.rendererError);
+            if (options.rendererPromise) return options.rendererPromise;
+            return rendererResults.shift() || {
+                success: true,
+                phase: 'ready',
+                activeType: type
+            };
+        },
+        publishModelType(type) {
+            events.push(`publish:${type}`);
+            published.push(type);
+        },
+        scheduleReload(payload) {
+            events.push(`reload:${payload.expectedType}`);
+            if (options.reloadError) throw new Error(options.reloadError);
+            scheduled.push(payload);
+        },
+        log() {}
+    });
+    return { config, events, manager, published, scheduled };
+}
+
+const context = { windowId: 7 };
+
+(async () => {
+    {
+        const harness = createHarness();
+        const result = await harness.manager.switchType('invalid', context);
+        assert.equal(result.success, false);
+        assert.equal(harness.events.length, 0);
+    }
+
+    {
+        const harness = createHarness({ missingModels: ['vrm'] });
+        const result = await harness.manager.switchType('vrm', context);
+        assert.equal(result.success, false);
+        assert.deepEqual(harness.events, ['model:vrm']);
+    }
+
+    {
+        const harness = createHarness();
+        const result = await harness.manager.switchType('live2d', context);
+        assert.equal(result.phase, 'ready');
+        assert.deepEqual(harness.events, ['model:live2d', 'read']);
+    }
+
+    {
+        const harness = createHarness();
+        const result = await harness.manager.switchType('pngtuber', context);
+        assert.equal(result.success, true);
+        assert.equal(result.phase, 'ready');
+        assert.equal(harness.config.ui.model_type, 'pngtuber');
+        assert.equal(harness.config.ui.unrelated, 'keep');
+        assert.deepEqual(harness.events, [
+            'model:pngtuber',
+            'read',
+            'write:pngtuber',
+            'renderer:pngtuber',
+            'publish:pngtuber'
+        ]);
+    }
+
+    {
+        const harness = createHarness({
+            rendererResults: [{
+                success: true,
+                phase: 'reload-required',
+                reloadRequired: true,
+                activeType: 'live2d'
+            }]
+        });
+        const result = await harness.manager.switchType('vrm', context);
+        assert.equal(result.phase, 'reload-scheduled');
+        assert.equal(harness.config.ui.model_type, 'vrm');
+        assert.equal(harness.manager.hasPendingReload(context.windowId), true);
+        assert.equal(harness.scheduled[0].expectedType, 'vrm');
+
+        const ready = await harness.manager.handleRuntimeReady({
+            windowId: context.windowId,
+            success: true,
+            activeType: 'vrm'
+        });
+        assert.equal(ready.phase, 'ready');
+        assert.equal(harness.manager.hasPendingReload(context.windowId), false);
+    }
+
+    {
+        const harness = createHarness({
+            rendererResults: [{
+                success: false,
+                restored: true,
+                activeType: 'live2d',
+                message: 'init failed'
+            }]
+        });
+        const result = await harness.manager.switchType('mmd', context);
+        assert.equal(result.phase, 'rolled-back');
+        assert.equal(harness.config.ui.model_type, 'live2d');
+        assert.equal(harness.scheduled.length, 0);
+        assert.deepEqual(harness.published, ['live2d']);
+    }
+
+    {
+        const harness = createHarness({
+            rendererResults: [{
+                success: false,
+                restored: false,
+                reloadRequired: true,
+                message: 'restore failed'
+            }]
+        });
+        const result = await harness.manager.switchType('mmd', context);
+        assert.equal(result.phase, 'reload-scheduled');
+        assert.equal(harness.config.ui.model_type, 'live2d');
+        assert.equal(harness.scheduled[0].expectedType, 'live2d');
+
+        const ready = await harness.manager.handleRuntimeReady({
+            windowId: context.windowId,
+            success: true,
+            activeType: 'live2d'
+        });
+        assert.equal(ready.phase, 'ready');
+    }
+
+    {
+        const harness = createHarness({
+            rendererResults: [{
+                success: false,
+                restored: false,
+                timedOut: true,
+                message: 'timeout'
+            }]
+        });
+        const result = await harness.manager.switchType('vrm', context);
+        assert.equal(result.phase, 'reload-scheduled');
+        assert.equal(harness.config.ui.model_type, 'live2d');
+        assert.equal(harness.scheduled[0].expectedType, 'live2d');
+    }
+
+    {
+        const harness = createHarness({ failWrites: ['vrm'] });
+        const result = await harness.manager.switchType('vrm', context);
+        assert.equal(result.success, false);
+        assert.equal(harness.events.includes('renderer:vrm'), false);
+        assert.equal(harness.config.ui.model_type, 'live2d');
+    }
+
+    {
+        const harness = createHarness({ rendererError: 'send failed' });
+        const result = await harness.manager.switchType('vrm', context);
+        assert.equal(result.phase, 'rolled-back');
+        assert.equal(harness.config.ui.model_type, 'live2d');
+        assert.equal(harness.scheduled.length, 0);
+    }
+
+    {
+        const harness = createHarness({
+            rendererResults: [{
+                success: true,
+                reloadRequired: true,
+                activeType: 'live2d'
+            }],
+            reloadError: 'reload unavailable'
+        });
+        const result = await harness.manager.switchType('vrm', context);
+        assert.equal(result.phase, 'rolled-back');
+        assert.equal(harness.config.ui.model_type, 'live2d');
+    }
+
+    {
+        const harness = createHarness({
+            rendererResults: [{
+                success: true,
+                reloadRequired: true,
+                activeType: 'live2d'
+            }]
+        });
+        await harness.manager.switchType('vrm', context);
+        const mismatch = await harness.manager.handleRuntimeReady({
+            windowId: context.windowId,
+            success: true,
+            activeType: 'mmd'
+        });
+        assert.equal(mismatch.phase, 'rollback-reload-scheduled');
+        assert.equal(harness.config.ui.model_type, 'live2d');
+        assert.equal(harness.scheduled.length, 2);
+        assert.equal(harness.scheduled[1].expectedType, 'live2d');
+
+        const secondFailure = await harness.manager.handleRuntimeReady({
+            windowId: context.windowId,
+            success: false,
+            activeType: null,
+            message: 'rollback boot failed'
+        });
+        assert.equal(secondFailure.phase, 'failed');
+        assert.equal(harness.manager.hasPendingReload(context.windowId), false);
+    }
+
+    {
+        let resolveRenderer;
+        const rendererPromise = new Promise(resolve => {
+            resolveRenderer = resolve;
+        });
+        const harness = createHarness({ rendererPromise });
+        const first = harness.manager.switchType('vrm', context);
+        const second = await harness.manager.switchType('mmd', context);
+        assert.equal(second.phase, 'busy');
+        resolveRenderer({ success: true, activeType: 'vrm' });
+        assert.equal((await first).phase, 'ready');
+    }
+
+    {
+        const facadeSource = fs.readFileSync(
+            path.resolve(__dirname, '..', 'js/avatar/avatar-facade.js'),
+            'utf8'
+        );
+        assert.equal(
+            facadeSource.includes('window.location.reload'),
+            false,
+            'renderer facade must not reload the window directly'
+        );
+        assert.equal(
+            facadeSource.includes("ipcRenderer.invoke('avatar-runtime-ready'"),
+            true,
+            'renderer facade must report runtime readiness'
+        );
+        assert.equal(
+            facadeSource.includes("phase: 'reload-required'"),
+            true,
+            'renderer facade must distinguish reload-required from ready'
+        );
+    }
+
+    {
+        const modelDir = fs.mkdtempSync(path.join(os.tmpdir(), 'avatar-expression-profile-'));
+        try {
+            const loaded = loadExpressionProfile(modelDir, { info() {}, warn() {} });
+            assert.equal(loaded.seeded, false);
+            assert.equal(
+                fs.existsSync(path.join(modelDir, PROFILE_FILE_NAME)),
+                false,
+                'startup must not write a generated expression profile into the model directory'
+            );
+        } finally {
+            fs.rmSync(modelDir, { recursive: true, force: true });
+        }
+    }
+
+    console.log('avatar switch transaction tests passed');
+})().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/live-2d/scripts/test-avatar-voice-chat-binding.js
+++ b/live-2d/scripts/test-avatar-voice-chat-binding.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const assert = require('assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { bindVoiceChatAvatar } = require('../js/avatar/avatar-voice-chat-binding.js');
+
+assert.deepEqual(
+    bindVoiceChatAvatar(null, {}, {}),
+    { bound: false, reason: 'voice-chat-unavailable' }
+);
+assert.deepEqual(
+    bindVoiceChatAvatar(undefined, {}, {}),
+    { bound: false, reason: 'voice-chat-unavailable' }
+);
+
+{
+    const calls = [];
+    const voiceChat = {
+        setModel(model) {
+            calls.push(['model', model]);
+        },
+        setEmotionMapper(mapper) {
+            calls.push(['emotion', mapper]);
+        }
+    };
+    const model = { id: 'model-a' };
+    const mapper = { id: 'mapper-a' };
+
+    assert.deepEqual(bindVoiceChatAvatar(voiceChat, model, mapper), { bound: true });
+    assert.deepEqual(calls, [
+        ['model', model],
+        ['emotion', mapper]
+    ]);
+    assert.equal(typeof voiceChat.setEmotionMapper, 'function');
+}
+
+{
+    const models = [];
+    const mappers = [];
+    const voiceChat = {
+        setModel(model) {
+            models.push(model);
+        },
+        setEmotionMapper(mapper) {
+            mappers.push(mapper);
+        }
+    };
+    const firstModel = { id: 1 };
+    const secondModel = { id: 2 };
+    const firstMapper = { id: 1 };
+    const secondMapper = { id: 2 };
+
+    bindVoiceChatAvatar(voiceChat, firstModel, firstMapper);
+    bindVoiceChatAvatar(voiceChat, secondModel, secondMapper);
+
+    assert.deepEqual(models, [firstModel, secondModel]);
+    assert.deepEqual(mappers, [firstMapper, secondMapper]);
+    assert.equal(typeof voiceChat.setEmotionMapper, 'function');
+}
+
+assert.throws(
+    () => bindVoiceChatAvatar({ setEmotionMapper() {} }, {}, {}),
+    /setModel/
+);
+assert.throws(
+    () => bindVoiceChatAvatar({ setModel() {} }, {}, {}),
+    /setEmotionMapper/
+);
+
+{
+    const setupPaths = [
+        'js/avatar/live2d/setup.js',
+        'js/avatar/vrm/setup.js'
+    ];
+    for (const relativePath of setupPaths) {
+        const source = fs.readFileSync(path.resolve(__dirname, '..', relativePath), 'utf8');
+        assert.equal(
+            /voiceChat\.setEmotionMapper\s*=/.test(source),
+            false,
+            `${relativePath} must not overwrite setEmotionMapper`
+        );
+        assert.equal(
+            source.includes('bindVoiceChatAvatar('),
+            true,
+            `${relativePath} must use the shared binding helper`
+        );
+    }
+}
+
+console.log('avatar voice-chat binding tests passed');


### PR DESCRIPTION
## Summary

- Add a plugin-independent Avatar facade, driver registry, model registry, preference store, VoiceChat binding, and renderer-confirmed switch transaction.
- Migrate the Live2D runtime, including model loading, interaction, emotion/AU solving, micro motion, parameter direction, and lifecycle handling.
- Migrate the VRM runtime, including model management, interaction, expression mapping, and the shared Avatar contract.
- Replace source-file model path rewriting with runtime model discovery, validated switching, persistence only after renderer confirmation, and rollback/reload recovery.
- Wire the unified Avatar lifecycle into the existing Electron main/renderer entry points and UI behavior.

## Scope and exclusions

Included in this PR:

- Avatar core infrastructure
- Live2D support
- VRM support
- Electron IPC/lifecycle integration
- VoiceChat/TTS binding through the common Avatar interface
- Focused switch-transaction and VoiceChat-binding regression tests

Explicitly excluded:

- All files and behavior under `live-2d/plugins/**`
- Feiniu House / `auto-act`
- Head-pat, head-region, and pat-gesture behavior
- MMD and PNGTuber drivers
- Private models, textures, credentials, local configuration, logs, chat history, or runtime data

This PR does not change dependency versions. Live2D reuses the upstream PIXI 6 and `pixi-live2d-display` runtime instead of introducing a second global PIXI bundle.

## Verification

- `npm ci`
- `node --check` for all 30 files under `live-2d/js/avatar/**`
- `node --check` for the modified main/renderer entry points and both test scripts
- `npm run test:avatar:switch`
- `npm run test:avatar:voice`
- `git diff --check`
- Staged file allowlist audit: 42 files, 0 plugin paths, 0 private/runtime-data paths
- Forbidden dependency scan for plugin, Feiniu House, and head-pat identifiers

Electron smoke verification covered:

- Live2D cold start with the upstream PIXI 6 runtime
- VRM cold start and first frame
- Live2D -> VRM and VRM -> Live2D cross-engine switching with scheduled reload and ready acknowledgement
- VoiceChat emotion-mapper binding in both runtimes
- Isolated config paths without modifying the real `config.json`

