### PR TITLE
修复 portable 安装器外层目录识别

### DIFF
--- a/electron-installer/main.js
+++ b/electron-installer/main.js
@@ -68,7 +68,9 @@ function download(url, destination) {
 }
 
 async function install(components) {
-  const installDir = app.isPackaged ? path.dirname(process.execPath) : path.resolve(__dirname, '..');
+  const installDir = app.isPackaged
+    ? path.resolve(process.env.PORTABLE_EXECUTABLE_DIR || path.dirname(process.execPath))
+    : path.resolve(__dirname, '..');
   const envDir = path.join(installDir, 'env');
   const envPython = path.join(envDir, 'python.exe');
   const archive = path.join(installDir, 'my-neuro-env.tar.gz');


### PR DESCRIPTION
使用 electron-builder 的 PORTABLE_EXECUTABLE_DIR 定位用户实际启动的外层 EXE，避免 process.execPath 指向临时解包目录导致环境和模型被写入 Temp。