### PR TITLE
构建完成后自动清理依赖和中间文件

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -21,9 +21,18 @@ if errorlevel 1 goto :failed
 copy /y "dist\My-Neuro-Installer.exe" "..\My-Neuro-Installer.exe" >nul
 if errorlevel 1 goto :failed
 
+echo Cleaning build dependencies and intermediate files...
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0electron-installer\cleanup-build.ps1"
+if errorlevel 1 goto :cleanup_failed
+
 echo Done. Output: My-Neuro-Installer.exe
 pause
 exit /b 0
+
+:cleanup_failed
+echo Build succeeded, but cleanup failed. Output: My-Neuro-Installer.exe
+pause
+exit /b 1
 
 :failed
 echo Build failed.

--- a/electron-installer/cleanup-build.ps1
+++ b/electron-installer/cleanup-build.ps1
@@ -1,0 +1,38 @@
+$ErrorActionPreference = 'Stop'
+
+$buildRoot = [System.IO.Path]::GetFullPath($PSScriptRoot).TrimEnd('\')
+$targets = @(
+    [System.IO.Path]::Combine($buildRoot, 'dist'),
+    [System.IO.Path]::Combine($buildRoot, 'node_modules')
+)
+
+function Remove-ValidatedTree {
+    param([Parameter(Mandatory = $true)][string]$LiteralPath)
+
+    if (-not (Test-Path -LiteralPath $LiteralPath)) {
+        return
+    }
+
+    $item = Get-Item -LiteralPath $LiteralPath -Force -ErrorAction Stop
+    if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        Remove-Item -LiteralPath $item.FullName -Force -ErrorAction Stop
+        return
+    }
+
+    if ($item.PSIsContainer) {
+        foreach ($child in Get-ChildItem -LiteralPath $item.FullName -Force -ErrorAction Stop) {
+            Remove-ValidatedTree -LiteralPath $child.FullName
+        }
+    }
+    Remove-Item -LiteralPath $item.FullName -Force -ErrorAction Stop
+}
+
+foreach ($target in $targets) {
+    $fullTarget = [System.IO.Path]::GetFullPath($target)
+    $parent = [System.IO.Path]::GetDirectoryName($fullTarget).TrimEnd('\')
+    $leaf = [System.IO.Path]::GetFileName($fullTarget)
+    if ($parent -ne $buildRoot -or $leaf -notin @('dist', 'node_modules')) {
+        throw "Refusing unexpected cleanup target: $fullTarget"
+    }
+    Remove-ValidatedTree -LiteralPath $fullTarget
+}


### PR DESCRIPTION
build.bat 在复制 portable EXE 到根目录后，安全清理 electron-installer/dist 和 node_modules，避免构建工作目录占用接近 1GB。