### PR TITLE
修复桌宠无法拖到副屏：恢复 6.55 巨窗并集

### DIFF
--- a/live-2d/js/avatar/live2d/interaction.js
+++ b/live-2d/js/avatar/live2d/interaction.js
@@ -11,8 +11,8 @@
 //   saveModelPosition()               - 持久化位置/缩放（存储用 legacy 语义）
 //   resetModelPosition()              - 复位（供 HTTP /reset-model-position）
 //   isPointOverInteractive(x, y)      - 供 ui-controller 鼠标穿透判定（client 坐标）
-//   checkAndSwitchDisplay(x, y)       - 松手跨屏判定（光标贴边 + 模型越界 → 整窗重定位）
-//   _bounceModelIntoWindow()          - 模型几乎出屏时平滑回弹（bounce_back 开关控制）
+//   checkAndSwitchDisplay(x, y)       - 已停用：6.55 巨窗下不再整窗切屏
+//   _bounceModelIntoWindow()          - 相对整块巨窗回弹（bounce_back 开关控制）
 const { ipcRenderer } = require('electron');
 const { LEGACY_SCALE_RATIO } = require('./core.js');
 let _logToTerminal;
@@ -139,18 +139,20 @@ class Live2DInteractionController {
 
         this._on(window, 'pointermove', (e) => {
             if (!this.isDragging || !this.model) return;
-            const newX = e.clientX - this.dragOffset.x;
-            const newY = e.clientY - this.dragOffset.y;
+            let newX = e.clientX - this.dragOffset.x;
+            let newY = e.clientY - this.dragOffset.y;
 
-            // 拖动期间模型自由跟随光标，允许超出当前窗口边缘（会被窗口裁切）；
-            // 跨屏判定推迟到松手时的 checkAndSwitchDisplay，不在拖动中限制范围。
-            // （旧 screen_extend 巨窗方案已废弃，主进程不再读取该配置，相应钳制一并移除。）
+            // 6.55：左扩模式下限制 x >= 0；右扩/多屏巨窗内自由移动。
+            const extend = this.config?.ui?.screen_extend;
+            if (extend?.extend && extend?.left && newX < 0) newX = 0;
+
             this.model.position.set(newX, newY);
             this.updateInteractionArea();
+            this._maybeExpandPetWindow(newX, newY);
             this._notifyActivity();
         });
 
-        this._on(window, 'pointerup', async (e) => {
+        this._on(window, 'pointerup', (e) => {
             if (!this.isDragging) return;
             this.isDragging = false;
 
@@ -166,12 +168,8 @@ class Live2DInteractionController {
                 }
             }
 
-            // 松手时若“光标拖到了窗口边缘 + 模型越过该边”，整窗重定位到那一侧的显示器；
-            // 未切屏时若模型越出窗口，平滑回弹到窗口内（两个分支内部各自负责保存位置）。
-            const switched = await this.checkAndSwitchDisplay(e.clientX, e.clientY);
-            if (!switched) {
-                this._bounceModelIntoWindow();
-            }
+            // 巨窗方案：松手不再整窗切屏。回弹按整块窗口判断，副屏画布区内的模型不会弹回主屏。
+            this._bounceModelIntoWindow();
 
             // 松手后若指针不在交互区上则恢复穿透
             setTimeout(() => {
@@ -294,84 +292,40 @@ class Live2DInteractionController {
 
     // ============ 跨屏 / 回弹（v2 坐标系：舞台坐标 = CSS 像素，无需缩放换算） ============
 
-    // 松手时若“光标拖到窗口边缘 + 模型越过该边”，整窗重定位到那一侧的显示器。
-    // 触发用“光标贴边(EDGE 内) 且 模型可见区也越过该边”双重确认：光标到边缘=明确要往那侧推出去，
-    // 松手在屏幕中间不会误触；光标永远能拖到边缘，故四向、任意抓取点都对称。
-    async checkAndSwitchDisplay(cursorX, cursorY) {
-        if (!window.electronScreen || !window.electronScreen.moveWindowToDisplay) return false;
-        if (!this.model) return false;
-        if (!Number.isFinite(cursorX) || !Number.isFinite(cursorY)) return false;
+    _isDualRightCanvas() {
+        return window.innerWidth > window.screen.width * 1.2 && this.config?.ui?.screen_extend?.right !== false;
+    }
 
+    _getPrimaryWindowOffset() {
         try {
-            const displays = await window.electronScreen.getAllDisplays();
-            if (!displays || displays.length <= 1) return false;
-            const currentDisplay = await window.electronScreen.getCurrentDisplay();
-            if (!currentDisplay) return false;
-
-            const W = window.innerWidth, H = window.innerHeight;
-            // 模型可见区域在当前窗口 CSS 像素下的边界（v2：getBounds 即 CSS 坐标）
-            const b = this.model.getBounds();
-            const vLeft = b.left, vRight = b.right, vTop = b.top, vBottom = b.bottom;
-
-            // 光标贴到哪条边(EDGE 内) 且 模型也越过该边，就在那侧“边外一点”探测目标显示器；另一轴用光标位置。
-            const EDGE = 10;
-            const sX = currentDisplay.screenX, sY = currentDisplay.screenY;
-            const probes = [];
-            if (cursorX <= EDGE && vLeft < 0)       probes.push({ x: sX - 1,      y: sY + cursorY });
-            if (cursorX >= W - EDGE && vRight > W)   probes.push({ x: sX + W + 1,  y: sY + cursorY });
-            if (cursorY <= EDGE && vTop < 0)        probes.push({ x: sX + cursorX, y: sY - 1 });
-            if (cursorY >= H - EDGE && vBottom > H)  probes.push({ x: sX + cursorX, y: sY + H + 1 });
-
-            let targetDisplay = null, probe = null;
-            for (const p of probes) {
-                for (const d of displays) {
-                    if (d.id === currentDisplay.id) continue;
-                    if (p.x >= d.screenX && p.x < d.screenX + d.width &&
-                        p.y >= d.screenY && p.y < d.screenY + d.height) {
-                        targetDisplay = d; probe = p; break;
-                    }
-                }
-                if (targetDisplay) break;
+            const info = ipcRenderer.sendSync('get-screen-info-sync');
+            if (info?.primaryDisplay?.bounds && info?.windowBounds) {
+                return {
+                    x: info.primaryDisplay.bounds.x - info.windowBounds.x,
+                    y: info.primaryDisplay.bounds.y - info.windowBounds.y,
+                    width: info.primaryDisplay.bounds.width,
+                    height: info.primaryDisplay.bounds.height
+                };
             }
-            if (!targetDisplay) return false;
+        } catch (_) { /* 主进程未就绪时退回整窗 */ }
+        return { x: 0, y: 0, width: window.innerWidth, height: window.innerHeight };
+    }
 
-            console.log('[Live2D] 光标拖到屏幕边缘，准备切换到屏幕:', targetDisplay.id);
+    _maybeExpandPetWindow(modelX, modelY) {
+        const now = Date.now();
+        if (this._lastWindowMoveAt && now - this._lastWindowMoveAt < 200) return;
+        const edge = 40;
+        const nearEdge = modelX < edge || modelY < edge ||
+            modelX > window.innerWidth - edge || modelY > window.innerHeight - edge;
+        if (!nearEdge) return;
+        this._lastWindowMoveAt = now;
+        ipcRenderer.send('window-move', { mouseX: 0, mouseY: 0 });
+    }
 
-            const result = await window.electronScreen.moveWindowToDisplay(probe.x, probe.y);
-            if (result && result.success && !result.sameDisplay) {
-                if (result.scaleRatio && result.scaleRatio !== 1) {
-                    console.log('[Live2D] 屏幕缩放比变化:', result.scaleRatio);
-                }
-
-                // 以探测点为视觉中心，夹住可见模型完整落入目标屏（目标屏 DIP 尺寸），用 delta 落位。
-                const tw = targetDisplay.width, th = targetDisplay.height;
-                const halfVisW = (vRight - vLeft) / 2;
-                const halfVisH = (vBottom - vTop) / 2;
-                const margin = 16;
-                let cx = probe.x - targetDisplay.screenX;
-                let cy = probe.y - targetDisplay.screenY;
-                const loX = margin + halfVisW, hiX = tw - margin - halfVisW;
-                const loY = margin + halfVisH, hiY = th - margin - halfVisH;
-                cx = hiX >= loX ? Math.min(Math.max(cx, loX), hiX) : tw / 2;
-                cy = hiY >= loY ? Math.min(Math.max(cy, loY), hiY) : th / 2;
-
-                const b2 = this.model.getBounds();
-                const curCenterX = (b2.left + b2.right) / 2;
-                const curCenterY = (b2.top + b2.bottom) / 2;
-                this.model.x += cx - curCenterX;
-                this.model.y += cy - curCenterY;
-                this.updateInteractionArea();
-
-                // 保存：用“目标显示器的 DIP 尺寸”算相对位置，避免依赖跨屏后尚未稳定的 innerWidth。
-                this.saveModelPosition(tw, th);
-                console.log('[Live2D] 跨屏切换完成，模型新位置:', this.model.x, this.model.y);
-                return true;
-            }
-            return false;
-        } catch (error) {
-            console.error('[Live2D] 跨屏检测/切换出错:', error);
-            return false;
-        }
+    // 6.55 巨窗下不再整窗切屏。保留空实现，避免旧调用把窗口缩回单屏。
+    async checkAndSwitchDisplay() {
+        console.log('[Live2D] 巨窗方案不再整窗切屏');
+        return false;
     }
 
     // 若模型中心越出当前窗口，吸回窗口内（保持中心位于窗口范围内）。
@@ -538,7 +492,7 @@ class Live2DInteractionController {
         const stageH = overrideHeight || window.innerHeight || 1;
         const relativeX = this.model.x / stageW;
         const relativeY = this.model.y / stageH;
-        const isDualRight = window.innerWidth > window.screen.width * 1.2 && this.config?.ui?.screen_extend?.right;
+        const isDualRight = this._isDualRightCanvas();
         // 存储用 legacy 语义（兼容 WebUI 直接读写 config.ui.model_scale）
         const legacyScale = this.model.scale.x * LEGACY_SCALE_RATIO;
 
@@ -579,16 +533,18 @@ class Live2DInteractionController {
     // 复位到默认位置与缩放（供 HTTP /reset-model-position）
     resetModelPosition() {
         if (!this.model) return { success: false };
-        const isDualRight = window.innerWidth > window.screen.width * 1.2 && this.config?.ui?.screen_extend?.right;
-        const relX = isDualRight ? 0.825 : 0.65;
-        const relY = 0.38;
+        const primary = this._getPrimaryWindowOffset();
         const legacyScale = 0.65;
-
-        this.model.x = relX * window.innerWidth;
-        this.model.y = relY * window.innerHeight;
+        this.model.x = primary.x + primary.width * 0.65;
+        this.model.y = primary.y + primary.height * 0.38;
         this.model.scale.set(legacyScale / LEGACY_SCALE_RATIO);
         this.updateInteractionArea();
 
+        const stageW = window.innerWidth || 1;
+        const stageH = window.innerHeight || 1;
+        const isDualRight = this._isDualRightCanvas();
+        const relX = this.model.x / stageW;
+        const relY = this.model.y / stageH;
         ipcRenderer.send('save-model-position', {
             x: relX, y: relY, scale: legacyScale, dual: isDualRight,
             modelName: this._currentModelName()

--- a/live-2d/js/avatar/live2d/model-loader.js
+++ b/live-2d/js/avatar/live2d/model-loader.js
@@ -128,7 +128,7 @@ class Live2DModelLoader {
         model.scale.set(legacyScale / LEGACY_SCALE_RATIO);
 
         // 位置：0~1 相对值（与旧实现语义一致），双屏右扩展时用 x_dual/y_dual
-        const isDualRight = window.innerWidth > window.screen.width * 1.2 && config.ui?.screen_extend?.right;
+        const isDualRight = window.innerWidth > window.screen.width * 1.2 && config.ui?.screen_extend?.right !== false;
         const pos = prefs?.position || config.ui?.model_position || {};
         const relX = isDualRight ? (pos.x_dual ?? 0.825) : (pos.x ?? 0.65);
         const relY = isDualRight ? (pos.y_dual ?? 0.38) : (pos.y ?? 0.38);

--- a/live-2d/js/avatar/vrm/interaction.js
+++ b/live-2d/js/avatar/vrm/interaction.js
@@ -223,6 +223,7 @@ class VRMInteractionController {
                 const vr = model.viewRect;
                 vr.x = e.clientX - this.dragOffset.x;
                 vr.y = e.clientY - this.dragOffset.y;
+                this._maybeExpandPetWindow(vr.x, vr.y);
                 return;
             }
             if (isRightDragging) {
@@ -269,7 +270,7 @@ class VRMInteractionController {
             }
         });
 
-        this._on(window, 'mouseup', async (e) => {
+        this._on(window, 'mouseup', (e) => {
             if (e.button === 0 && this.isDragging) {
                 this.isDragging = false;
 
@@ -282,12 +283,8 @@ class VRMInteractionController {
                     }
                 }
 
-                // 松手时若“光标拖到了窗口边缘 + 模型越过该边”，整窗重定位到那一侧的显示器；
-                // 未切屏时若模型越出窗口，平滑回弹到窗口内（两个分支内部各自负责保存位置）。
-                const switched = await this.checkAndSwitchDisplay(e.clientX, e.clientY);
-                if (!switched) {
-                    this._bounceViewRectIntoWindow();
-                }
+                // 巨窗方案：松手不再整窗切屏。回弹按整块窗口判断。
+                this._bounceViewRectIntoWindow();
                 setTimeout(() => {
                     if (this.model && !model.containsPoint({ x: e.clientX, y: e.clientY })) {
                         ipcRenderer.send('set-ignore-mouse-events', { ignore: true, options: { forward: true } });
@@ -406,15 +403,21 @@ class VRMInteractionController {
 
     resetModelPosition() {
         if (!this.model) return { success: false };
-        this.model.viewRect = this._savedToViewRect(1.35, 0.8, 2.3);
+        const primary = this._getPrimaryWindowOffset();
+        const vr = this._savedToViewRectWithSize(1.35, 0.8, 2.3, primary.width, primary.height);
+        vr.x += primary.x;
+        vr.y += primary.y;
+        this.model.viewRect = vr;
         this._clampViewRect();
         this.saveModelPosition();
         return { success: true };
     }
 
     _savedToViewRect(relX, relY, scale) {
-        const iW = window.innerWidth;
-        const iH = window.innerHeight;
+        return this._savedToViewRectWithSize(relX, relY, scale, window.innerWidth, window.innerHeight);
+    }
+
+    _savedToViewRectWithSize(relX, relY, scale, iW, iH) {
         const width = scale * VRM_SCALE_FACTOR * iW;
         const height = width * VRM_VIEWPORT_ASPECT;
         return {
@@ -423,6 +426,32 @@ class VRMInteractionController {
             width,
             height
         };
+    }
+
+    _getPrimaryWindowOffset() {
+        try {
+            const info = ipcRenderer.sendSync('get-screen-info-sync');
+            if (info?.primaryDisplay?.bounds && info?.windowBounds) {
+                return {
+                    x: info.primaryDisplay.bounds.x - info.windowBounds.x,
+                    y: info.primaryDisplay.bounds.y - info.windowBounds.y,
+                    width: info.primaryDisplay.bounds.width,
+                    height: info.primaryDisplay.bounds.height
+                };
+            }
+        } catch (_) { /* ignore */ }
+        return { x: 0, y: 0, width: window.innerWidth, height: window.innerHeight };
+    }
+
+    _maybeExpandPetWindow(x, y) {
+        const now = Date.now();
+        if (this._lastWindowMoveAt && now - this._lastWindowMoveAt < 200) return;
+        const edge = 40;
+        const nearEdge = x < edge || y < edge ||
+            x > window.innerWidth - edge || y > window.innerHeight - edge;
+        if (!nearEdge) return;
+        this._lastWindowMoveAt = now;
+        ipcRenderer.send('window-move', { mouseX: 0, mouseY: 0 });
     }
 
     // overrideWidth/Height：跨屏切换时传入“目标显示器的 DIP 尺寸”作基准。
@@ -437,83 +466,10 @@ class VRMInteractionController {
         };
     }
 
-    // ===== 跨屏：松手时若“光标拖到窗口边缘 + 模型越过该边”，整窗重定位到那一侧的显示器 =====
-    // 触发用“光标贴边(EDGE 内) 且 模型可见区也越过该边”双重确认：光标到边缘=明确要往那侧推出去，
-    // 松手在屏幕中间不会误触；光标永远能拖到边缘，故四向、任意抓取点都对称。
-    // VRM 在 client/CSS 像素下工作（渲染器 1:1）。cursorX/cursorY：松手时光标的窗口 CSS 坐标。
-    async checkAndSwitchDisplay(cursorX, cursorY) {
-        if (!window.electronScreen || !window.electronScreen.moveWindowToDisplay) return false;
-        if (!this.model || !this.model.viewRect) return false;
-        if (!Number.isFinite(cursorX) || !Number.isFinite(cursorY)) return false;
-
-        try {
-            const displays = await window.electronScreen.getAllDisplays();
-            if (!displays || displays.length <= 1) return false;
-            const currentDisplay = await window.electronScreen.getCurrentDisplay();
-            if (!currentDisplay) return false;
-
-            const vr = this.model.viewRect;
-            const W = window.innerWidth, H = window.innerHeight;
-            // 模型可见区域在当前窗口 client 像素下的边界
-            const vLeft = vr.x + VRM_PADDING_X * vr.width;
-            const vRight = vr.x + (1 - VRM_PADDING_X) * vr.width;
-            const vTop = vr.y + VRM_PADDING_Y * vr.height;
-            const vBottom = vr.y + 0.96 * vr.height;
-
-            // 光标贴到哪条边(EDGE 内) 且 模型也越过该边，就在那侧“边外一点”探测目标显示器；另一轴用光标位置。
-            const EDGE = 10;
-            const sX = currentDisplay.screenX, sY = currentDisplay.screenY;
-            const probes = [];
-            if (cursorX <= EDGE && vLeft < 0)       probes.push({ x: sX - 1,      y: sY + cursorY });
-            if (cursorX >= W - EDGE && vRight > W)   probes.push({ x: sX + W + 1,  y: sY + cursorY });
-            if (cursorY <= EDGE && vTop < 0)        probes.push({ x: sX + cursorX, y: sY - 1 });
-            if (cursorY >= H - EDGE && vBottom > H)  probes.push({ x: sX + cursorX, y: sY + H + 1 });
-
-            let targetDisplay = null, probe = null;
-            for (const p of probes) {
-                for (const d of displays) {
-                    if (d.id === currentDisplay.id) continue;
-                    if (p.x >= d.screenX && p.x < d.screenX + d.width &&
-                        p.y >= d.screenY && p.y < d.screenY + d.height) {
-                        targetDisplay = d; probe = p; break;
-                    }
-                }
-                if (targetDisplay) break;
-            }
-            if (!targetDisplay) return false;
-
-            console.log('[VRM] 光标拖到屏幕边缘，准备切换到屏幕:', targetDisplay.id);
-            const result = await window.electronScreen.moveWindowToDisplay(probe.x, probe.y);
-            if (result && result.success && !result.sameDisplay) {
-                if (result.scaleRatio && result.scaleRatio !== 1) {
-                    console.log('[VRM] 屏幕缩放比变化:', result.scaleRatio);
-                }
-
-                // 以探测点为视觉中心放到新窗口，再夹住可见模型完整落入目标屏（用目标屏 DIP 尺寸，免受 innerWidth 未稳定影响）。
-                const tw = targetDisplay.width, th = targetDisplay.height;
-                const halfVisW = (vRight - vLeft) / 2;
-                const halfVisH = (vBottom - vTop) / 2; // VRM_CENTER_Y_FRAC 取可见区上下中点，故上下对称
-                const margin = 16;
-                let cx = probe.x - targetDisplay.screenX;
-                let cy = probe.y - targetDisplay.screenY;
-                const loX = margin + halfVisW, hiX = tw - margin - halfVisW;
-                const loY = margin + halfVisH, hiY = th - margin - halfVisH;
-                cx = hiX >= loX ? Math.min(Math.max(cx, loX), hiX) : tw / 2;
-                cy = hiY >= loY ? Math.min(Math.max(cy, loY), hiY) : th / 2;
-
-                this.model.viewRect.x = cx - 0.5 * vr.width;
-                this.model.viewRect.y = cy - VRM_CENTER_Y_FRAC * vr.height;
-
-                // 保存：用目标显示器 DIP 尺寸作基准，避免依赖跨屏后尚未稳定的 innerWidth。
-                this.saveModelPosition(tw, th);
-                console.log('[VRM] 跨屏切换完成，viewRect:', this.model.viewRect);
-                return true;
-            }
-            return false;
-        } catch (error) {
-            console.error('[VRM] 跨屏检测/切换出错:', error);
-            return false;
-        }
+    // 6.55 巨窗下不再整窗切屏。保留空实现，避免旧调用把窗口缩回单屏。
+    async checkAndSwitchDisplay() {
+        console.log('[VRM] 巨窗方案不再整窗切屏');
+        return false;
     }
 
     // ===== 回弹：以「碰撞箱（getScreenHitBox，骨骼投影的真实可抓取范围）」为判断依据 =====

--- a/live-2d/js/services/http-server.js
+++ b/live-2d/js/services/http-server.js
@@ -202,37 +202,18 @@ class HttpServer {
 		
 		    const jsCode = `
 		        (() => {
-		            // 获取全局的模型控制器
-		            const mc = global.modelController;
-		            if (!mc?.model) return { success: false};
-		
-		            const { ipcRenderer } = require('electron');
-		            const model = mc.model;
-		            const scaleFactor = window.canvasScaleFactor || 2;
-		            // 窗口只覆盖当前显示器，重置到当前窗口内的默认相对位置即可（不再区分单/双屏）。
-		            const relX = 0.65;
-		            const relY = 0.38;
-		            const scale = 0.65;
+		            const facade = global.avatarFacade || window.avatar;
+		            const mc = facade?.getController?.() || global.modelController;
+		            if (!mc) return { success: false };
 
-		            if (model.modelType === 'vrm') {
-		                model.viewRect = mc._savedToViewRect(relX, relY, scale);
-		                if (mc._clampViewRect) mc._clampViewRect();
-		            } else {
-		                const defaultX = relX * window.innerWidth * scaleFactor;
-		                const defaultY = relY * window.innerHeight * scaleFactor;
-		                model.x = defaultX;
-		                model.y = defaultY;
-		                if (model.scale?.set) model.scale.set(scale);
-		                if (mc.updateInteractionArea) mc.updateInteractionArea();
+		            if (typeof mc.resetModelPosition === 'function') {
+		                const result = mc.resetModelPosition();
+		                const uic = global.uiController;
+		                if (uic) uic.resetSubtitlePosition();
+		                return result && result.success !== false ? { success: true } : { success: false };
 		            }
-		
-		            ipcRenderer.send('save-model-position', { x: relX, y: relY, scale });
 
-		            // 同步复位字幕位置
-		            const uic = global.uiController;
-		            if (uic) uic.resetSubtitlePosition();
-
-		            return { success: true};
+		            return { success: false };
 		        })()
 		    `;
 		

--- a/live-2d/js/ui/ui-controller.js
+++ b/live-2d/js/ui/ui-controller.js
@@ -97,22 +97,37 @@ class UIController {
             textChatContainer.style.setProperty('opacity', '0', 'important');
         }
 
-        // 窗口只覆盖“当前显示器”，聊天框/字幕直接锚定到本窗口的右下角即可，
-        // 不再需要 get-screen-info-sync 把坐标换算到主屏（那是旧巨型跨屏窗口才需要的）。
-        textChatContainer.style.setProperty('left', 'auto', 'important');
-        textChatContainer.style.setProperty('right', '20px', 'important');
-        textChatContainer.style.setProperty('bottom', '50px', 'important');
+        // 巨窗覆盖多屏时，必须锚到主屏右下，不能锚整窗右下（否则对话框会跑到副屏最右侧）。
+        const screenInfo = ipcRenderer.sendSync('get-screen-info-sync');
+        if (screenInfo?.primaryDisplay && screenInfo?.windowBounds) {
+            const { primaryDisplay, windowBounds } = screenInfo;
+            const winX = windowBounds.x;
+            const winY = windowBounds.y;
+            const winH = windowBounds.height;
+            const primaryLeftOffset = primaryDisplay.bounds.x - winX;
+            const primaryTopOffset = primaryDisplay.bounds.y - winY;
+            const primaryBottomOffset = winH - (primaryTopOffset + primaryDisplay.bounds.height);
+            const rightPos = primaryLeftOffset + primaryDisplay.bounds.width - 350 - 20;
 
-        const subtitleContainer = document.getElementById('subtitle-container');
-        if (subtitleContainer) {
-            subtitleContainer.style.setProperty('position', 'fixed', 'important');
-            subtitleContainer.style.setProperty('left', 'auto', 'important');
-            subtitleContainer.style.setProperty('right', '20px', 'important');
-            subtitleContainer.style.setProperty('bottom', '20px', 'important');
-            subtitleContainer.style.setProperty('width', '400px', 'important');
-            subtitleContainer.style.setProperty('max-width', '400px', 'important');
-            subtitleContainer.style.setProperty('transform', 'none', 'important');
-            subtitleContainer.style.setProperty('display', 'block', 'important');
+            textChatContainer.style.setProperty('left', rightPos + 'px', 'important');
+            textChatContainer.style.setProperty('right', 'auto', 'important');
+            textChatContainer.style.setProperty('bottom', (primaryBottomOffset + 50) + 'px', 'important');
+
+            const subtitleContainer = document.getElementById('subtitle-container');
+            if (subtitleContainer) {
+                subtitleContainer.style.setProperty('position', 'fixed', 'important');
+                subtitleContainer.style.setProperty('left', (primaryLeftOffset + primaryDisplay.bounds.width - 800) + 'px', 'important');
+                subtitleContainer.style.setProperty('right', 'auto', 'important');
+                subtitleContainer.style.setProperty('bottom', (primaryBottomOffset + 20) + 'px', 'important');
+                subtitleContainer.style.setProperty('width', '400px', 'important');
+                subtitleContainer.style.setProperty('max-width', '400px', 'important');
+                subtitleContainer.style.setProperty('transform', 'none', 'important');
+                subtitleContainer.style.setProperty('display', 'block', 'important');
+            }
+        } else {
+            textChatContainer.style.setProperty('left', 'auto', 'important');
+            textChatContainer.style.setProperty('right', '20px', 'important');
+            textChatContainer.style.setProperty('bottom', '50px', 'important');
         }
 
         const setMousePassthrough = (ignore, forward = true) => {
@@ -1025,7 +1040,17 @@ class UIController {
         this.subtitleScale = 1;
 
         if (this.isAdjustingSubtitle) {
-            const tx = window.innerWidth * 0.7, ty = window.innerHeight - 80;
+            let tx = window.innerWidth * 0.7;
+            let ty = window.innerHeight - 80;
+            try {
+                const info = ipcRenderer.sendSync('get-screen-info-sync');
+                if (info?.primaryDisplay?.bounds && info?.windowBounds) {
+                    const left = info.primaryDisplay.bounds.x - info.windowBounds.x;
+                    const top = info.primaryDisplay.bounds.y - info.windowBounds.y;
+                    tx = left + info.primaryDisplay.bounds.width * 0.7;
+                    ty = top + info.primaryDisplay.bounds.height - 80;
+                }
+            } catch (_) { /* 单屏回退 */ }
             this._subtitleCenterX = tx; this._subtitleCenterY = ty;
             Object.assign(c.style, {
                 left: `${tx}px`, top: `${ty}px`,

--- a/live-2d/main.js
+++ b/live-2d/main.js
@@ -269,9 +269,7 @@ function ensureTopMost(win) {
 }
 
 // ===== 跨屏方案辅助函数 =====
-// 单显示器全屏边界：左/上各内缩 1px，破坏“起点贴齐 + size 等于 display”的完美全屏判定，
-// 规避 DWM/Chromium borderless-fullscreen / 遮挡优化带来的副作用（后台视频暂停、播放器卡顿等）。
-// 用于把窗口尺寸定为单个显示器的全屏填充范围。
+// 6.6 单屏窗口边界（仅留给调试/兼容调用，创建窗口不再走这条路径）。
 function getFullscreenDisplayBounds(display) {
     const b = display && display.bounds ? display.bounds : { x: 0, y: 0, width: 1280, height: 720 };
     return {
@@ -282,24 +280,69 @@ function getFullscreenDisplayBounds(display) {
     };
 }
 
-// 启动时选择窗口所在显示器：优先上次保存的显示器（config.ui.model_position.display），否则主屏。
-function findStartupDisplay(config) {
-    const displays = screen.getAllDisplays();
-    const saved = config && config.ui && config.ui.model_position && config.ui.model_position.display;
-    if (saved && Number.isFinite(saved.screenX) && Number.isFinite(saved.screenY)) {
-        const px = saved.screenX + 10;
-        const py = saved.screenY + 10;
-        const found = displays.find(d =>
-            px >= d.bounds.x && px < d.bounds.x + d.bounds.width &&
-            py >= d.bounds.y && py < d.bounds.y + d.bounds.height
-        );
-        if (found) return found;
-        try {
-            const near = screen.getDisplayNearestPoint({ x: saved.screenX, y: saved.screenY });
-            if (near) return near;
-        } catch (e) { /* ignore */ }
+// 6.55 巨窗并集：用 Electron display.bounds 原始 x/y（副屏在左时为负数），禁止 clamp 到 0。
+// 相对 6.55 的唯一行为调整：显式 extend=false 但已有 2 块及以上屏幕时，仍覆盖全部屏幕，
+// 避免用户必须先改 config.json 才能把皮套拖到副屏。
+function computePetWindowBounds(config, displays, primaryDisplay) {
+    const screenExtend = (config && config.ui && config.ui.screen_extend) || { extend: false, left: false, right: true };
+    const all = Array.isArray(displays) && displays.length > 0 ? displays : [primaryDisplay];
+    const primary = primaryDisplay || all[0];
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+
+    const include = (display) => {
+        const { x, y, width, height } = display.bounds;
+        minX = Math.min(minX, x);
+        minY = Math.min(minY, y);
+        maxX = Math.max(maxX, x + width);
+        maxY = Math.max(maxY, y + height);
+    };
+
+    const multi = all.length >= 2;
+    if (screenExtend.extend === false && !multi) {
+        include(primary);
+    } else if (screenExtend.extend === true && screenExtend.left) {
+        all.forEach((display) => {
+            if (display.bounds.x <= primary.bounds.x) include(display);
+        });
+    } else {
+        all.forEach(include);
     }
-    return screen.getPrimaryDisplay();
+
+    return {
+        minX,
+        minY,
+        maxX,
+        maxY,
+        totalWidth: maxX - minX,
+        totalHeight: maxY - minY,
+        screenExtend,
+        displayCount: all.length
+    };
+}
+
+function applyPetUnionBounds(win, config) {
+    if (!win || win.isDestroyed()) return null;
+    const displays = screen.getAllDisplays();
+    const primary = screen.getPrimaryDisplay();
+    const target = computePetWindowBounds(config || {}, displays, primary);
+    const next = {
+        x: target.minX,
+        y: target.minY,
+        width: target.totalWidth,
+        height: target.totalHeight
+    };
+    const current = win.getBounds();
+    const near = (a, b) => Math.abs(a - b) <= 2;
+    if (!(near(current.x, next.x) && near(current.y, next.y) &&
+        near(current.width, next.width) && near(current.height, next.height))) {
+        win.setBounds(next);
+        schedulePetBoundsRepair(win, next);
+        console.log(`窗口调整: ${next.width}x${next.height} at (${next.x}, ${next.y})`);
+    }
+    return target;
 }
 
 // 创建/跨屏后多次重申窗口边界：抵消创建期被夹到 workArea，以及跨不同 DPI 屏时 Electron 单次
@@ -378,19 +421,24 @@ function createWindow () {
         console.error('读取配置失败:', e);
     }
 
-    // ===== 跨屏方案：窗口只覆盖“单个”显示器，跨屏靠整窗重定位（move-window-to-display）实现 =====
-    // 不再把所有显示器并集成一块巨型窗口；启动时落在上次所在的显示器（否则主屏）。
-    const startupDisplay = findStartupDisplay(config);
-    const startupBounds = getFullscreenDisplayBounds(startupDisplay);
-    const minX = startupBounds.x;
-    const minY = startupBounds.y;
-    const totalWidth = startupBounds.width;
-    const totalHeight = startupBounds.height;
+    // ===== 跨屏方案：恢复 6.55 巨窗并集。拖到副屏靠画布坐标，不再整窗跳单屏。 =====
+    const displays = screen.getAllDisplays();
+    const primaryDisplay = screen.getPrimaryDisplay();
+    displays.forEach((display, index) => {
+        const { x, y, width, height } = display.bounds;
+        console.log(`显示器 ${index}: id=${display.id}, x=${x}, y=${y}, width=${width}, height=${height}, scale=${display.scaleFactor}`);
+    });
+    const union = computePetWindowBounds(config, displays, primaryDisplay);
+    const minX = union.minX;
+    const minY = union.minY;
+    const totalWidth = union.totalWidth;
+    const totalHeight = union.totalHeight;
 
-    console.log(`=== 窗口创建信息（单屏方案）===`)
-    console.log(`目标显示器: id=${startupDisplay.id}, 缩放=${startupDisplay.scaleFactor}, bounds=${JSON.stringify(startupDisplay.bounds)}`)
-    console.log(`窗口尺寸: ${totalWidth}x${totalHeight}`)
-    console.log(`窗口位置: (${minX}, ${minY})`)
+    console.log(`=== 窗口创建信息（6.55 巨窗并集）===`);
+    console.log(`screen_extend: ${JSON.stringify(union.screenExtend)}, 显示器数量=${union.displayCount}`);
+    console.log(`总边界: minX=${minX}, minY=${minY}, maxX=${union.maxX}, maxY=${union.maxY}`);
+    console.log(`计算的窗口尺寸: ${totalWidth}x${totalHeight}`);
+    console.log(`窗口位置: (${minX}, ${minY})`);
     
     const win = new BrowserWindow({
         x: minX,
@@ -411,7 +459,7 @@ function createWindow () {
             zoomFactor: 1.0,
             enableWebSQL: true
         },
-        resizable: false,
+        resizable: true,
         movable: true,
         skipTaskbar: true,
         maximizable: false,
@@ -425,7 +473,7 @@ function createWindow () {
     console.log(`窗口创建后立即尺寸: ${immediateBounds.width}x${immediateBounds.height}`)
     console.log(`窗口创建后立即位置: (${immediateBounds.x}, ${immediateBounds.y})`)
     
-    // 创建后多次重申单屏边界（替代旧的一次性 100ms 自检），抵消创建期被夹到 workArea。
+    // 创建后多次重申并集边界，抵消创建期被夹到 workArea；不再打回单屏。
     schedulePetBoundsRepair(win, { x: minX, y: minY, width: totalWidth, height: totalHeight })
     
     win.loadFile('index.html')
@@ -498,8 +546,30 @@ app.on('activate', () => {
     }
 })
 
-// 旧的 'window-move'（巨窗跟随 + 动态并集 setBounds）方案已废弃。
-// 跨屏改由 'move-window-to-display' 实现（见下方），渲染端拖动只移动模型精灵。
+// 恢复 6.55 的 window-move：拖到窗边时把窗口扩成当前配置下的显示器并集。
+ipcMain.on('window-move', (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win || win.isDestroyed()) return;
+    let config = {};
+    try {
+        config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    } catch (e) { /* 用空配置走 computePetWindowBounds 的多屏默认 */ }
+    applyPetUnionBounds(win, config);
+});
+
+ipcMain.on('get-screen-info-sync', (event) => {
+    try {
+        const win = BrowserWindow.fromWebContents(event.sender);
+        event.returnValue = {
+            primaryDisplay: screen.getPrimaryDisplay(),
+            allDisplays: screen.getAllDisplays(),
+            windowBounds: win && !win.isDestroyed() ? win.getBounds() : null
+        };
+    } catch (e) {
+        console.error('获取屏幕信息失败:', e);
+        event.returnValue = null;
+    }
+});
 
 ipcMain.on('set-ignore-mouse-events', (event, { ignore, options }) => {
     BrowserWindow.fromWebContents(event.sender).setIgnoreMouseEvents(ignore, options)
@@ -829,68 +899,20 @@ ipcMain.handle('get-primary-display-info', () => {
     };
 });
 
-// ===== 跨屏核心：把整个窗口重定位到“包含指定屏幕点”的显示器并填满它 =====
-// 渲染端在松手时检测到模型中心越出当前窗口，换算成屏幕绝对坐标后调用本接口。
-ipcMain.handle('move-window-to-display', async (event, screenX, screenY) => {
+// 6.6 单屏切屏入口保留给旧调用，但不再把窗口缩回一块屏。
+ipcMain.handle('move-window-to-display', async (event) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     if (!win || win.isDestroyed()) return { success: false, error: 'Window not found' };
     try {
-        const displays = screen.getAllDisplays();
-        const currentBounds = win.getBounds();
-
-        // 找到包含该屏幕点的目标显示器
-        let targetDisplay = null;
-        for (const display of displays) {
-            const b = display.bounds;
-            if (screenX >= b.x && screenX < b.x + b.width &&
-                screenY >= b.y && screenY < b.y + b.height) {
-                targetDisplay = display;
-                break;
-            }
-        }
-        if (!targetDisplay) {
-            console.log('move-window-to-display: 未找到包含点的屏幕, screenX=', screenX, 'screenY=', screenY);
-            return { success: false, error: 'No display found at the given point' };
-        }
-
-        const currentDisplay = screen.getDisplayMatching(currentBounds);
-        if (currentDisplay.id === targetDisplay.id) {
-            return { success: true, sameDisplay: true };
-        }
-
-        console.log('move-window-to-display: 从屏幕', currentDisplay.id, '切换到屏幕', targetDisplay.id);
-
-        // 不同屏幕可能有不同缩放：广播 scaleRatio（渲染端目前保持模型原大小，仅调位置）
-        const scaleRatio = targetDisplay.scaleFactor / currentDisplay.scaleFactor;
-        const newBounds = getFullscreenDisplayBounds(targetDisplay);
-
-        // 切屏期间隐藏窗口，遮住“尺寸过冲/修正”那一两帧的闪跳；尺寸稳定后由 revealPetAfterMove 恢复。
-        hidePetForMove(win);
-        win.setBounds(newBounds);
-
-        // 关键修复：跨“不同缩放因子(DPI)”的显示器时，Electron 单次 setBounds 会用错误的缩放因子
-        // 计算物理尺寸，使窗口尺寸不匹配目标屏。等窗口落到目标屏后多次重申边界，按目标屏缩放因子重算尺寸。
-        schedulePetBoundsRepair(win, newBounds);
-        revealPetAfterMove(win, newBounds);
-
-        setTimeout(() => {
-            if (!win.isDestroyed()) {
-                win.webContents.send('display-changed', {
-                    displayId: targetDisplay.id,
-                    bounds: targetDisplay.bounds,
-                    scaleFactor: targetDisplay.scaleFactor,
-                    scaleRatio: scaleRatio,
-                    previousScaleFactor: currentDisplay.scaleFactor
-                });
-            }
-        }, 32);
-
+        let config = {};
+        try {
+            config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+        } catch (e) { /* ignore */ }
+        const target = applyPetUnionBounds(win, config);
         return {
             success: true,
-            displayId: targetDisplay.id,
-            bounds: targetDisplay.bounds,
-            scaleFactor: targetDisplay.scaleFactor,
-            scaleRatio: scaleRatio
+            sameDisplay: true,
+            bounds: target ? { x: target.minX, y: target.minY, width: target.totalWidth, height: target.totalHeight } : null
         };
     } catch (err) {
         console.error('move-window-to-display 错误:', err.message);
@@ -918,12 +940,17 @@ ipcMain.on('save-model-position', (event, position) => {
             };
         }
 
-        // 跨屏方案：位置按“当前显示器内的相对位置（0~1）”保存，不再区分单/双屏 x_dual/y_dual。
-        configData.ui.model_position.x = nextPosition.x;
-        configData.ui.model_position.y = nextPosition.y;
+        // 巨窗方案恢复 6.55 的单/双屏坐标：右扩巨窗写 x_dual/y_dual。
+        if (nextPosition.dual) {
+            configData.ui.model_position.x_dual = nextPosition.x;
+            configData.ui.model_position.y_dual = nextPosition.y;
+        } else {
+            configData.ui.model_position.x = nextPosition.x;
+            configData.ui.model_position.y = nextPosition.y;
+        }
         configData.ui.model_scale = nextPosition.scale;
 
-        // 记录当前窗口所在显示器的屏幕原点，供下次启动把窗口落回同一块屏（findStartupDisplay 使用）。
+        // 仍记录当前屏原点，仅供诊断；启动落点以巨窗并集为准。
         const win = BrowserWindow.fromWebContents(event.sender);
         if (win && !win.isDestroyed()) {
             try {


### PR DESCRIPTION
## 这个功能从哪一版开始坏的

**v6.5.5 能用，v6.6 正式版开始不能用。**

6.55 的做法是：Electron 窗口按所有显示器 `bounds` 求并集，做成一块透明巨窗。皮套只是这块大画布上的精灵，从主屏拖到副屏就是改 `model.x/y`，副屏上能直接看见。不需要松手、不需要切窗口。

6.6 发布说明里写了这次改动：

> 模型多屏跨越改为单屏窗口 + 整窗重定位、跨屏判定改为“光标贴边 + 模型越界”

对应提交：

- `e68362d` 把巨窗拆成只盖一块屏，删掉 `window-move`，改成 `move-window-to-display`
- `f3cc5a0` 松手时必须同时满足「光标贴边 10px」且「模型可见区越过同一条边」才切屏

所以 **6.6 以及之后的 6.6.1 / 6.6.2 / 6.6.3 都继承了这套单屏方案**，拖到副屏会失败或松手弹回主屏。

## 6.6 之后为什么拖不过去

窗口物理上不再覆盖副屏。拖动只在当前这块屏的 client 坐标里改精灵，模型一出边就被裁掉，副屏上看不见。

松手想切过去，还要同时满足：

1. `window.electronScreen` 已注入
2. 检测到 2 块及以上屏幕
3. 光标在窗口某条边 **10px 内**
4. 模型可见区越过 **同一条边**
5. 「边外 1px」探测点正好落在另一块屏的 bounds 里

常见失败：

- 指针一出窗，`pointerup` 的坐标还是窗内最后一点，到不了 10px 贴边
- 只推出模型、光标还在窗内中部 → 不切屏
- 窗口还被 `getFullscreenDisplayBounds` 左/上各内缩 1px，`innerWidth` 和显示器宽度对不齐，探测点落在当前屏或两屏缝里
- 竖排屏、负坐标副屏、混合 DPI 时更容易判错
- 切屏失败后 `_bounceModelIntoWindow()` 默认开启，用户感觉就是「一松手弹回主屏」

6.6 自己的提交也承认过：原先「模型中心出窗」在竖屏上单向失效；改成贴边后又过钝或过灵敏。根因不是阈值调得不好，而是窗口不再盖住副屏。

关联：#222（更早的「只能出现在主屏」；6.6 单屏方案没有把 6.55 的可用拖拽找回来）

## 本 PR 做什么

在当前 `main` 上恢复 6.55 的巨窗并集，**不整树回退 6.55**，6.6 之后的 PTT、气泡锁、云端 ASR/TTS 等无关功能不动。

- `live-2d/main.js`：`computePetWindowBounds` 按显示器并集建窗；恢复 `window-move`；`move-window-to-display` 不再把窗口缩回单屏
- 多屏机器即使没开 `screen_extend.extend`，也默认盖住全部屏幕（相对 6.55 的唯一行为调整，避免必须手改配置）
- `js/avatar/live2d/interaction.js` / `js/avatar/vrm/interaction.js`：拖拽主路径不再贴边切屏；回弹按整块巨窗判断，已经在副屏画布区的模型不会弹回主屏
- `ui-controller.js`：聊天框/字幕重新锚到**主屏**右下，避免巨窗把对话框拉到副屏最右侧
- 复位皮套按主屏宽度落在主屏右侧，不用巨窗宽度去乘

## 测试

静态：6 个 JS 文件 `node --check` 已过；diff 无密钥、无本机路径。

双屏实机请勾：

- [ ] 主屏按住皮套拖过接缝，不松手时副屏上能看见；松手留在副屏，不弹回
- [ ] 从副屏拖回主屏同样可见
- [ ] 副屏在左（负坐标）也能拖过去
- [ ] 聊天框/字幕仍在主屏右下
- [ ] 复位后模型回到主屏右侧，不飞出屏幕
- [ ] 只有一块屏时行为正常

未在真实双屏机器上点过之前，请勿把本 PR 写成「副屏已验收」。