### PR TITLE
优化：完善本地模块下载与终端控制

### DIFF
--- a/full-hub/omni_bert_api.py
+++ b/full-hub/omni_bert_api.py
@@ -5,6 +5,8 @@ from pydantic import BaseModel
 import os
 import sys
 import re
+import threading
+import time
 
 # 保存原始stdout和stderr
 original_stdout = sys.stdout
@@ -44,6 +46,15 @@ sys.stdout = TeeOutput(original_stdout, log_file)
 sys.stderr = TeeOutput(original_stderr, log_file)
 
 app = FastAPI()
+
+@app.post("/shutdown")
+async def shutdown_service():
+    """让控制台无需管理员权限即可正常停止 BERT 服务。"""
+    def exit_after_response():
+        time.sleep(0.15)
+        os._exit(0)
+    threading.Thread(target=exit_after_response, daemon=True).start()
+    return {"ok": True}
 
 class TextInput(BaseModel):
     text: str

--- a/live-2d/control-main.js
+++ b/live-2d/control-main.js
@@ -2,6 +2,8 @@ const { app, BrowserWindow, ipcMain, shell, net, dialog } = require('electron');
 const fs = require('fs');
 const path = require('path');
 const { spawn } = require('child_process');
+const { Readable } = require('node:stream');
+const { pipeline } = require('node:stream/promises');
 const http = require('http');
 const nodeNet = require('node:net');
 const { scanLive2DModels, resolveLive2DModel, scanVRMModels } = require('./js/avatar/model-registry');
@@ -133,6 +135,52 @@ const serviceDefinitions = {
 };
 const projectRoot = path.resolve(__dirname, '..');
 const hubRoot = path.join(projectRoot, 'full-hub');
+const projectEnvPython = path.join(projectRoot, 'env', 'python.exe');
+const projectEnvUrl = 'https://modelscope.cn/models/morelle/my-neuro-env/resolve/master/my-neuro-env.tar.gz';
+
+async function ensureProjectPython(sender, service) {
+  if (fs.existsSync(projectEnvPython)) return projectEnvPython;
+  const tempDir = fs.mkdtempSync(path.join(app.getPath('temp'), 'my-neuro-env-'));
+  const archive = path.join(tempDir, 'my-neuro-env.tar.gz');
+  const envDir = path.join(projectRoot, 'env');
+  sendServiceLog(sender, service, '@@ENV_START\n');
+  sendServiceLog(sender, service, '\u672a\u68c0\u6d4b\u5230\u9879\u76ee Python \u73af\u5883\uff0c\u5f00\u59cb\u4e0b\u8f7d morelle/my-neuro-env...\n');
+  try {
+    const response = await net.fetch(projectEnvUrl, { redirect: 'follow' });
+    if (!response.ok || !response.body) throw new Error(`HTTP ${response.status}`);
+    const total = Number(response.headers.get('content-length')) || 0;
+    let received = 0;
+    let lastPercent = -1;
+    const progressStream = new (require('node:stream').Transform)({
+      transform(chunk, _encoding, callback) {
+        received += chunk.length;
+        const percent = total ? Math.min(100, Math.floor(received / total * 100)) : 0;
+        if (percent !== lastPercent) {
+          lastPercent = percent;
+          sendServiceLog(sender, service, `@@ENV_PROGRESS:${percent}:${received}:${total}\n`);
+        }
+        callback(null, chunk);
+      }
+    });
+    await pipeline(Readable.fromWeb(response.body), progressStream, fs.createWriteStream(archive));
+    fs.mkdirSync(envDir, { recursive: true });
+    sendServiceLog(sender, service, '@@ENV_EXTRACT\n');
+    sendServiceLog(sender, service, '\u9879\u76ee Python \u73af\u5883\u4e0b\u8f7d\u5b8c\u6210\uff0c\u6b63\u5728\u89e3\u538b...\n');
+    await new Promise((resolve, reject) => {
+      const child = spawn('tar.exe', ['-xzf', archive, '-C', envDir], { windowsHide: true });
+      let errorText = '';
+      child.stderr.on('data', chunk => { errorText += String(chunk); });
+      child.once('error', reject);
+      child.once('exit', code => code === 0 ? resolve() : reject(new Error(errorText.trim() || `tar.exe ${code}`)));
+    });
+    if (!fs.existsSync(projectEnvPython)) throw new Error('\u89e3\u538b\u540e\u672a\u627e\u5230 env\\python.exe');
+    sendServiceLog(sender, service, '@@ENV_DONE\n');
+    sendServiceLog(sender, service, '\u9879\u76ee Python \u73af\u5883\u5b89\u88c5\u5b8c\u6210\u3002\n');
+    return projectEnvPython;
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
 
 function serviceLaunchDefinition(id) {
   const definition = serviceDefinitions[id];
@@ -167,12 +215,17 @@ function sendServiceLog(sender, service, text) {
 }
 
 async function serviceStatus() {
-  return Promise.all(Object.entries(serviceDefinitions).map(async ([id, definition]) => ({
-    id, name: definition.name, port: definition.port,
-    installed: serviceInstalled(definition),
-    downloading: Boolean(serviceDownloads[id]),
-    running: await portListening(definition.port)
-  })));
+  return Promise.all(Object.entries(serviceDefinitions).map(async ([id, definition]) => {
+    const listening = await portListening(definition.port);
+    const processActive = Boolean(serviceProcesses[id] && serviceProcesses[id].exitCode === null);
+    return {
+      id, name: definition.name, port: definition.port,
+      installed: serviceInstalled(definition),
+      downloading: Boolean(serviceDownloads[id]),
+      running: listening || processActive,
+      starting: processActive && !listening
+    };
+  }));
 }
 
 async function stopConfiguredServices() {
@@ -705,16 +758,49 @@ ipcMain.handle('control:stop-service', async (event, id) => {
   const uniquePids = [...new Set(pids)];
   if (!uniquePids.length) return { ok: false, message: `${definition.name} 未在运行` };
   sendServiceLog(event.sender, id, `正在停止 ${definition.name}...\n`);
-  await Promise.all(uniquePids.map(pid => new Promise(resolve => {
-    const killer = spawn('taskkill.exe', ['/pid', pid, '/t', '/f'], { windowsHide: true });
-    killer.on('error', resolve);
-    killer.on('exit', resolve);
-  })));
+  if (id === 'bert') {
+    try {
+      await net.fetch('http://127.0.0.1:6007/shutdown', {
+        method: 'POST',
+        signal: AbortSignal.timeout(1500)
+      });
+      await new Promise(resolve => setTimeout(resolve, 500));
+      if (!(await portListening(definition.port))) {
+        serviceProcesses[id] = null;
+        sendServiceLog(event.sender, id, `${definition.name} 已停止\n`);
+        return { ok: true, message: `${definition.name} 已停止` };
+      }
+    } catch (_) {
+      // 旧版 BERT 服务没有退出接口时，继续使用进程结束兜底。
+    }
+  }
+  const stopResults = await Promise.allSettled(uniquePids.map(pid =>
+    runProcess('taskkill.exe', ['/pid', pid, '/t', '/f'])
+  ));
+  await new Promise(resolve => setTimeout(resolve, 300));
+  let remainingPids = await listeningPids(definition.port);
+  if (remainingPids.length) {
+    await Promise.allSettled(remainingPids.map(pid =>
+      runProcess('taskkill.exe', ['/pid', pid, '/f'])
+    ));
+    await new Promise(resolve => setTimeout(resolve, 500));
+    remainingPids = await listeningPids(definition.port);
+  }
+  if (remainingPids.length) {
+    const errors = stopResults
+      .filter(result => result.status === 'rejected')
+      .map(result => result.reason?.message)
+      .filter(Boolean)
+      .join('；');
+    const message = `${definition.name} 停止失败，端口 ${definition.port} 仍被 PID ${remainingPids.join(', ')} 占用${errors ? `：${errors}` : ''}`;
+    sendServiceLog(event.sender, id, `${message}\n`);
+    return { ok: false, message };
+  }
   serviceProcesses[id] = null;
   sendServiceLog(event.sender, id, `${definition.name} 已停止\n`);
   return { ok: true, message: `${definition.name} 已停止` };
 });
-ipcMain.handle('control:download-service', (event, id) => {
+ipcMain.handle('control:download-service', async (event, id) => {
   const definition = serviceDefinitions[id];
   if (!definition) return { ok: false, message: '未知服务' };
   if (serviceInstalled(definition)) return { ok: false, message: `${definition.name} 已安装` };
@@ -722,7 +808,22 @@ ipcMain.handle('control:download-service', (event, id) => {
   const script = path.join(hubRoot, 'Batch_Download.py');
   if (!fs.existsSync(script)) return { ok: false, message: '找不到 Batch_Download.py' };
   sendServiceLog(event.sender, id, `开始下载 ${definition.name} 模块...\n`);
-  const child = spawn('python.exe', ['-u', script, definition.flag], { cwd: hubRoot, windowsHide: true });
+  serviceDownloads[id] = { exitCode: null };
+  if (!event.sender.isDestroyed()) event.sender.send('control:service-state');
+  let pythonExecutable;
+  try {
+    pythonExecutable = await ensureProjectPython(event.sender, id);
+  } catch (error) {
+    serviceDownloads[id] = null;
+    sendServiceLog(event.sender, id, `\u9879\u76ee Python \u73af\u5883\u5b89\u88c5\u5931\u8d25\uff1a${error.message}\n`);
+    if (!event.sender.isDestroyed()) event.sender.send('control:service-state');
+    return { ok: false, message: `\u9879\u76ee Python \u73af\u5883\u5b89\u88c5\u5931\u8d25\uff1a${error.message}` };
+  }
+  const child = spawn(pythonExecutable, ['-u', script, definition.flag], {
+    cwd: hubRoot,
+    windowsHide: true,
+    env: { ...process.env, PYTHONUTF8: '1', PYTHONIOENCODING: 'utf-8', MY_NEURO_FULL_HUB_DIR: hubRoot }
+  });
   serviceDownloads[id] = child;
   child.stdout.on('data', chunk => sendServiceLog(event.sender, id, chunk));
   child.stderr.on('data', chunk => sendServiceLog(event.sender, id, chunk));

--- a/live-2d/control-renderer.js
+++ b/live-2d/control-renderer.js
@@ -8,6 +8,10 @@ let pluginConfigDirty = false;
 let loadingConfigUi = true;
 let closePromptOpen = false;
 const serviceLogs = { tts: '', asr: '', bert: '' };
+const serviceDownloadProgress = { tts: null, asr: null, bert: null };
+const serviceDownloadActive = { tts: false, asr: false, bert: false };
+const serviceDownloadStage = { tts: null, asr: null, bert: null };
+const serviceDownloadHasEnvironmentStage = { tts: false, asr: false, bert: false };
 let serviceData = [];
 
 const $ = id => document.getElementById(id);
@@ -415,30 +419,157 @@ function render() {
   syncContextConfig();
 }
 
+function serviceLogLineType(line) {
+  if (/\b(ERROR|CRITICAL|FATAL)\b|Traceback|Exception|Error:|错误|失败|无法|找不到|未找到/i.test(line)) return 'error';
+  if (/\b(WARN(?:ING)?)\b|警告|注意/i.test(line)) return 'warning';
+  if (/\b(SUCCESS|DONE)\b|成功|已启动|已停止|下载完成|加载完成/i.test(line)) return 'success';
+  if (/\b(DEBUG|TRACE)\b/i.test(line)) return 'debug';
+  if (/\bINFO\b|正在启动|正在停止|开始下载|Listening|Running on|Uvicorn running/i.test(line)) return 'info';
+  if (/^\s*(File \"|at\s+|\^+)|\.(py|js):\d+/i.test(line)) return 'trace';
+  return 'plain';
+}
+
+function renderServiceLog(output, text) {
+  const cleanText = String(text || '').replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -\/]*[@-~])/g, '');
+  const lines = cleanText.split('\n');
+  const fragment = document.createDocumentFragment();
+  lines.forEach((line, index) => {
+    const span = document.createElement('span');
+    span.className = `service-log-line service-log-${serviceLogLineType(line)}`;
+    span.textContent = line;
+    fragment.appendChild(span);
+    if (index < lines.length - 1) fragment.appendChild(document.createTextNode('\n'));
+  });
+  output.replaceChildren(fragment);
+}
+
 function paintServiceLog() {
   $('service-log-title').textContent = `${activeServiceLog.toUpperCase()} 日志`;
-  $('service-log-output').textContent = serviceLogs[activeServiceLog];
-  $('service-log-output').scrollTop = $('service-log-output').scrollHeight;
+  const output = $('service-log-output');
+  renderServiceLog(output, serviceLogs[activeServiceLog]);
+  output.scrollTop = output.scrollHeight;
+}
+
+function consumeServiceDownloadProgress(service, text) {
+  const cleanText = String(text || '').replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -\/]*[@-~])/g, '');
+  if (!serviceDownloadActive[service]) return cleanText;
+  const parts = cleanText.split(/([\r\n]+)/);
+  for (let index = 0; index < parts.length; index += 2) {
+    const line = parts[index] || '';
+    if (line === '@@ENV_START') {
+      serviceDownloadHasEnvironmentStage[service] = true;
+      serviceDownloadProgress[service] = { percent: 0, stage: '\u6b63\u5728\u4e0b\u8f7d\u9879\u76ee Python \u73af\u5883', detail: '' };
+      continue;
+    }
+    const environmentProgress = line.match(/^@@ENV_PROGRESS:(\d+):(\d+):(\d+)$/);
+    if (environmentProgress) {
+      const filePercent = Number(environmentProgress[1]);
+      const receivedMb = Number(environmentProgress[2]) / 1024 / 1024;
+      const totalMb = Number(environmentProgress[3]) / 1024 / 1024;
+      serviceDownloadProgress[service] = {
+        percent: filePercent * 0.45,
+        stage: '\u6b63\u5728\u4e0b\u8f7d\u9879\u76ee Python \u73af\u5883',
+        detail: totalMb ? `${receivedMb.toFixed(0)}MB/${totalMb.toFixed(0)}MB` : `${receivedMb.toFixed(0)}MB`
+      };
+      continue;
+    }
+    if (line === '@@ENV_EXTRACT') {
+      serviceDownloadProgress[service] = { percent: 47, stage: '\u6b63\u5728\u89e3\u538b\u9879\u76ee Python \u73af\u5883', detail: '' };
+      continue;
+    }
+    if (line === '@@ENV_DONE') {
+      serviceDownloadProgress[service] = { percent: 50, stage: '\u9879\u76ee Python \u73af\u5883\u5b89\u88c5\u5b8c\u6210', detail: '' };
+      continue;
+    }
+    if (line === `@@MODULE_DONE:${service}`) {
+      serviceDownloadProgress[service] = { percent: 100, stage: '\u6a21\u5757\u5b89\u88c5\u5b8c\u6210', detail: '' };
+      continue;
+    }
+    if (service === 'asr') {
+      if (line.includes('morelle/my-neuro-vad')) serviceDownloadStage.asr = { index: 0, name: 'VAD \u6a21\u578b' };
+      else if (line.includes('speech_seaco_paraformer')) serviceDownloadStage.asr = { index: 1, name: 'ASR \u4e3b\u6a21\u578b' };
+      else if (line.includes('punc_ct-transformer')) serviceDownloadStage.asr = { index: 2, name: '\u6807\u70b9\u6a21\u578b' };
+      if (/ASR\u6a21\u578b\u4e0b\u8f7d\u5b8c\u6210/.test(line)) {
+        serviceDownloadProgress.asr = { percent: 100, stage: '\u5168\u90e8\u6a21\u578b\u4e0b\u8f7d\u5b8c\u6210', detail: '' };
+      }
+    }
+    const percentages = [...line.matchAll(/(\d{1,3}(?:\.\d+)?)\s*%/g)];
+    if (!percentages.length) continue;
+    const filePercent = Math.max(0, Math.min(100, Number(percentages.at(-1)[1])));
+    const asrStage = service === 'asr' ? (serviceDownloadStage.asr || { index: 0, name: 'VAD \u6a21\u578b' }) : null;
+    const basePercent = serviceDownloadHasEnvironmentStage[service] ? 50 : 0;
+    const stageCount = asrStage ? 3 : 1;
+    const stageIndex = asrStage?.index || 0;
+    let percent = basePercent + (stageIndex + Math.min(filePercent, 99) / 100) * ((100 - basePercent) / stageCount);
+    percent = Math.min(99, percent);
+    percent = Math.max(serviceDownloadProgress[service]?.percent || 0, percent);
+    const stageMatch = line.match(/([^:：|]{1,24})(?:[:：]|\s*\|)/);
+    const detailMatch = line.match(/\(([^)]+)\)/);
+    serviceDownloadProgress[service] = {
+      percent,
+      stage: (stageMatch?.[1] || (line.includes('解压') ? '正在解压' : '正在下载')).trim(),
+      detail: detailMatch?.[1] || ''
+    };
+    if (asrStage) serviceDownloadProgress[service].stage = `\u6b63\u5728\u4e0b\u8f7d${asrStage.name}`;
+  }
+  return cleanText
+    .replace(/^@@ENV_(?:START|EXTRACT|DONE|PROGRESS:[^\r\n]*)[\r\n]*/gm, '')
+    .replace(new RegExp(`^@@MODULE_(?:START|DONE|FAIL):${service}[\\r\\n]*`, 'gm'), '')
+    .replace(/\r/g, '\n');
 }
 
 function renderActiveService() {
   const service = serviceData.find(item => item.id === activeServiceLog);
+  const progress = service ? serviceDownloadProgress[service.id] : null;
+  const progressPercent = progress?.percent ?? 0;
+  const progressDetail = progress
+    ? `${progress.stage} · ${Math.round(progressPercent)}%${progress.detail ? ` · ${progress.detail}` : ''}`
+    : '正在准备下载，请稍候…';
+  const progressMarkup = service?.downloading
+    ? `<div class="service-download-progress"><div class="service-download-meta"><span>${escapeHtml(progressDetail)}</span>${progress ? `<strong>${Math.round(progressPercent)}%</strong>` : ''}</div><div class="service-progress-track"><i class="${progress ? '' : 'indeterminate'}" style="width:${progress ? progressPercent : 32}%"></i></div></div>`
+    : '';
   $('service-list').innerHTML = service
-    ? `<article class="service card" data-service="${service.id}"><div class="service-info"><b>${service.name}</b><small class="${service.running ? 'running' : ''}">${service.downloading ? '正在下载' : service.running ? '运行中' : service.installed ? '未启动' : '未安装'} · 端口 ${service.port}</small></div><div class="service-actions">${service.installed ? `<button data-service-action="start" ${service.running ? 'disabled' : ''}>启动</button><button data-service-action="stop" ${service.running ? '' : 'disabled'}>停止</button>` : `<button data-service-action="download" ${service.downloading ? 'disabled' : ''}>${service.downloading ? '下载中' : '下载模块'}</button>`}</div></article>`
+    ? `<article class="service card ${service.downloading ? 'is-downloading' : ''}" data-service="${service.id}"><div class="service-info"><b>${service.name}</b><small class="${service.running ? 'running' : ''}">${service.downloading ? '正在下载模块' : service.starting ? '正在启动' : service.running ? '运行中' : service.installed ? '未启动' : '未安装'} · 端口 ${service.port}</small>${progressMarkup}</div><div class="service-actions">${service.installed ? `<button data-service-action="start" ${service.running ? 'disabled' : ''}>启动</button><button data-service-action="stop" ${service.running ? '' : 'disabled'}>停止</button>` : `<button data-service-action="download" ${service.downloading ? 'disabled' : ''}>${service.downloading ? '下载中…' : '下载模块'}</button>`}</div></article>`
     : '<div class="empty"><p>暂无模块信息</p></div>';
-  document.querySelectorAll('[data-service-action]').forEach(button => button.addEventListener('click', async () => {
-    const id = button.closest('[data-service]').dataset.service;
-    button.disabled = true;
-    const action = button.dataset.serviceAction;
-    const result = action === 'start' ? await window.controlApi.startService(id) : action === 'stop' ? await window.controlApi.stopService(id) : await window.controlApi.downloadService(id);
-    showToast(result.message);
-    setTimeout(refreshServiceStatus, action === 'start' ? 1200 : 250);
-  }));
 }
+
+$('service-list').addEventListener('click', async event => {
+  const button = event.target.closest('[data-service-action]');
+  if (!button || button.disabled) return;
+  const service = button.closest('[data-service]');
+  if (!service) return;
+  const id = service.dataset.service;
+  const action = button.dataset.serviceAction;
+  button.disabled = true;
+  if (action === 'download') {
+    serviceDownloadProgress[id] = null;
+    serviceDownloadStage[id] = null;
+    serviceDownloadHasEnvironmentStage[id] = false;
+    serviceDownloadActive[id] = true;
+    button.textContent = '正在准备…';
+  }
+  if (action === 'stop') {
+    button.textContent = '正在停止...';
+    showToast('正在停止服务...');
+  }
+  try {
+    const result = action === 'start'
+      ? await window.controlApi.startService(id)
+      : action === 'stop'
+        ? await window.controlApi.stopService(id)
+        : await window.controlApi.downloadService(id);
+    showToast(result.message);
+  } catch (error) {
+    showToast(`操作失败：${error.message}`);
+  } finally {
+    await refreshServiceStatus();
+  }
+});
 
 async function refreshServiceStatus() {
   try {
     serviceData = await window.controlApi.serviceStatus();
+    serviceData.forEach(service => { serviceDownloadActive[service.id] = service.downloading; });
     renderActiveService();
   } catch (error) { showToast(`服务状态读取失败：${error.message}`); }
 }
@@ -452,8 +583,12 @@ document.querySelectorAll('[data-service-tab]').forEach(button => button.addEven
 }));
 $('clear-service-log').addEventListener('click', () => { serviceLogs[activeServiceLog] = ''; paintServiceLog(); });
 window.controlApi.onServiceLog(({ service, text }) => {
-  serviceLogs[service] = (serviceLogs[service] + text).slice(-120000);
-  if (service === activeServiceLog) paintServiceLog();
+  const logText = consumeServiceDownloadProgress(service, text);
+  serviceLogs[service] = (serviceLogs[service] + logText).slice(-120000);
+  if (service === activeServiceLog) {
+    paintServiceLog();
+    renderActiveService();
+  }
 });
 window.controlApi.onServiceState(refreshServiceStatus);
 

--- a/live-2d/css/control-refined.css
+++ b/live-2d/css/control-refined.css
@@ -278,16 +278,32 @@ button:hover { background: #f0ece4; }
 #services .service-info b { color:#403a32; font-size:16px; }
 #services .service-info small { color:#91897e; }
 #services .service-info small.running { color:#b67818; }
+#services .service.is-downloading { border-color:#e0c99f; box-shadow:0 8px 22px rgba(139,100,39,.1); }
+#services .service-download-progress { width:min(620px,100%); margin-top:3px; }
+#services .service-download-meta { display:flex; align-items:center; justify-content:space-between; gap:14px; margin-bottom:7px; color:#71685b; font-size:13px; }
+#services .service-download-meta span { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+#services .service-download-meta strong { flex:none; color:#b56a12; font-variant-numeric:tabular-nums; }
+#services .service-progress-track { position:relative; height:9px; overflow:hidden; border-radius:999px; background:#e9e3d9; box-shadow:inset 0 1px 2px rgba(68,53,31,.1); }
+#services .service-progress-track i { display:block; height:100%; border-radius:inherit; background:linear-gradient(90deg,#dc9637,#efa848); box-shadow:0 0 8px rgba(222,145,47,.3); transition:width .22s ease; }
+#services .service-progress-track i.indeterminate { position:absolute; animation:service-download-moving 1.25s ease-in-out infinite; }
+@keyframes service-download-moving { from { transform:translateX(-110%); } to { transform:translateX(330%); } }
 #services .service-actions { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:8px; }
 #services .service-actions button:only-child { grid-column:1/-1; }
 #services .service-console { display:flex; flex-direction:column; min-width:0; min-height:0; overflow:hidden; padding:0; }
 .service-log-tabs { display:flex; align-items:center; min-height:50px; padding:6px 8px; border-bottom:1px solid #e2dbcf; }
-.service-log-tabs strong { padding-left:8px; color:#5f574c; font-size:14px; }
+.service-log-tabs strong { padding-left:8px; color:#403a32; font-size:15px; font-weight:700; }
 .service-log-tabs button { min-height:36px; padding:7px 14px; border:0; background:transparent; box-shadow:none; color:#756d62; }
 .service-log-tabs button:hover { background:#eee9e0; transform:none; }
 .service-log-tabs button.active { background:#8e8473; color:#fff; }
 .service-log-tabs .service-log-clear { margin-left:auto; color:#81786c; }
-#service-log-output { flex:1; min-height:0; margin:0; padding:16px; overflow:auto; background:#fcfbf8; color:#625b50; white-space:pre-wrap; overflow-wrap:anywhere; font:13px/1.65 Consolas,monospace; user-select:text; }
+#service-log-output { flex:1; min-height:0; margin:0; padding:18px 20px; overflow:auto; background:#f8f6f1; color:#37322c; white-space:pre-wrap; overflow-wrap:anywhere; font:500 15px/1.75 "Cascadia Mono","Microsoft YaHei UI",Consolas,monospace; letter-spacing:.01em; user-select:text; }
+#service-log-output .service-log-line { color:#37322c; }
+#service-log-output .service-log-info { color:#246b95; }
+#service-log-output .service-log-success { color:#27824f; font-weight:650; }
+#service-log-output .service-log-warning { color:#b56a12; font-weight:650; }
+#service-log-output .service-log-error { color:#c13d36; font-weight:650; }
+#service-log-output .service-log-trace { color:#a64e49; }
+#service-log-output .service-log-debug { color:#81786c; }
 .log-panel { display:flex; flex-direction:column; min-width:0; min-height:0; height:100%; overflow:hidden; }
 .log-panel header { display:flex; align-items:center; justify-content:space-between; min-height:53px; padding:8px 15px; color:#5c5448; border-color:#e7e0d5; }
 .log-trash { display:grid; place-items:center; width:36px; height:34px; min-height:0; padding:0; border:0; border-radius:7px; background:transparent; color:#82796d; box-shadow:none; }


### PR DESCRIPTION
## 本次改动
- 修复 BERT 服务停止后端口仍被占用的问题
- 支持在 BERT 启动过程中直接停止
- 优化终端日志字号、对比度和级别颜色
- 增加模块下载进度条及 ASR 分阶段进度
- 下载 ASR、TTS、BERT 前自动安装项目 Python 环境
- 模型下载统一使用项目内 env\\python.exe

## 检查
- Node.js 语法检查通过
- Python 语法检查通过
- Git 差异检查通过