### PR TITLE
fix: prevent circular project links during Electron packaging

### DIFF
--- a/live-2d/scripts/package-electron-ui.ps1
+++ b/live-2d/scripts/package-electron-ui.ps1
@@ -60,8 +60,16 @@ $builderCli = Join-Path (Split-Path -Parent $projectDir) 'electron-installer\nod
 if (-not (Test-Path -LiteralPath $builderCli)) {
     $builderCli = Join-Path $toolsDir 'node_modules\electron-builder\cli.js'
     if (-not (Test-Path -LiteralPath $builderCli)) {
-        & npm.cmd install --prefix $toolsDir --no-audit --no-fund
-        if ($LASTEXITCODE -ne 0) { throw 'Failed to install electron-builder.' }
+        # Run inside the tools package. With some npm versions, installing
+        # from the project root using --prefix links the root into node_modules,
+        # creating a directory cycle that breaks ZIP archiving.
+        Push-Location -LiteralPath $toolsDir
+        try {
+            & npm.cmd install --no-audit --no-fund
+            if ($LASTEXITCODE -ne 0) { throw 'Failed to install electron-builder.' }
+        } finally {
+            Pop-Location
+        }
     }
 }
 & node.exe $builderCli --projectDir $toolsDir --config $configPath --win portable --x64


### PR DESCRIPTION
Installing build tools with npm --prefix from the live-2d root could add combined-project as a local dependency pointing back to the root, creating a directory cycle that breaks ZIP compression. Run npm install inside the build-tools directory with Push-Location and restore the working directory in finally.

Validation: PowerShell syntax and git whitespace checks. On the affected local installation, removed the circular junction and stale dependency records, then traversed 6097 files with no remaining links. Existing affected installations need their previously created junction and dependency records cleaned separately. Only the packaging script is changed.