### PR TITLE
修复 TTS 模块解压时的日志编码异常

### DIFF
--- a/full-hub/Batch_Download.py
+++ b/full-hub/Batch_Download.py
@@ -135,13 +135,14 @@ def extract_7z(archive_file, target_folder):
                 print(f"下载7z失败: {e}")
                 return False
         print('正在解压TTS模型包，这可能需要几分钟时间.......')
-        cmd = f'"{local_7z}" x "{archive_file}" -o"{target_folder}" -y'
-        result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+        # Capture bytes: 7z output may use a Windows code page even with PYTHONUTF8=1.
+        cmd = [local_7z, "x", archive_file, f"-o{target_folder}", "-y"]
+        result = subprocess.run(cmd, capture_output=True)
         if result.returncode == 0:
             print("\n解压完成!")
             return True
         else:
-            print(f"\n解压失败: {result.stderr}")
+            print("\n解压失败: " + result.stderr.decode("utf-8", errors="replace"))
             return False
     except Exception as e:
         print(f"解压过程中出错: {e}")


### PR DESCRIPTION
通过 Electron 下载 TTS 模块时，Python 启用了 UTF-8 模式，但 7z 可能输出 Windows 本地编码。解压本身成功时，读取日志的线程仍会抛出 UnicodeDecodeError，造成安装失败的误解。

本次将 7z 输出按字节捕获，错误信息使用容错解码，并以参数列表直接启动 7z。仍根据解压进程退出码判断成功或失败，不会将真正的解压失败误报为成功。

验证：
- 使用实际子进程输出非 UTF-8 字节，验证退出码 0 和非零两种情况。
- Python 语法及 Git 差异格式检查通过。
- 报错安装目录中的关键 TTS 文件已检查存在；未重新下载大型模型包。