### PR TITLE
安装器：完成后提供打开程序文件夹按钮

### DIFF
--- a/electron-installer/main.js
+++ b/electron-installer/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, dialog } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog, shell } = require('electron');
 const fs = require('node:fs');
 const path = require('node:path');
 const https = require('node:https');
@@ -72,6 +72,22 @@ async function resolveLatestLive2D(log, fetchPage = fetchReleasePage) {
 }
 let mainWindow;
 let installing = false;
+let completedProgramDir = null;
+
+async function openInstalledFolder() {
+  try {
+    if (!completedProgramDir) throw new Error('请等待安装成功后再打开程序文件夹');
+    if (!fs.existsSync(completedProgramDir)) throw new Error('程序文件夹不存在，可能已被移动或删除');
+    const executable = path.join(completedProgramDir, '肥牛.exe');
+    if (fs.existsSync(executable)) {
+      shell.showItemInFolder(executable);
+    } else {
+      const error = await shell.openPath(completedProgramDir);
+      if (error) throw new Error(error);
+    }
+    return {success:true};
+  } catch (error) { return {success:false,message:error.message}; }
+}
 
 function defaultInstallDir() {
   const localAppData = process.env.LOCALAPPDATA || path.join(app.getPath('home'), 'AppData', 'Local');
@@ -280,6 +296,7 @@ async function installLive2D(installDir, log, release) {
 }
 
 async function install(request) {
+  completedProgramDir = null;
   // 安装器现在固定使用云端版。旧版版本判断保留供以后恢复：
   // const edition = request?.edition === 'cloud' ? 'cloud' : 'local';
   // const components = Array.isArray(request?.components) ? request.components : [];
@@ -314,6 +331,7 @@ async function install(request) {
   await installLive2D(installDir, log, release);
   send({type:'progress',overall:100,label:'云端版安装完成'});
   log('云端版安装成功');
+  completedProgramDir = path.join(installDir, 'live-2d');
   send({type:'done',logPath});
   return;
 
@@ -446,6 +464,7 @@ ipcMain.handle('choose-install-dir', (_event, currentDir) => {
 });
 ipcMain.on('window-minimize', () => mainWindow?.minimize());
 ipcMain.on('window-close', () => mainWindow?.close());
+ipcMain.handle('open-installed-folder', openInstalledFolder);
 ipcMain.handle('start-install', async (_event, request) => {
   if (installing) return {accepted:false};
   installing = true;

--- a/electron-installer/preload.js
+++ b/electron-installer/preload.js
@@ -5,6 +5,7 @@ contextBridge.exposeInMainWorld('installer', {
   // 本地版显卡检测接口，暂时停用：
   // inspectSystem: () => ipcRenderer.invoke('inspect-system'),
   getDefaultInstallDir: () => ipcRenderer.invoke('get-default-install-dir'),
+  openInstalledFolder: () => ipcRenderer.invoke('open-installed-folder'),
   chooseInstallDir: currentDir => ipcRenderer.invoke('choose-install-dir', currentDir),
   start: components => ipcRenderer.invoke('start-install', components),
   onStatus: callback => {

--- a/electron-installer/renderer/app.js
+++ b/electron-installer/renderer/app.js
@@ -4,6 +4,16 @@ bar.querySelector('.window-close').addEventListener('click',()=>window.installer
 
 const edition='cloud';
 const next=document.querySelector('#next');
+const openFolder=document.querySelector('#open-folder');
+openFolder.addEventListener('click',async()=>{
+  openFolder.disabled=true;
+  try{
+    const result=await window.installer.openInstalledFolder();
+    if(!result.success)throw new Error(result.message);
+  }catch(error){
+    window.alert(`无法打开程序文件夹：${error.message}`);
+  }finally{openFolder.disabled=false}
+});
 const installDir=document.querySelector('#install-dir');
 // 本地版模块列表暂时停用，保留供以后恢复：
 // const modules=['live2d','bert','tts','asr'];
@@ -34,6 +44,6 @@ window.installer.onStatus(status=>{
   if(status.type==='progress'){const pct=Math.floor(status.overall);document.querySelector('#module-track').style.setProperty('--track-progress',`${Math.max(0,Math.min(100,status.overall))}%`);document.querySelector('#percent').textContent=`${pct}%`;document.querySelector('#task').textContent=status.label}
   if(status.type==='module-status'){const node=document.querySelector(`[data-module="${status.module}"]`);if(node){node.className=`module-node ${status.status}`;node.querySelector('small').textContent=status.status==='start'?'下载中':status.status==='done'?'已完成':'失败'}}
   if(status.type==='log'){const log=document.querySelector('#log');log.textContent+=status.message+'\n';log.scrollTop=log.scrollHeight}
-  if(status.type==='done'){document.querySelector('#done-message').textContent='打开 live-2d 文件夹，双击“肥牛.exe”即可使用。';next.textContent='关闭';next.hidden=false;show('done')}
-  if(status.type==='error'){document.querySelector('#done').classList.add('error');document.querySelector('#done-icon').textContent='×';document.querySelector('#done-title').textContent='安装失败';document.querySelector('#done-message').textContent=status.message;next.textContent='关闭';next.hidden=false;show('done')}
+  if(status.type==='done'){document.querySelector('#done-message').textContent='点击“打开程序文件夹”，双击“肥牛.exe”即可使用。';openFolder.hidden=false;next.textContent='关闭';next.hidden=false;show('done')}
+  if(status.type==='error'){openFolder.hidden=true;document.querySelector('#done').classList.add('error');document.querySelector('#done-icon').textContent='×';document.querySelector('#done-title').textContent='安装失败';document.querySelector('#done-message').textContent=status.message;next.textContent='关闭';next.hidden=false;show('done')}
 });

--- a/electron-installer/renderer/index.html
+++ b/electron-installer/renderer/index.html
@@ -4,5 +4,5 @@
 <section id="welcome" class="page shown"><div class="install-hero"><div class="app-logo"><span>N</span></div><h1>安装 My-Neuro</h1></div><!-- 旧版版本选择入口，暂时保留供以后恢复：<div class="edition-list"><button class="edition" data-edition="cloud"><strong>云端版</strong><span>下载程序源码，使用云端服务</span></button><button class="edition" data-edition="local"><strong>本地版</strong><span>下载程序源码、本地环境和模型</span></button></div> --><div class="install-location"><label for="install-dir">安装到</label><div><input id="install-dir" type="text" spellcheck="false" aria-label="安装位置"><button id="browse-dir" type="button">选择位置</button></div></div></section>
 <section id="installing" class="page"><div class="page-head"><h1>正在安装</h1></div><div class="progress-hero"><b id="percent">0%</b><p id="task">准备中…</p></div><div id="module-track" class="module-track"></div><details><summary>详细信息</summary><pre id="log"></pre></details></section>
 <section id="done" class="page hero"><div id="done-icon" class="done-icon">✓</div><h1 id="done-title">安装完成</h1><p id="done-message"></p></section>
-<footer><button id="next">开始安装</button></footer>
+<footer><button id="open-folder" type="button" hidden>打开程序文件夹</button><button id="next">开始安装</button></footer>
 </main><script src="app.js"></script></body></html>


### PR DESCRIPTION
安装完成后，用户需要手动查找安装位置才能启动程序。现在完成页提供“打开程序文件夹”按钮，打开实际安装目录下的 live-2d 文件夹，并在资源管理器中选中“肥牛.exe”，方便用户双击启动；该按钮不会运行 EXE。

- 只在安装成功后显示按钮，保留“关闭”按钮。
- 主进程记录实际安装目录，支持自定义安装位置；EXE 不存在时仍打开文件夹。
- 目录被移动或删除、打开失败时显示提示，安装未完成时拒绝打开。

验证：三个 JavaScript 文件语法检查及 diff 检查通过；模拟验证自定义路径、选中 EXE、文件夹回退、打开失败、目录不存在和安装未完成等情况。