### PR TITLE
fix: import logger in tool_manager.py to prevent NameError in error handlers

### DIFF
--- a/live-2d/webui/tool_manager.py
+++ b/live-2d/webui/tool_manager.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from flask import Blueprint, request, jsonify
 from .state_io import atomic_write_json, resource_lock
+from .utils import logger
 
 # 设置项目根目录
 PROJECT_ROOT = Path(__file__).parent.parent.absolute()


### PR DESCRIPTION
### Problem

`live-2d/webui/tool_manager.py` calls `logger.error(...)` in three exception handlers, but `logger` is never imported or defined in this module:

- line 114 — `except Exception as e: logger.error(f'读取外部 MCP 工具失败：{e}')`
- line 244 — `except Exception as e: logger.error(f'切换工具状态失败：{e}')`
- line 262 — `except Exception as e: logger.error(f'获取模型列表失败：{e}')`

Because `logger` is undefined in this file's namespace, each of these handlers raises `NameError: name 'logger' is not defined` when its `except` branch runs — turning a recoverable, logged failure into a hard crash and hiding the original exception.

### Root cause

Every other module in `live-2d/webui/` imports the shared logger from `.utils` (which defines `logger = logging.getLogger(__name__)` at `utils.py:34`), e.g.:

```python
# avatar_manager.py, config_manager.py, live2d_manager.py, marketplace.py,
# plugin_manager.py, telemetry.py, updater.py, main_app.py, ...
from .utils import PROJECT_ROOT, logger
```

`tool_manager.py` imports `atomic_write_json, resource_lock` from `.state_io` and defines its own local `PROJECT_ROOT`, but the `logger` import was dropped, while three call sites still reference it.

### Fix

Import the shared logger, matching the sibling modules:

```diff
 from flask import Blueprint, request, jsonify
 from .state_io import atomic_write_json, resource_lock
+from .utils import logger
```

One-line import; no behavior change other than the error handlers now logging correctly instead of raising `NameError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
