### PR TITLE
fix: 修复教程启动器缺少依赖报错并自动打开网页

### DIFF
--- a/打开教程网页.bat
+++ b/打开教程网页.bat
@@ -1,15 +1,67 @@
-@echo off
+﻿@echo off
 chcp 65001 >nul
+setlocal
 cd /d "%~dp0"
+
 if exist "docs\.vitepress\dist\index.html" (
     start "" "%~dp0docs\.vitepress\dist\index.html"
     echo 已打开构建好的 WebUI 教程站。
-    timeout /t 2 >nul
+    ping 127.0.0.1 -n 2 >nul
     exit /b 0
 )
-echo 未找到构建产物。正在启动本地预览（需要 Node.js）...
-echo 浏览器打开终端里显示的 localhost 地址即可。
-echo 官网旧教程仍在: http://mynewbot.com/tutorials
+
+echo 未找到构建产物。正在准备本地预览（需要 Node.js）...
+
+where node >nul 2>&1
+if errorlevel 1 (
+    echo [错误] 未找到 Node.js。请先安装 Node.js 20 或更新版本。
+    echo 官网旧教程仍在: http://mynewbot.com/tutorials
+    pause
+    exit /b 1
+)
+
+if not exist "docs\package.json" (
+    echo [错误] 未找到 docs\package.json
+    pause
+    exit /b 1
+)
+
+if not exist "docs\node_modules\.bin\vitepress.cmd" (
+    echo 首次打开或文档依赖不完整，正在安装 vitepress...
+    pushd docs
+    call npm install
+    if errorlevel 1 (
+        popd
+        echo [错误] 文档依赖安装失败。请检查网络后重试。
+        pause
+        exit /b 1
+    )
+    popd
+)
+
+curl.exe -s -o nul -m 2 http://localhost:5173/ >nul 2>&1
+if not errorlevel 1 goto :open_browser
+
+echo 正在启动教程站...
 cd /d "%~dp0docs"
 start "my-neuro-docs" cmd /k "npm run docs:dev"
+
+echo 正在等待教程站就绪，随后会自动弹出浏览器...
+set /a _n=0
+:wait_docs
+ping 127.0.0.1 -n 2 >nul
+set /a _n+=1
+curl.exe -s -o nul -m 2 http://localhost:5173/ >nul 2>&1
+if not errorlevel 1 goto :open_browser
+if %_n% geq 60 (
+    echo [错误] 教程站启动超时。请查看 my-neuro-docs 窗口里的报错。
+    echo 官网旧教程仍在: http://mynewbot.com/tutorials
+    pause
+    exit /b 1
+)
+goto :wait_docs
+
+:open_browser
+start "" "http://localhost:5173/"
+echo 已自动打开教程网页: http://localhost:5173/
 exit /b 0


### PR DESCRIPTION
在没有文档构建产物、也没有安装 docs 依赖的 Windows 副本中，原启动器直接执行 `npm run docs:dev`，会出现 `vitepress` 不是内部或外部命令的报错；启动服务后还需要用户手动打开网址。本 PR 将本地已有修复同步到根目录 `打开教程网页.bat`。

- 保留已有 `docs/.vitepress/dist/index.html` 时直接打开静态教程的路径。
- 增加 Node.js、`docs/package.json` 检查；缺少 `docs/node_modules/.bin/vitepress.cmd` 时在 `docs` 目录执行 `call npm install`，失败后显示中文提示并暂停。
- 使用 `curl.exe` 探测 `http://localhost:5173/`，在服务响应后自动打开浏览器；未响应时启动文档服务并有限次等待，超时后提示查看服务窗口。
- 仅修改根目录启动器，保留本地版本的 UTF-8 BOM；教程正文、依赖声明和 `live-2d` 转调入口均保持原样。

验证：复制后的文件与本地修复逐字节一致，Git 暂存内容与源文件一致（仅 Git 换行规范化），`git diff --cached --check` 通过；相对上游 `main` 仅此一个文件变化。

本次未执行 Windows 双击、依赖安装、服务启动或浏览器实机验收，实机验证由后续验证者完成。该版本沿用本地修复的 `curl.exe` 与固定 `localhost:5173` 探测，端口占用等运行场景尚待实机确认。
