### PR TITLE
fix: 教程启动器正常后台运行，失败时显示错误日志

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
-# Preserve CRLF in this launcher, including raw-file and source-archive downloads.
+# Preserve CRLF in Windows launchers, including raw-file and source-archive downloads.
 "/打开教程网页.bat" -text whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
+docs/scripts/open-tutorial.cmd -text whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
+docs/scripts/open-tutorial.vbs -text whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Preserve CRLF in this launcher, including raw-file and source-archive downloads.
+"/打开教程网页.bat" -text whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol

--- a/docs/scripts/open-tutorial.cmd
+++ b/docs/scripts/open-tutorial.cmd
@@ -1,0 +1,135 @@
+@echo off
+chcp 65001 >nul
+setlocal DisableDelayedExpansion
+cd /d "%~dp0..\.."
+
+if /i "%~1"=="--error" goto :show_error
+if not defined MY_NEURO_DOCS_LOG_DIR exit /b 1
+if not exist "%MY_NEURO_DOCS_LOG_DIR%\" exit /b 1
+if /i "%~1"=="--server" goto :server
+
+call :launch >"%MY_NEURO_DOCS_LOG_DIR%\launcher.log" 2>&1
+exit /b %errorlevel%
+
+:launch
+if exist "docs\.vitepress\dist\index.html" (
+    start "" "%cd%\docs\.vitepress\dist\index.html"
+    if errorlevel 1 (
+        echo [错误] 无法打开已经构建的教程页面。
+        exit /b 1
+    )
+    exit /b 0
+)
+
+where.exe node >nul 2>&1
+if errorlevel 1 (
+    echo [错误] 未找到 Node.js。请先安装 Node.js 20 或更新版本。
+    exit /b 1
+)
+
+where.exe npm.cmd >nul 2>&1
+if errorlevel 1 (
+    echo [错误] 未找到 npm。请检查 Node.js 安装是否完整。
+    exit /b 1
+)
+
+if not exist "docs\package.json" (
+    echo [错误] 未找到 docs\package.json。
+    exit /b 1
+)
+
+where.exe curl.exe >nul 2>&1
+if errorlevel 1 (
+    echo [错误] 未找到 curl.exe，无法检查教程站是否就绪。
+    exit /b 1
+)
+
+if not exist "docs\node_modules\.bin\vitepress.cmd" (
+    echo 首次打开或文档依赖不完整，正在安装 vitepress...
+    pushd docs
+    call npm.cmd install
+    if errorlevel 1 (
+        popd
+        echo [错误] 文档依赖安装失败。请检查网络后重试。
+        exit /b 1
+    )
+    popd
+)
+
+if not exist "docs\node_modules\.bin\vitepress.cmd" (
+    echo [错误] 安装结束后仍未找到 vitepress，请检查上面的安装输出。
+    exit /b 1
+)
+
+set "MY_NEURO_DOCS_URL=http://localhost:5173/"
+curl.exe --fail --silent --output nul --max-time 2 "%MY_NEURO_DOCS_URL%" >nul 2>&1
+if not errorlevel 1 goto :open_browser
+
+echo 正在后台启动教程站...
+start "" /b "%ComSpec%" /d /c docs\scripts\open-tutorial.cmd --server <nul
+if errorlevel 1 (
+    echo [错误] 无法启动教程服务进程。
+    exit /b 1
+)
+
+set /a _attempt=0 >nul
+:wait_docs
+if exist "%MY_NEURO_DOCS_LOG_DIR%\server-exit.txt" (
+    echo [错误] 教程服务在就绪前已经退出。退出码:
+    type "%MY_NEURO_DOCS_LOG_DIR%\server-exit.txt"
+    exit /b 1
+)
+curl.exe --fail --silent --output nul --max-time 2 "%MY_NEURO_DOCS_URL%" >nul 2>&1
+if not errorlevel 1 goto :open_browser
+set /a _attempt+=1 >nul
+if %_attempt% geq 60 (
+    echo [错误] 等待教程站就绪超时，请查看下面的服务日志。
+    exit /b 1
+)
+ping 127.0.0.1 -n 2 >nul
+goto :wait_docs
+
+:open_browser
+start "" "%MY_NEURO_DOCS_URL%"
+if errorlevel 1 (
+    echo [错误] 教程站已就绪，但无法打开默认浏览器。
+    exit /b 1
+)
+exit /b 0
+
+:server
+call :serve >"%MY_NEURO_DOCS_LOG_DIR%\server.log" 2>&1
+set "_server_exit=%errorlevel%"
+>"%MY_NEURO_DOCS_LOG_DIR%\server-exit.txt" echo %_server_exit%
+exit /b %_server_exit%
+
+:serve
+cd /d "%cd%\docs"
+call npm.cmd run docs:dev -- --host localhost --port 5173 --strictPort
+exit /b %errorlevel%
+
+:show_error
+title my-neuro tutorial error
+echo [错误] 教程网页未能打开。
+echo.
+if defined MY_NEURO_DOCS_BOOTSTRAP_ERROR echo 后台启动失败，Windows 错误码: %MY_NEURO_DOCS_BOOTSTRAP_ERROR%
+if not defined MY_NEURO_DOCS_LOG_DIR goto :no_log
+echo 日志目录:
+echo "%MY_NEURO_DOCS_LOG_DIR%"
+echo.
+if exist "%MY_NEURO_DOCS_LOG_DIR%\launcher.log" (
+    echo 启动记录:
+    type "%MY_NEURO_DOCS_LOG_DIR%\launcher.log"
+)
+if exist "%MY_NEURO_DOCS_LOG_DIR%\server.log" (
+    echo.
+    echo 服务记录:
+    type "%MY_NEURO_DOCS_LOG_DIR%\server.log"
+)
+echo.
+echo 修正问题后可重新双击打开教程网页.bat。日志已保留，可关闭此窗口。
+exit /b 1
+
+:no_log
+echo 无法创建启动日志，请检查临时目录是否可写，以及 Windows Script Host 是否可用。
+exit /b 1

--- a/docs/scripts/open-tutorial.vbs
+++ b/docs/scripts/open-tutorial.vbs
@@ -1,0 +1,36 @@
+Option Explicit
+
+' Keep the host injectable so error-window routing can be checked without UI.
+Function LaunchTutorial(shell, fso, scriptPath)
+    Dim projectDir, taskEnv, logDir, exitCode, failureCode
+    projectDir = fso.GetParentFolderName(fso.GetParentFolderName(fso.GetParentFolderName(scriptPath)))
+    shell.CurrentDirectory = projectDir
+    Set taskEnv = shell.Environment("PROCESS")
+    taskEnv.Item("MY_NEURO_DOCS_LOG_DIR") = ""
+    taskEnv.Item("MY_NEURO_DOCS_BOOTSTRAP_ERROR") = ""
+    exitCode = 1
+
+    On Error Resume Next
+    logDir = fso.BuildPath(fso.GetSpecialFolder(2), "my-neuro-docs-" & fso.GetTempName)
+    fso.CreateFolder logDir
+    If Err.Number = 0 Then
+        taskEnv.Item("MY_NEURO_DOCS_LOG_DIR") = logDir
+        exitCode = shell.Run("""%ComSpec%"" /d /c docs\scripts\open-tutorial.cmd <nul", 0, True)
+    End If
+    failureCode = Err.Number
+    Err.Clear
+    On Error GoTo 0
+
+    If failureCode <> 0 Then
+        taskEnv.Item("MY_NEURO_DOCS_BOOTSTRAP_ERROR") = CStr(failureCode)
+    End If
+
+    If exitCode <> 0 Or failureCode <> 0 Then
+        shell.Run """%ComSpec%"" /d /k docs\scripts\open-tutorial.cmd --error", 1, False
+        LaunchTutorial = 1
+    Else
+        LaunchTutorial = 0
+    End If
+End Function
+
+WScript.Quit LaunchTutorial(CreateObject("WScript.Shell"), CreateObject("Scripting.FileSystemObject"), WScript.ScriptFullName)

--- a/打开教程网页.bat
+++ b/打开教程网页.bat
@@ -1,4 +1,4 @@
-﻿@echo off
+@echo off
 chcp 65001 >nul
 setlocal
 cd /d "%~dp0"

--- a/打开教程网页.bat
+++ b/打开教程网页.bat
@@ -1,67 +1,27 @@
 @echo off
 chcp 65001 >nul
-setlocal
+setlocal DisableDelayedExpansion
 cd /d "%~dp0"
 
-if exist "docs\.vitepress\dist\index.html" (
-    start "" "%~dp0docs\.vitepress\dist\index.html"
-    echo 已打开构建好的 WebUI 教程站。
-    ping 127.0.0.1 -n 2 >nul
-    exit /b 0
-)
+if not exist "docs\scripts\open-tutorial.vbs" goto :missing_helper
+if not exist "docs\scripts\open-tutorial.cmd" goto :missing_helper
+if not exist "%SystemRoot%\System32\wscript.exe" goto :missing_host
 
-echo 未找到构建产物。正在准备本地预览（需要 Node.js）...
-
-where node >nul 2>&1
-if errorlevel 1 (
-    echo [错误] 未找到 Node.js。请先安装 Node.js 20 或更新版本。
-    echo 官网旧教程仍在: http://mynewbot.com/tutorials
-    pause
-    exit /b 1
-)
-
-if not exist "docs\package.json" (
-    echo [错误] 未找到 docs\package.json
-    pause
-    exit /b 1
-)
-
-if not exist "docs\node_modules\.bin\vitepress.cmd" (
-    echo 首次打开或文档依赖不完整，正在安装 vitepress...
-    pushd docs
-    call npm install
-    if errorlevel 1 (
-        popd
-        echo [错误] 文档依赖安装失败。请检查网络后重试。
-        pause
-        exit /b 1
-    )
-    popd
-)
-
-curl.exe -s -o nul -m 2 http://localhost:5173/ >nul 2>&1
-if not errorlevel 1 goto :open_browser
-
-echo 正在启动教程站...
-cd /d "%~dp0docs"
-start "my-neuro-docs" cmd /k "npm run docs:dev"
-
-echo 正在等待教程站就绪，随后会自动弹出浏览器...
-set /a _n=0
-:wait_docs
-ping 127.0.0.1 -n 2 >nul
-set /a _n+=1
-curl.exe -s -o nul -m 2 http://localhost:5173/ >nul 2>&1
-if not errorlevel 1 goto :open_browser
-if %_n% geq 60 (
-    echo [错误] 教程站启动超时。请查看 my-neuro-docs 窗口里的报错。
-    echo 官网旧教程仍在: http://mynewbot.com/tutorials
-    pause
-    exit /b 1
-)
-goto :wait_docs
-
-:open_browser
-start "" "http://localhost:5173/"
-echo 已自动打开教程网页: http://localhost:5173/
+start "" /b "%SystemRoot%\System32\wscript.exe" //nologo "docs\scripts\open-tutorial.vbs"
+if errorlevel 1 goto :launch_failed
 exit /b 0
+
+:missing_helper
+echo [错误] 教程启动文件不完整。请同时下载 docs\scripts 下的启动辅助文件。
+goto :failed
+
+:missing_host
+echo [错误] 未找到 Windows Script Host，无法在后台打开教程。
+goto :failed
+
+:launch_failed
+echo [错误] 无法启动教程后台程序。
+
+:failed
+pause
+exit /b 1


### PR DESCRIPTION
双击根目录 `打开教程网页.bat` 后，正常启动会留下启动/服务命令行窗口；下载后的脚本还存在 BOM 和 LF 导致 CMD 误解析的问题。本 PR 让入口完成交接后立即退出，依赖安装和文档服务在后台运行，就绪后只请求打开默认浏览器；启动失败时再打开保留错误日志的命令行窗口。

- 保留 `.bat` 双击入口。Windows 创建初始 CMD 窗口时仍可能短暂闪一下，后续流程使用 Windows Script Host 的隐藏窗口执行。辅助脚本随项目放在 `docs/scripts/`，不需要用户另外打开。
- 保留静态构建优先、Node/npm 检查、缺依赖时自动安装、已有本地服务复用；服务以 `start /b` 留在后台，并显式使用 `localhost:5173` 与 `strictPort`。
- 每次打开在 `%TEMP%` 下创建独立日志目录。工作进程失败、后台调度异常、安装不完整、服务提前退出或等待超时时，显示错误与日志；成功不打开错误窗口。
- 去掉根启动器的 UTF-8 BOM，三份启动脚本均保存 CRLF，并通过精确路径 `.gitattributes` 规则保留仓库和下载内容的字节格式。
- 修改范围为根启动器、两个辅助脚本及 `.gitattributes`；教程正文、依赖声明、全局设置和其他入口均保持原样。更新时需要同时包含两个辅助脚本。

验证：

- 4 项 VBS 调度隔离检查：注入模拟 Shell，验证成功只有隐藏调用，工作进程失败、调度异常和日志初始化失败各只触发一次可见错误窗口调用。
- 6 项 CMD 假依赖检查：缺 Node、缺 npm、缺 package.json、安装失败、安装后仍缺 VitePress、模拟服务退出并保存准确退出码。模拟 npm 只输出标记，不安装或启动任何服务。
- 错误显示分支的中文输出和两份日志读取检查通过，包含空格、中文及括号的隔离路径检查通过。
- `git diff --cached --check` 通过，本地文件与 Git 暂存内容逐字节一致，CRLF 与无 BOM 检查通过。

Windows 真实双击、窗口可见性、npm 安装、VitePress 启动和浏览器实机验收尚未执行，由后续验证者完成。首次缺少依赖时需要等待下载与安装；浏览器关闭后文档服务继续在后台运行，供下次打开复用。

后续修正 #433。
